### PR TITLE
feat: build the authored Emberwatch: The Fading Ward demo adventure (…

### DIFF
--- a/apps/frontend/client/src/lib/services/game/inventory_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/inventory_service.svelte.ts
@@ -89,6 +89,28 @@ const ITEM_CATALOG: Record<string, ItemDefinition> = {
     equippable: false,
     slot: undefined,
   },
+  // C-316: Emberwatch adventure items
+  wardPendant: {
+    label: 'Ward Pendant',
+    attackBonus: 0,
+    defenseBonus: 0,
+    equippable: false,
+    slot: undefined,
+  },
+  wardAmulet: {
+    label: 'Ward Amulet',
+    attackBonus: 0,
+    defenseBonus: 3,
+    equippable: true,
+    slot: 'armor',
+  },
+  wardShard: {
+    label: 'Ward Shard',
+    attackBonus: 0,
+    defenseBonus: 0,
+    equippable: false,
+    slot: undefined,
+  },
 } as const satisfies Record<string, ItemDefinition>;
 
 /** Default definition for unknown item IDs. */

--- a/apps/frontend/client/static/content-packs/emberwatch/manifest.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/manifest.json
@@ -1,62 +1,282 @@
 {
   "id": "emberwatch",
-  "name": "Emberwatch",
-  "version": "1.0.0",
+  "name": "Emberwatch: The Fading Ward",
+  "version": "2.0.0",
   "updatedAt": "2026-07-13T00:00:00.000Z",
-  "startingMapId": "sandbox_zone_a",
+  "startingMapId": "emberwatch_village",
   "maps": {
-    "sandbox_zone_a": {
-      "file": "/game-data/maps/sandbox_zone_a.json",
-      "name": "Sandbox Zone A",
-      "defaultX": 160,
-      "defaultY": 192
+    "emberwatch_village": {
+      "file": "maps/emberwatch_village.json",
+      "name": "Emberwatch Village",
+      "defaultSpawnId": "village_gate",
+      "defaultX": 320,
+      "defaultY": 576
     },
-    "sandbox_zone_b": {
-      "file": "/game-data/maps/sandbox_zone_b.json",
-      "name": "Sandbox Zone B",
-      "defaultX": 160,
-      "defaultY": 192
+    "old_road": {
+      "file": "maps/old_road.json",
+      "name": "The Old Road",
+      "defaultX": 64,
+      "defaultY": 240
     },
-    "sandbox_combat": {
-      "file": "/game-data/maps/sandbox_combat.json",
-      "name": "Sandbox Combat Arena",
-      "defaultX": 160,
-      "defaultY": 192
-    },
-    "sandbox_textured": {
-      "file": "/game-data/maps/sandbox_textured.jton",
-      "name": "Sandbox Textured",
-      "defaultX": 160,
-      "defaultY": 192
-    },
-    "debug_map": {
-      "file": "/game-data/maps/debug_map.jton",
-      "name": "Debug Map",
-      "defaultX": 160,
-      "defaultY": 192
+    "ruined_ward_shrine": {
+      "file": "maps/ruined_ward_shrine.json",
+      "name": "Ruined Ward Shrine",
+      "defaultX": 96,
+      "defaultY": 332
     }
   },
   "npcs": {
+    "village_elder": {
+      "name": "Elder Thalia",
+      "defaultDialogueKey": "elder_thalia_greeting",
+      "appearanceLayers": [1, 5, 8, 12],
+      "isVendor": false
+    },
     "guard_captain": {
       "name": "Guard Captain Aldric",
       "defaultDialogueKey": "guard_captain_greeting",
+      "appearanceLayers": [3, 7, 10, 15],
       "isVendor": false
+    },
+    "traveling_merchant": {
+      "name": "Keth the Merchant",
+      "defaultDialogueKey": "merchant_keth_greeting",
+      "appearanceLayers": [1, 4, 9, 11],
+      "isVendor": true,
+      "vendorInventory": "ironSword, healthPotion, manaPotion, ironArmor, woodenShield"
+    },
+    "elara_wayfinder": {
+      "name": "Elara Wayfinder",
+      "defaultDialogueKey": "elara_wayfinder_greeting",
+      "appearanceLayers": [2, 6, 13, 14],
+      "isVendor": false
+    },
+    "kade_blackthorn": {
+      "name": "Kade Blackthorn",
+      "defaultDialogueKey": "kade_blackthorn_taunt",
+      "appearanceLayers": [3, 5, 11, 15],
+      "isVendor": false
+    },
+    "shrine_spirit": {
+      "name": "Vesperine Spirit",
+      "defaultDialogueKey": "shrine_spirit_greeting",
+      "appearanceLayers": [4, 8, 12, 16],
+      "isVendor": false
+    },
+    "shade_guardian": {
+      "name": "Shade Guardian",
+      "defaultDialogueKey": "shade_guardian_manifest",
+      "isVendor": false,
+      "combatStats": {
+        "hitPoints": 30,
+        "armorClass": 13,
+        "attackBonus": 4,
+        "damage": "1d8+2",
+        "initiativeBonus": 0,
+        "xpValue": 75
+      }
     }
   },
   "items": {
-    "rusty_sword": {
-      "name": "Rusty Sword",
+    "ironSword": {
+      "name": "Iron Sword",
       "type": "weapon",
-      "attackBonus": 3,
-      "equipmentSlot": "main_hand"
+      "attackBonus": 5,
+      "equipmentSlot": "weapon"
     },
-    "healing_potion": {
-      "name": "Healing Potion",
+    "healthPotion": {
+      "name": "Health Potion",
       "type": "consumable"
+    },
+    "manaPotion": {
+      "name": "Mana Potion",
+      "type": "consumable"
+    },
+    "ironArmor": {
+      "name": "Iron Armor",
+      "type": "armor",
+      "defenseBonus": 5,
+      "equipmentSlot": "armor"
+    },
+    "woodenShield": {
+      "name": "Wooden Shield",
+      "type": "armor",
+      "defenseBonus": 2,
+      "equipmentSlot": "armor"
+    },
+    "wardPendant": {
+      "name": "Ward Pendant",
+      "type": "key",
+      "equipmentSlot": "neck"
+    },
+    "wardAmulet": {
+      "name": "Ward Amulet",
+      "type": "misc",
+      "defenseBonus": 3,
+      "equipmentSlot": "neck"
+    },
+    "wardShard": {
+      "name": "Ward Shard",
+      "type": "misc"
     }
   },
   "dialogues": {
-    "guard_captain_greeting": "Welcome to Emberwatch, traveler. The roads have been dangerous lately.",
-    "guard_captain_quest": "If you're looking for work, the captain of the watch could use someone with your... talents."
+    "elder_thalia_greeting": "Ah, a traveler! Welcome to Emberwatch. I am Elder Thalia, keeper of this village's lore. You arrive at a troubling time — the ancient ward protecting our lands is fading. Please, come inside and let me explain.",
+    "elder_thalia_offer": "The Ward of Emberwatch was placed centuries ago by the Vesperine Order. It shields our valley from the corruption that festers beyond the Old Road. But the ward crystal at the Ruined Shrine grows dim. If it fails, Emberwatch will fall. I need someone brave to travel the Old Road, reach the shrine, and renew the ward. Will you help us?",
+    "elder_thalia_progress": "Any news from the Old Road? The ward grows weaker each day. You must reach the Ruined Shrine before it is too late. Elara Wayfinder was last seen along the Old Road — she may have discovered something useful.",
+    "elder_thalia_complete": "You've returned! And the ward — I can feel its power surging through the valley once more. Emberwatch owes you a debt that can never be repaid. Thank you, brave soul. You are a true hero of our village.",
+    "elder_thalia_ending_renewed": "The Ward renewed! I felt its pulse from here. You have restored hope to Emberwatch. The Vesperine Order smiles upon you.",
+    "elder_thalia_ending_sacrificed": "A sacrifice was made... I sense the ward's power has changed. It is different now — heavier, tinged with sorrow. But it holds. That is what matters.",
+    "elder_thalia_ending_shattered": "The ward... it is gone. I felt it break. Emberwatch is unprotected now. We will need to prepare for what comes. Still, you did your best — and for that, we are grateful.",
+    "guard_captain_greeting": "Welcome to Emberwatch, traveler. The roads have been dangerous lately. If you're looking for work, Elder Thalia could use someone with your talents. Her hut is the one with the thatched roof to the west.",
+    "guard_captain_quest": "Elder Thalia's been worried sick about the ward. She could use someone like you. You should speak with her directly — her hut is the one with the thatched roof.",
+    "merchant_keth_greeting": "Well met, traveler! Keth's the name, and fine wares are my game. I've got swords, shields, armor, and potions — everything an adventurer needs. What catches your eye?",
+    "merchant_keth_lost_pendant": "Say, you look like someone who gets around. I dropped a family pendant on the Old Road a while back — silver chain, small blue gem. If you find it out there, I'd be mighty grateful. Might even have something special for you in return.",
+    "elara_wayfinder_greeting": "You must be the one Elder Thalia sent. I'm Elara Wayfinder — I scout the Old Road for signs of corruption. The road ahead is treacherous, but I've marked a safe path through the brambles. Before you continue to the shrine, you should know: Kade Blackthorn lies in wait ahead. He's a rogue sword-for-hire who abandoned the guard years ago. He'll try to stop you.",
+    "elara_wayfinder_join": "You'll need help against whatever waits at the shrine. I know these roads better than anyone. Let me accompany you. Together we stand a better chance.",
+    "elara_wayfinder_context": "The ward's been failing for weeks now. Animals have grown restless. Strange lights flicker in the forest at night. Everyone's scared, but no one wants to admit it. You're doing something brave, you know.",
+    "kade_blackthorn_taunt": "Well, well. Another fool chasing fairy tales. The ward isn't worth saving — it's kept Emberwatch weak and complacent for centuries. I'm here to make sure no one reaches that shrine. Turn back now, or I'll make you regret it.",
+    "kade_blackthorn_persuasion_success": "Hmph. You speak with conviction, I'll give you that. Fine — I won't stop you. But don't think this makes us friends. If that ward falls, I'll be the one saying 'I told you so.' Now get out of my sight.",
+    "kade_blackthorn_persuasion_failure": "Nice words. But words don't change anything. If you want to pass, you'll have to go through me. Draw your weapon.",
+    "shrine_spirit_greeting": "At last... someone has come. I am the last echo of the Vesperine Order — the spirit bound to the Fading Ward. For centuries I have held back the corruption, but my strength wanes. The ward requires a living soul to renew it. Will you give of yourself to save Emberwatch?",
+    "shrine_spirit_explanation": "The ward was created through sacrifice — a Vesperine mage gave their essence to forge the crystal. To renew it, you must offer something of equal value. There are three paths before you: You may channel your own life force into the ward, taking its burden upon yourself. The ward will be renewed, but at great personal cost. Or... you may shatter the ward entirely, releasing all its power in a single burst that will purify the valley — but leave Emberwatch unprotected forever. The choice is yours alone.",
+    "shrine_spirit_ending_renewed": "You chose renewal through sacrifice. I feel your essence flowing into the crystal... the ward blazes with light! Emberwatch is saved. But a part of you will always remain here, bound to this stone. Thank you, brave one.",
+    "shrine_spirit_ending_sacrificed": "You gave something precious, and the ward accepted the offering. It is changed — no longer the pure shield it once was. But it holds. The valley is safe. Go now, and live with what you have given.",
+    "shrine_spirit_ending_shattered": "The crystal shatters... the ward's power erupts in a wave of cleansing fire! The corruption burns away. The valley is purged. Emberwatch is free — but unprotected. You have traded safety for freedom. I hope it was worth it.",
+    "shade_guardian_manifest": "The corruption stirs... a dark shape rises from the crumbling stones, its form wreathed in shadow.",
+    "encounter_start": "A twisted shade emerges from the shadows of the ruined shrine! Its hollow eyes fix upon you as it raises a sword of blackened steel.",
+    "encounter_victory": "The shade dissolves into mist with a mournful wail. The path to the ward crystal is clear. You feel a chill run down your spine — the corruption is strong here, but you have prevailed.",
+    "shade_persuaded": "You speak words of peace and understanding. The shade hesitates... something flickers in its hollow eyes — a memory, perhaps, of who it once was. Slowly, it lowers its weapon and fades into the darkness, granting you passage.",
+    "shade_enraged": "Your words mean nothing to the shade — it has forgotten language, forgotten mercy. With a shriek of rage, it lunges at you!"
+  },
+  "quests": {
+    "fading_ward": {
+      "id": "fading_ward",
+      "name": "The Fading Ward",
+      "description": "The ancient ward protecting Emberwatch is failing. Travel the Old Road to the Ruined Ward Shrine, discover the truth behind the ward's decay, and decide the fate of the valley.",
+      "objectives": [
+        {
+          "text": "Investigate the Old Road",
+          "completeOnMapEnter": "old_road"
+        },
+        {
+          "text": "Reach the Ruined Ward Shrine",
+          "completeOnMapEnter": "ruined_ward_shrine"
+        },
+        {
+          "text": "Decide the ward's fate",
+          "completeOnEncounterComplete": "ruined_ward_encounter"
+        }
+      ],
+      "offerDialogueKey": "elder_thalia_offer",
+      "progressDialogueKey": "elder_thalia_progress",
+      "rewards": [
+        {
+          "type": "item",
+          "itemId": "wardAmulet"
+        },
+        {
+          "type": "gold",
+          "amount": 200
+        },
+        {
+          "type": "xp",
+          "amount": 500
+        }
+      ],
+      "endings": {
+        "ward_renewed": {
+          "title": "The Ward Renewed",
+          "narration": "You place your hands upon the fading crystal and channel your own life force into the ward. A searing light erupts from the shrine, flooding the valley with warmth. The corruption recoils and retreats beyond the mountains. Emberwatch is saved. But as the light fades, you feel a cold emptiness where your vitality once burned — a piece of you now lives within the ward, guarding the valley for all time.",
+          "reactionDialogueKey": "elder_thalia_ending_renewed",
+          "worldStateFlag": "emberwatch.ending.renewed"
+        },
+        "ward_sacrificed": {
+          "title": "The Ward Sacrificed",
+          "narration": "You offer the Ward Pendant — Elara's family heirloom, entrusted to you on the road — to the crystal. The pendant dissolves into motes of blue light that weave themselves into the failing ward, mending its fractures. The shield holds, but it is not the same: it now carries the weight of loss, of a gift given freely. The valley is protected, but you cannot shake the feeling that something irreplaceable was lost in the exchange.",
+          "reactionDialogueKey": "elder_thalia_ending_sacrificed",
+          "worldStateFlag": "emberwatch.ending.sacrificed"
+        },
+        "ward_shattered": {
+          "title": "The Ward Shattered",
+          "narration": "With a decisive strike, you shatter the ward crystal. A shockwave of raw arcane energy ripples outward, scouring the valley clean of corruption. The dark creatures that lurked in the shadows are obliterated. Emberwatch is free — but the shield that protected it for centuries is gone forever. The villagers will need to learn to defend themselves. You have given them freedom, but taken away their sanctuary.",
+          "reactionDialogueKey": "elder_thalia_ending_shattered",
+          "worldStateFlag": "emberwatch.ending.shattered"
+        }
+      }
+    },
+    "lost_pendant": {
+      "id": "lost_pendant",
+      "name": "The Merchant's Lost Pendant",
+      "description": "Keth the Merchant dropped a silver pendant with a blue gem somewhere on the Old Road. Find it and return it to him for a reward.",
+      "objectives": [
+        {
+          "text": "Find Keth's lost pendant on the Old Road",
+          "completeOnItemPickup": "wardPendant"
+        },
+        {
+          "text": "Return the pendant to Keth",
+          "completeOnNpcInteract": "traveling_merchant"
+        }
+      ],
+      "offerDialogueKey": "merchant_keth_lost_pendant",
+      "progressDialogueKey": "merchant_keth_greeting",
+      "rewards": [
+        {
+          "type": "item",
+          "itemId": "steelSword"
+        },
+        {
+          "type": "gold",
+          "amount": 100
+        }
+      ],
+      "endings": {
+        "returned": {
+          "title": "Pendant Returned",
+          "narration": "Keth's eyes light up as you hand him the pendant. 'My grandmother's pendant! I thought I'd never see it again.' He presses a gleaming steel sword into your hands and refuses to take no for an answer. 'You've done me a kindness I cannot repay. Take this — you'll need it more than I do.'",
+          "reactionDialogueKey": "merchant_keth_greeting",
+          "worldStateFlag": "emberwatch.pendant.returned"
+        }
+      }
+    }
+  },
+  "encounters": {
+    "ruined_ward_encounter": {
+      "id": "ruined_ward_encounter",
+      "mapId": "ruined_ward_shrine",
+      "name": "Shade of the Ruined Shrine",
+      "enemyNpcIds": ["shade_guardian"],
+      "allowNonCombatResolution": true,
+      "nonCombatSkillCheck": {
+        "skill": "persuasion",
+        "dc": 14,
+        "statModifier": "charisma",
+        "successDialogueKey": "shade_persuaded",
+        "failureDialogueKey": "shade_enraged"
+      },
+      "startDialogueKey": "encounter_start",
+      "victoryDialogueKey": "encounter_victory",
+      "nonCombatSuccessDialogueKey": "shade_persuaded",
+      "loot": [
+        {
+          "itemId": "wardShard",
+          "quantity": 1,
+          "dropChance": 1.0
+        },
+        {
+          "itemId": "healthPotion",
+          "quantity": 1,
+          "dropChance": 0.5
+        }
+      ]
+    }
+  },
+  "credits": {
+    "design": ["Aikami Studio"],
+    "writing": ["Aikami Studio"],
+    "art": ["Liberated Pixel Cup (LPC) asset contributors"],
+    "music": ["Chainsmoker — Exploration Theme"],
+    "thanks": ["The open-source game development community", "The LPC asset artists"]
   }
 }

--- a/apps/frontend/client/static/content-packs/emberwatch/maps/emberwatch_village.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/maps/emberwatch_village.json
@@ -1,0 +1,182 @@
+{
+  "compressionlevel": -1,
+  "width": 20,
+  "height": 20,
+  "tilewidth": 32,
+  "tileheight": 32,
+  "infinite": false,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "tilesets": [
+    {
+      "firstgid": 1,
+      "name": "debug_tiles",
+      "image": "/game-data/sprites/tilesets/debug_tiles.png",
+      "imagewidth": 128,
+      "imageheight": 32,
+      "tilewidth": 32,
+      "tileheight": 32,
+      "columns": 4,
+      "tilecount": 4,
+      "spacing": 0,
+      "margin": 0
+    }
+  ],
+  "layers": [
+    {
+      "name": "ground",
+      "type": "tilelayer",
+      "width": 20,
+      "height": 20,
+      "visible": true,
+      "data": [
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 1, 1, 1, 3, 3, 1, 1, 1, 3, 3, 3, 3, 1, 1, 1, 1,
+        3, 3, 3, 3, 1, 1, 1, 3, 3, 1, 1, 1, 3, 3, 3, 3, 1, 1, 1, 1, 3, 3, 3, 3, 1, 1, 1, 3, 3, 1, 1,
+        1, 3, 3, 3, 3, 1, 1, 1, 1, 3, 3, 3, 3, 1, 1, 1, 3, 3, 1, 1, 1, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3,
+        3, 1, 1, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1
+      ]
+    },
+    {
+      "name": "collision",
+      "type": "tilelayer",
+      "width": 20,
+      "height": 20,
+      "visible": false,
+      "data": [
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 2, 2, 0,
+        2, 2, 2, 2, 0, 2, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 2, 2, 0, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0,
+        0, 2, 2, 2, 2, 0, 2, 2, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 0, 2, 2, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 2, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        2, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 2, 0, 0, 0, 0, 0,
+        0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 0, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 2, 2, 2, 2, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2,
+        0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2
+      ]
+    },
+    {
+      "name": "spawns",
+      "type": "objectgroup",
+      "visible": true,
+      "objects": [
+        {
+          "id": 1,
+          "type": "npc",
+          "x": 256,
+          "y": 192,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "npcId", "type": "string", "value": "village_elder" },
+            { "name": "npcName", "type": "string", "value": "Elder Thalia" },
+            { "name": "dialogueKey", "type": "string", "value": "elder_thalia_greeting" },
+            { "name": "interactionRadius", "type": "float", "value": 48 }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "npc",
+          "x": 480,
+          "y": 192,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "npcId", "type": "string", "value": "guard_captain" },
+            { "name": "npcName", "type": "string", "value": "Guard Captain Aldric" },
+            { "name": "dialogueKey", "type": "string", "value": "guard_captain_greeting" },
+            { "name": "interactionRadius", "type": "float", "value": 48 }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "npc",
+          "x": 448,
+          "y": 416,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "npcId", "type": "string", "value": "traveling_merchant" },
+            { "name": "npcName", "type": "string", "value": "Keth the Merchant" },
+            { "name": "dialogueKey", "type": "string", "value": "merchant_keth_greeting" },
+            { "name": "interactionRadius", "type": "float", "value": 48 },
+            { "name": "isVendor", "type": "bool", "value": true },
+            {
+              "name": "vendorInventory",
+              "type": "string",
+              "value": "ironSword,healthPotion,manaPotion,ironArmor,woodenShield"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "prop",
+          "x": 160,
+          "y": 320,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "village_well" },
+            { "name": "propName", "type": "string", "value": "Old Stone Well" }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "prop",
+          "x": 96,
+          "y": 224,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "notice_board" },
+            { "name": "propName", "type": "string", "value": "Village Notice Board" }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "prop",
+          "x": 320,
+          "y": 544,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "village_gate" },
+            { "name": "propName", "type": "string", "value": "Emberwatch Village Gate" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "transitions",
+      "type": "objectgroup",
+      "visible": false,
+      "objects": [
+        {
+          "id": 7,
+          "type": "transition",
+          "x": 288,
+          "y": 610,
+          "width": 96,
+          "height": 24,
+          "properties": [
+            { "name": "targetMap", "type": "string", "value": "old_road" },
+            { "name": "targetX", "type": "float", "value": 32 },
+            { "name": "targetY", "type": "float", "value": 240 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/frontend/client/static/content-packs/emberwatch/maps/old_road.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/maps/old_road.json
@@ -1,0 +1,191 @@
+{
+  "compressionlevel": -1,
+  "width": 30,
+  "height": 15,
+  "tilewidth": 32,
+  "tileheight": 32,
+  "infinite": false,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "tilesets": [
+    {
+      "firstgid": 1,
+      "name": "debug_tiles",
+      "image": "/game-data/sprites/tilesets/debug_tiles.png",
+      "imagewidth": 128,
+      "imageheight": 32,
+      "tilewidth": 32,
+      "tileheight": 32,
+      "columns": 4,
+      "tilecount": 4,
+      "spacing": 0,
+      "margin": 0
+    }
+  ],
+  "layers": [
+    {
+      "name": "ground",
+      "type": "tilelayer",
+      "width": 30,
+      "height": 15,
+      "visible": true,
+      "data": [
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+      ]
+    },
+    {
+      "name": "collision",
+      "type": "tilelayer",
+      "width": 30,
+      "height": 15,
+      "visible": false,
+      "data": [
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 2, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0,
+        0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
+        0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+      ]
+    },
+    {
+      "name": "spawns",
+      "type": "objectgroup",
+      "visible": true,
+      "objects": [
+        {
+          "id": 1,
+          "type": "npc",
+          "x": 192,
+          "y": 240,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "npcId", "type": "string", "value": "elara_wayfinder" },
+            { "name": "npcName", "type": "string", "value": "Elara Wayfinder" },
+            { "name": "dialogueKey", "type": "string", "value": "elara_wayfinder_greeting" },
+            { "name": "interactionRadius", "type": "float", "value": 48 }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "npc",
+          "x": 704,
+          "y": 240,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "npcId", "type": "string", "value": "kade_blackthorn" },
+            { "name": "npcName", "type": "string", "value": "Kade Blackthorn" },
+            { "name": "dialogueKey", "type": "string", "value": "kade_blackthorn_taunt" },
+            { "name": "interactionRadius", "type": "float", "value": 64 }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "item_pickup",
+          "x": 464,
+          "y": 304,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "itemId", "type": "string", "value": "wardPendant" },
+            { "name": "itemName", "type": "string", "value": "Ward Pendant" }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "prop",
+          "x": 128,
+          "y": 224,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "abandoned_campfire" },
+            { "name": "propName", "type": "string", "value": "Abandoned Campfire" }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "prop",
+          "x": 448,
+          "y": 192,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "broken_cart" },
+            { "name": "propName", "type": "string", "value": "Broken Cart" }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "prop",
+          "x": 704,
+          "y": 320,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "old_signpost" },
+            { "name": "propName", "type": "string", "value": "Old Signpost" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "transitions",
+      "type": "objectgroup",
+      "visible": false,
+      "objects": [
+        {
+          "id": 7,
+          "type": "transition",
+          "x": 32,
+          "y": 226,
+          "width": 32,
+          "height": 64,
+          "properties": [
+            { "name": "targetMap", "type": "string", "value": "emberwatch_village" },
+            { "name": "targetX", "type": "float", "value": 320 },
+            { "name": "targetY", "type": "float", "value": 576 }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "transition",
+          "x": 904,
+          "y": 226,
+          "width": 32,
+          "height": 64,
+          "properties": [
+            { "name": "targetMap", "type": "string", "value": "ruined_ward_shrine" },
+            { "name": "targetX", "type": "float", "value": 64 },
+            { "name": "targetY", "type": "float", "value": 320 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/frontend/client/static/content-packs/emberwatch/maps/ruined_ward_shrine.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/maps/ruined_ward_shrine.json
@@ -1,0 +1,171 @@
+{
+  "compressionlevel": -1,
+  "width": 20,
+  "height": 20,
+  "tilewidth": 32,
+  "tileheight": 32,
+  "infinite": false,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "tilesets": [
+    {
+      "firstgid": 1,
+      "name": "debug_tiles",
+      "image": "/game-data/sprites/tilesets/debug_tiles.png",
+      "imagewidth": 128,
+      "imageheight": 32,
+      "tilewidth": 32,
+      "tileheight": 32,
+      "columns": 4,
+      "tilecount": 4,
+      "spacing": 0,
+      "margin": 0
+    }
+  ],
+  "layers": [
+    {
+      "name": "ground",
+      "type": "tilelayer",
+      "width": 20,
+      "height": 20,
+      "visible": true,
+      "data": [
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 1, 1, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+        1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1,
+        1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+      ]
+    },
+    {
+      "name": "collision",
+      "type": "tilelayer",
+      "width": 20,
+      "height": 20,
+      "visible": false,
+      "data": [
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0,
+        0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 2, 2, 0, 0, 2,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0,
+        0, 2, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 0, 0, 0,
+        0, 0, 2, 2, 2, 2, 0, 0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 2, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 2, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0,
+        2, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 2, 0, 0, 0, 0,
+        0, 0, 0, 0, 2, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 2,
+        0, 0, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+      ]
+    },
+    {
+      "name": "spawns",
+      "type": "objectgroup",
+      "visible": true,
+      "objects": [
+        {
+          "id": 1,
+          "type": "npc",
+          "x": 304,
+          "y": 192,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "npcId", "type": "string", "value": "shrine_spirit" },
+            { "name": "npcName", "type": "string", "value": "Vesperine Spirit" },
+            { "name": "dialogueKey", "type": "string", "value": "shrine_spirit_greeting" },
+            { "name": "interactionRadius", "type": "float", "value": 48 }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "encounter_trigger",
+          "x": 384,
+          "y": 320,
+          "width": 96,
+          "height": 96,
+          "properties": [
+            { "name": "encounterId", "type": "string", "value": "ruined_ward_encounter" }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "prop",
+          "x": 304,
+          "y": 304,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "ward_crystal" },
+            { "name": "propName", "type": "string", "value": "Fading Ward Crystal" }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "prop",
+          "x": 160,
+          "y": 448,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "fallen_pillar" },
+            { "name": "propName", "type": "string", "value": "Fallen Pillar" }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "prop",
+          "x": 448,
+          "y": 160,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "broken_statue" },
+            { "name": "propName", "type": "string", "value": "Broken Statue" }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "prop",
+          "x": 64,
+          "y": 544,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            { "name": "propId", "type": "string", "value": "ancient_brazier" },
+            { "name": "propName", "type": "string", "value": "Ancient Brazier" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "transitions",
+      "type": "objectgroup",
+      "visible": false,
+      "objects": [
+        {
+          "id": 7,
+          "type": "transition",
+          "x": 32,
+          "y": 322,
+          "width": 32,
+          "height": 96,
+          "properties": [
+            { "name": "targetMap", "type": "string", "value": "old_road" },
+            { "name": "targetX", "type": "float", "value": 864 },
+            { "name": "targetY", "type": "float", "value": 240 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/TODO_DRAFT.md
+++ b/docs/TODO_DRAFT.md
@@ -4,6 +4,8 @@
     - Offline first, it can use local ollama, comfyui, kokoro, and does not need firebase (but can enable it)
     - Web client, hosted on firebase hosting with byok (bring your own key) and also firebase is optional
     - No setup required, it uses firebase and cloud run and pay with stripe based on usage (we deploy the docker in apps/backend/image|voice|text to cloud run)
+        - For no setup we should have the models in storage not in docker image to speed up cold starts
+        - Considering of doing the same with ollama or if we use model garden from gcp
 - Remove all legacy, backwards compatible code, and unused code and projects, example i don't think we use
     - packages/backend/ai
     - packages/backend/image/src/index.ts
@@ -16,4 +18,6 @@
     - it is in apps/frontend/client/src/lib/services/agent/agent_registry_service.svelte.ts
     - apps/frontend/client/src/lib/services/chat/connected_chats_service.svelte.ts
     - apps/frontend/client/src/lib/services/npc/npc_schedule_service.svelte.ts
--
+- prevent using "as"
+- @inheritdoc is not needed
+- Consider making all classes in packages/frontend/engine/ use BaseClass and initalize with Class.create() to auto debug log

--- a/docs/contracts/C-316-build-the-authored-emberwatch-the-fading-ward-demo-adventure.md
+++ b/docs/contracts/C-316-build-the-authored-emberwatch-the-fading-ward-demo-adventure.md
@@ -8,7 +8,7 @@
 | **Target** | `apps/frontend/client/static/content-packs/emberwatch/` — 3 authored Tiled maps, complete manifest with NPCs/items/dialogues/quests/encounters, and fallback text for offline play |
 | **Priority** | P0 — Aikami needs a game, not another empty system surface |
 | **Dependencies** | C-315 (completed), C-313 (implemented/sandbox — tested in dev routes only, promotion `sandbox`), C-314 (implemented/production — composition root wired in `/game` route, promotion `production`), C-144 (completed), C-154 (completed), C-157 (completed), C-158 (completed), existing LPC/tile/audio assets |
-| **Status** | approved |
+| **Status** | verified |
 | **Promotion** | — |
 | **Docs Impact** | None — authored game content, not user-facing documentation |
 | **Contract version** | 2.0.0 |
@@ -612,3 +612,47 @@ N/A — no persistent state changes. The emberwatch content pack manifest versio
 > 📋 Status rules: see [SHARED_SECTIONS.md](SHARED_SECTIONS.md#status-lifecycle)
 
 ---
+
+## Execution Report
+
+### Summary
+Built the complete authored Emberwatch: The Fading Ward demo adventure content pack (v2.0.0). Extended the content pack schema with optional `quests`, `encounters`, `credits` fields plus `combatStats` on NPC entries and `vendorInventory` pattern validation. Extended the loader with `getQuest()`, `getEncounter()`, `getAllQuests()`, `getAllEncounters()`, `getCredits()` accessors. Created 3 authored Tiled JSON maps (Village 20×20, Old Road 30×15, Shrine 20×20), a full manifest with 7 NPCs, 8 items, 27 dialogue strings, 2 quests (1 main + 1 optional), 1 encounter with skill check, and credits. All 96 tests pass across schema, loader unit, and integration test suites.
+
+### AC Status
+| AC | Status | Notes |
+|---|---|---|
+| AC-1 | ✅ | Manifest loads/validates — version 2.0.0, 3 maps, 7 NPCs, 8 items, 27 dialogues, 2 quests, 1 encounter, credits present |
+| AC-2 | ✅ | 3 authored maps created (Village, Road, Shrine) with spawns, transitions, collision — valid Tiled JSON format |
+| AC-3 | ✅ | Full NPC cast with authored dialogue — all dialogue keys resolve, vendor inventory validated, appearance layers assigned |
+| AC-4 | ✅ | Fading Ward quest: 3 objectives, 3 endings (50+ char narration each), rewards with item+gold+xp. Optional Lost Pendant quest. |
+| AC-5 | ✅ | Encounter defined with skill check (persuasion DC 14, charisma), enemy NPC with combatStats, guaranteed loot, all dialogue keys resolve. Item IDs reconcile with ITEM_CATALOG. |
+
+### Files Created
+| File | Purpose |
+|---|---|
+| `apps/frontend/client/static/content-packs/emberwatch/maps/emberwatch_village.json` | Emberwatch Village map (20×20) — quest giver, merchant, guard spawns + transitions |
+| `apps/frontend/client/static/content-packs/emberwatch/maps/old_road.json` | Old Road map (30×15) — companion, rival spawns + item pickup + dual transitions |
+| `apps/frontend/client/static/content-packs/emberwatch/maps/ruined_ward_shrine.json` | Ruined Ward Shrine map (20×20) — shrine spirit, encounter trigger, altar + transition |
+
+### Files Modified
+| File | Change |
+|---|---|
+| `packages/shared/schemas/src/lib/game/content_pack.ts` | Extended schema: `quests`, `encounters`, `credits` optional fields on manifest; new sub-schemas for `ContentPackCombatStats`, `ContentPackQuestEntry`, `ContentPackEncounterEntry`, `ContentPackSkillCheck`, `ContentPackLootEntry`, `ContentPackCredits`; `vendorInventory` pattern validation; `combatStats` on NPC entries |
+| `packages/shared/types/src/lib/game/content_pack.ts` | Added 13 derived types via `Static<typeof Schema>` |
+| `packages/frontend/engine/src/assets/content_pack_loader.ts` | Added 5 accessor methods: `getQuest()`, `getEncounter()`, `getAllQuests()`, `getAllEncounters()`, `getCredits()` |
+| `packages/shared/schemas/src/lib/game/content_pack.test.ts` | Added 16 new tests (vendorInventory patterns, combatStats, quests, encounters, credits, validation) |
+| `packages/frontend/engine/src/assets/content_pack_loader.test.ts` | Added 12 new tests (quest/encounter/credits accessors, dispose coverage) |
+| `packages/frontend/engine/src/assets/content_pack_loader.integration.test.ts` | Complete rewrite for v2.0.0 manifest — 23 tests covering all ACs including item-ID reconciliation |
+| `apps/frontend/client/static/content-packs/emberwatch/manifest.json` | Complete rewrite: v2.0.0, 7 NPCs, 8 items, 27 dialogues, 2 quests, 1 encounter, credits |
+| `apps/frontend/client/src/lib/services/game/inventory_service.svelte.ts` | Added 3 Emberwatch items to ITEM_CATALOG (wardPendant, wardAmulet, wardShard) |
+
+### Deviations from Spec
+- **EquipmentSlot for neck items**: The `wardAmulet` and `wardPendant` items were specified with `slot: 'neck'` but the `EquipmentSlotSchema` only supports `'weapon' | 'armor'`. Set `wardAmulet` to `slot: 'armor'` and `wardPendant` to `slot: undefined` (key item, not equippable). Extending equipment slots is a separate concern.
+- **NPC count is 7, not 6**: Added `shade_guardian` as a separate NPC entry (needed for encounter enemy definition with combatStats). Total: 6 story NPCs + 1 enemy-only NPC.
+
+### Test Results
+- Unit (schemas): 38/38 pass (0 failures) — baseline was 22
+- Unit (loader): 35/35 pass (0 failures) — baseline was 23
+- Integration (emberwatch): 23/23 pass (0 failures) — baseline was 8
+- Full validate: 4/4 projects pass (schemas, types, frontend-engine, client)
+- Baseline: 0 pre-existing failures, 0 new failures

--- a/packages/frontend/engine/src/assets/content_pack_loader.integration.test.ts
+++ b/packages/frontend/engine/src/assets/content_pack_loader.integration.test.ts
@@ -1,89 +1,304 @@
 // packages/frontend/engine/src/assets/content_pack_loader.integration.test.ts
 //
-// Integration test: emberwatch stub → load → verify starting map resolution.
+// Integration test: Emberwatch v2.0.0 manifest → load → verify all accessors.
 // CI-verifiable via in-memory fetch mocking — no dev server needed.
 // Contract: C-315 Define a Versioned Campaign Content Pack and Atomic Loader
+// Contract: C-316 Build the Authored Emberwatch Demo Adventure
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { clearContentPackCache, loadContentPack } from './content_pack_loader.ts';
 
 // ---------------------------------------------------------------------------
-// Emberwatch stub manifest (matches the real manifest at
+// Emberwatch v2.0.0 authored manifest (matches
 // apps/frontend/client/static/content-packs/emberwatch/manifest.json)
 // ---------------------------------------------------------------------------
 
 const emberwatchManifest = {
   id: 'emberwatch',
-  name: 'Emberwatch',
-  version: '1.0.0',
+  name: 'Emberwatch: The Fading Ward',
+  version: '2.0.0',
   updatedAt: '2026-07-13T00:00:00.000Z',
-  startingMapId: 'sandbox_zone_a',
+  startingMapId: 'emberwatch_village',
   maps: {
     // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    sandbox_zone_a: {
-      file: '/game-data/maps/sandbox_zone_a.json',
-      name: 'Sandbox Zone A',
-      defaultX: 160,
-      defaultY: 192,
+    emberwatch_village: {
+      file: 'maps/emberwatch_village.json',
+      name: 'Emberwatch Village',
+      defaultSpawnId: 'village_gate',
+      defaultX: 320,
+      defaultY: 576,
     },
     // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    sandbox_zone_b: {
-      file: '/game-data/maps/sandbox_zone_b.json',
-      name: 'Sandbox Zone B',
-      defaultX: 160,
-      defaultY: 192,
+    old_road: {
+      file: 'maps/old_road.json',
+      name: 'The Old Road',
+      defaultX: 64,
+      defaultY: 240,
     },
     // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    sandbox_combat: {
-      file: '/game-data/maps/sandbox_combat.json',
-      name: 'Sandbox Combat Arena',
-      defaultX: 160,
-      defaultY: 192,
-    },
-    // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    sandbox_textured: {
-      file: '/game-data/maps/sandbox_textured.jton',
-      name: 'Sandbox Textured',
-      defaultX: 160,
-      defaultY: 192,
-    },
-    // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    debug_map: {
-      file: '/game-data/maps/debug_map.jton',
-      name: 'Debug Map',
-      defaultX: 160,
-      defaultY: 192,
+    ruined_ward_shrine: {
+      file: 'maps/ruined_ward_shrine.json',
+      name: 'Ruined Ward Shrine',
+      defaultX: 96,
+      defaultY: 332,
     },
   },
   npcs: {
     // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    village_elder: {
+      name: 'Elder Thalia',
+      defaultDialogueKey: 'elder_thalia_greeting',
+      appearanceLayers: [1, 5, 8, 12],
+      isVendor: false,
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
     guard_captain: {
       name: 'Guard Captain Aldric',
       defaultDialogueKey: 'guard_captain_greeting',
+      appearanceLayers: [3, 7, 10, 15],
       isVendor: false,
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    traveling_merchant: {
+      name: 'Keth the Merchant',
+      defaultDialogueKey: 'merchant_keth_greeting',
+      appearanceLayers: [1, 4, 9, 11],
+      isVendor: true,
+      vendorInventory: 'ironSword, healthPotion, manaPotion, ironArmor, woodenShield',
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elara_wayfinder: {
+      name: 'Elara Wayfinder',
+      defaultDialogueKey: 'elara_wayfinder_greeting',
+      appearanceLayers: [2, 6, 13, 14],
+      isVendor: false,
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    kade_blackthorn: {
+      name: 'Kade Blackthorn',
+      defaultDialogueKey: 'kade_blackthorn_taunt',
+      appearanceLayers: [3, 5, 11, 15],
+      isVendor: false,
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shrine_spirit: {
+      name: 'Vesperine Spirit',
+      defaultDialogueKey: 'shrine_spirit_greeting',
+      appearanceLayers: [4, 8, 12, 16],
+      isVendor: false,
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shade_guardian: {
+      name: 'Shade Guardian',
+      defaultDialogueKey: 'shade_guardian_manifest',
+      isVendor: false,
+      combatStats: {
+        hitPoints: 30,
+        armorClass: 13,
+        attackBonus: 4,
+        damage: '1d8+2',
+        initiativeBonus: 0,
+        xpValue: 75,
+      },
     },
   },
   items: {
-    // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    rusty_sword: {
-      name: 'Rusty Sword',
+    ironSword: {
+      name: 'Iron Sword',
       type: 'weapon',
-      attackBonus: 3,
-      equipmentSlot: 'main_hand',
+      attackBonus: 5,
+      equipmentSlot: 'weapon',
     },
-    // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    healing_potion: {
-      name: 'Healing Potion',
+    healthPotion: {
+      name: 'Health Potion',
       type: 'consumable',
+    },
+    manaPotion: {
+      name: 'Mana Potion',
+      type: 'consumable',
+    },
+    ironArmor: {
+      name: 'Iron Armor',
+      type: 'armor',
+      defenseBonus: 5,
+      equipmentSlot: 'armor',
+    },
+    woodenShield: {
+      name: 'Wooden Shield',
+      type: 'armor',
+      defenseBonus: 2,
+      equipmentSlot: 'armor',
+    },
+    wardPendant: {
+      name: 'Ward Pendant',
+      type: 'key',
+      equipmentSlot: 'neck',
+    },
+    wardAmulet: {
+      name: 'Ward Amulet',
+      type: 'misc',
+      defenseBonus: 3,
+      equipmentSlot: 'neck',
+    },
+    wardShard: {
+      name: 'Ward Shard',
+      type: 'misc',
     },
   },
   dialogues: {
     // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    guard_captain_greeting:
-      'Welcome to Emberwatch, traveler. The roads have been dangerous lately.',
+    elder_thalia_greeting:
+      "Ah, a traveler! Welcome to Emberwatch. I am Elder Thalia, keeper of this village's lore.",
     // biome-ignore lint/style/useNamingConvention: JSON manifest key
-    guard_captain_quest:
-      "If you're looking for work, the captain of the watch could use someone with your... talents.",
+    elder_thalia_offer: 'The Ward of Emberwatch was placed centuries ago by the Vesperine Order.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elder_thalia_progress: 'Any news from the Old Road?',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elder_thalia_complete: "You've returned!",
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elder_thalia_ending_renewed: 'The Ward renewed!',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elder_thalia_ending_sacrificed: 'A sacrifice was made...',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elder_thalia_ending_shattered: 'The ward... it is gone.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    guard_captain_greeting: 'Welcome to Emberwatch, traveler.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    guard_captain_quest: 'Elder Thalia could use someone like you.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    merchant_keth_greeting: 'Well met, traveler!',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    merchant_keth_lost_pendant: 'Say, you look like someone who gets around.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elara_wayfinder_greeting: 'You must be the one Elder Thalia sent.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elara_wayfinder_join: "You'll need help.",
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    elara_wayfinder_context: "The ward's been failing for weeks now.",
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    kade_blackthorn_taunt: 'Well, well. Another fool chasing fairy tales.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    kade_blackthorn_persuasion_success: 'Hmph. You speak with conviction.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    kade_blackthorn_persuasion_failure: "Nice words. But words don't change anything.",
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shrine_spirit_greeting: 'At last... someone has come.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shrine_spirit_explanation: 'The ward was created through sacrifice.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shrine_spirit_ending_renewed: 'You chose renewal through sacrifice.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shrine_spirit_ending_sacrificed: 'You gave something precious.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shrine_spirit_ending_shattered: 'The crystal shatters...',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shade_guardian_manifest: 'The corruption stirs...',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    encounter_start: 'A twisted shade emerges from the shadows!',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    encounter_victory: 'The shade dissolves into mist.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shade_persuaded: 'You speak words of peace and understanding.',
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    shade_enraged: 'Your words mean nothing to the shade.',
+  },
+  quests: {
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    fading_ward: {
+      id: 'fading_ward',
+      name: 'The Fading Ward',
+      description: 'The ancient ward protecting Emberwatch is failing.',
+      objectives: [
+        { text: 'Investigate the Old Road', completeOnMapEnter: 'old_road' },
+        { text: 'Reach the Ruined Ward Shrine', completeOnMapEnter: 'ruined_ward_shrine' },
+        { text: "Decide the ward's fate", completeOnEncounterComplete: 'ruined_ward_encounter' },
+      ],
+      offerDialogueKey: 'elder_thalia_offer',
+      progressDialogueKey: 'elder_thalia_progress',
+      rewards: [
+        { type: 'item', itemId: 'wardAmulet' },
+        { type: 'gold', amount: 200 },
+        { type: 'xp', amount: 500 },
+      ],
+      endings: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        ward_renewed: {
+          title: 'The Ward Renewed',
+          narration:
+            'You place your hands upon the fading crystal and channel your own life force into the ward. A searing light erupts from the shrine, flooding the valley with warmth.',
+          worldStateFlag: 'emberwatch.ending.renewed',
+        },
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        ward_sacrificed: {
+          title: 'The Ward Sacrificed',
+          narration:
+            'You offer the Ward Pendant to the crystal. The pendant dissolves into motes of blue light that weave themselves into the failing ward, mending its fractures.',
+          worldStateFlag: 'emberwatch.ending.sacrificed',
+        },
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        ward_shattered: {
+          title: 'The Ward Shattered',
+          narration:
+            'With a decisive strike, you shatter the ward crystal. A shockwave of raw arcane energy ripples outward, scouring the valley clean of corruption.',
+          worldStateFlag: 'emberwatch.ending.shattered',
+        },
+      },
+    },
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    lost_pendant: {
+      id: 'lost_pendant',
+      name: "The Merchant's Lost Pendant",
+      description: 'Keth the Merchant dropped a silver pendant on the Old Road.',
+      objectives: [
+        { text: "Find Keth's lost pendant on the Old Road", completeOnItemPickup: 'wardPendant' },
+        { text: 'Return the pendant to Keth', completeOnNpcInteract: 'traveling_merchant' },
+      ],
+      offerDialogueKey: 'merchant_keth_lost_pendant',
+      progressDialogueKey: 'merchant_keth_greeting',
+      rewards: [
+        { type: 'item', itemId: 'steelSword' },
+        { type: 'gold', amount: 100 },
+      ],
+      endings: {
+        returned: {
+          title: 'Pendant Returned',
+          narration:
+            "Keth's eyes light up as you hand him the pendant. He presses a gleaming steel sword into your hands.",
+          worldStateFlag: 'emberwatch.pendant.returned',
+        },
+      },
+    },
+  },
+  encounters: {
+    // biome-ignore lint/style/useNamingConvention: JSON manifest key
+    ruined_ward_encounter: {
+      id: 'ruined_ward_encounter',
+      mapId: 'ruined_ward_shrine',
+      name: 'Shade of the Ruined Shrine',
+      enemyNpcIds: ['shade_guardian'],
+      allowNonCombatResolution: true,
+      nonCombatSkillCheck: {
+        skill: 'persuasion',
+        dc: 14,
+        statModifier: 'charisma',
+        successDialogueKey: 'shade_persuaded',
+        failureDialogueKey: 'shade_enraged',
+      },
+      startDialogueKey: 'encounter_start',
+      victoryDialogueKey: 'encounter_victory',
+      nonCombatSuccessDialogueKey: 'shade_persuaded',
+      loot: [
+        { itemId: 'wardShard', quantity: 1, dropChance: 1.0 },
+        { itemId: 'healthPotion', quantity: 1, dropChance: 0.5 },
+      ],
+    },
+  },
+  credits: {
+    design: ['Aikami Studio'],
+    writing: ['Aikami Studio'],
+    art: ['Liberated Pixel Cup (LPC) asset contributors'],
+    music: ['Chainsmoker — Exploration Theme'],
+    thanks: ['The open-source game development community', 'The LPC asset artists'],
   },
 };
 
@@ -101,6 +316,25 @@ const createEmberwatchFetch = () => {
 };
 
 // ---------------------------------------------------------------------------
+// ITEM_CATALOG subset used for reconciliation testing
+// ---------------------------------------------------------------------------
+
+const ITEM_CATALOG_KEYS = new Set([
+  'rustySword',
+  'ironSword',
+  'steelSword',
+  'woodenShield',
+  'leatherArmor',
+  'ironArmor',
+  'healthPotion',
+  'manaPotion',
+  'goldCoin',
+  'wardPendant',
+  'wardAmulet',
+  'wardShard',
+]);
+
+// ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
@@ -113,122 +347,370 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests — AC-3 (static serving simulation) + AC-4 (engine-side starting map)
+// Tests — AC-1, AC-2, AC-3, AC-4, AC-5
 // ---------------------------------------------------------------------------
 
-describe('ContentPackLoader — Emberwatch Integration', () => {
-  test('loads emberwatch manifest via /content-packs/emberwatch/manifest.json', async () => {
-    const fetcher = createEmberwatchFetch();
+describe('ContentPackLoader — Emberwatch v2.0.0 Integration', () => {
+  // ── AC-1: Manifest loads and validates ──
 
+  test('loads emberwatch manifest with version 2.0.0', async () => {
+    const fetcher = createEmberwatchFetch();
     const loader = await loadContentPack({
       packId: 'emberwatch',
       fetchFn: fetcher as unknown as typeof fetch,
     });
 
     expect(loader.packId).toBe('emberwatch');
-    expect(loader.manifest.id).toBe('emberwatch');
-    expect(loader.manifest.name).toBe('Emberwatch');
-    expect(loader.manifest.version).toBe('1.0.0');
+    expect(loader.manifest.version).toBe('2.0.0');
+    expect(loader.manifest.startingMapId).toBe('emberwatch_village');
   });
 
-  test('getStartingMap resolves to sandbox_zone_a with real map path', async () => {
+  test('map count is exactly 3', async () => {
     const fetcher = createEmberwatchFetch();
-
-    const loader = await loadContentPack({
-      packId: 'emberwatch',
-      fetchFn: fetcher as unknown as typeof fetch,
-    });
-
-    const startingMap = loader.getStartingMap();
-    expect(startingMap.file).toBe('/game-data/maps/sandbox_zone_a.json');
-    expect(startingMap.name).toBe('Sandbox Zone A');
-    expect(startingMap.defaultX).toBe(160);
-    expect(startingMap.defaultY).toBe(192);
-  });
-
-  test('resolveMapUrl for starting map returns the real map path', async () => {
-    const fetcher = createEmberwatchFetch();
-
-    const loader = await loadContentPack({
-      packId: 'emberwatch',
-      fetchFn: fetcher as unknown as typeof fetch,
-    });
-
-    const url = loader.resolveMapUrl('sandbox_zone_a');
-    expect(url).toBe('/game-data/maps/sandbox_zone_a.json');
-  });
-
-  test('resolveMapUrl for sandbox_zone_b returns correct path', async () => {
-    const fetcher = createEmberwatchFetch();
-
-    const loader = await loadContentPack({
-      packId: 'emberwatch',
-      fetchFn: fetcher as unknown as typeof fetch,
-    });
-
-    const url = loader.resolveMapUrl('sandbox_zone_b');
-    expect(url).toBe('/game-data/maps/sandbox_zone_b.json');
-  });
-
-  test('dialogue lookup returns expected fallback strings', async () => {
-    const fetcher = createEmberwatchFetch();
-
-    const loader = await loadContentPack({
-      packId: 'emberwatch',
-      fetchFn: fetcher as unknown as typeof fetch,
-    });
-
-    expect(loader.getDialogue('guard_captain_greeting')).toContain('Welcome to Emberwatch');
-    expect(loader.getDialogue('guard_captain_quest')).toContain('captain of the watch');
-    expect(loader.getDialogue('nonexistent')).toBeUndefined();
-  });
-
-  test('NPC lookup returns expected entries', async () => {
-    const fetcher = createEmberwatchFetch();
-
-    const loader = await loadContentPack({
-      packId: 'emberwatch',
-      fetchFn: fetcher as unknown as typeof fetch,
-    });
-
-    const npc = loader.getNpc('guard_captain');
-    expect(npc?.name).toBe('Guard Captain Aldric');
-    expect(npc?.defaultDialogueKey).toBe('guard_captain_greeting');
-    expect(npc?.isVendor).toBe(false);
-  });
-
-  test('item lookup returns expected entries', async () => {
-    const fetcher = createEmberwatchFetch();
-
-    const loader = await loadContentPack({
-      packId: 'emberwatch',
-      fetchFn: fetcher as unknown as typeof fetch,
-    });
-
-    const sword = loader.getItem('rusty_sword');
-    expect(sword?.name).toBe('Rusty Sword');
-    expect(sword?.type).toBe('weapon');
-    expect(sword?.attackBonus).toBe(3);
-
-    const potion = loader.getItem('healing_potion');
-    expect(potion?.name).toBe('Healing Potion');
-    expect(potion?.type).toBe('consumable');
-  });
-
-  test('map count matches expected', async () => {
-    const fetcher = createEmberwatchFetch();
-
     const loader = await loadContentPack({
       packId: 'emberwatch',
       fetchFn: fetcher as unknown as typeof fetch,
     });
 
     const mapIds = Object.keys(loader.manifest.maps);
-    expect(mapIds.length).toBe(5);
-    expect(mapIds).toContain('sandbox_zone_a');
-    expect(mapIds).toContain('sandbox_zone_b');
-    expect(mapIds).toContain('sandbox_combat');
-    expect(mapIds).toContain('sandbox_textured');
-    expect(mapIds).toContain('debug_map');
+    expect(mapIds.length).toBe(3);
+    expect(mapIds).toContain('emberwatch_village');
+    expect(mapIds).toContain('old_road');
+    expect(mapIds).toContain('ruined_ward_shrine');
+  });
+
+  test('npc count is at least 6', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const npcIds = Object.keys(loader.manifest.npcs);
+    expect(npcIds.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test('dialogue count is at least 20', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const dialogueKeys = Object.keys(loader.manifest.dialogues);
+    expect(dialogueKeys.length).toBeGreaterThanOrEqual(20);
+  });
+
+  test('item count is at least 8', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const itemIds = Object.keys(loader.manifest.items);
+    expect(itemIds.length).toBeGreaterThanOrEqual(8);
+  });
+
+  // ── AC-1: credits present ──
+
+  test('credits section is present', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const credits = loader.getCredits();
+    expect(credits).toBeDefined();
+    expect(credits?.design).toBeDefined();
+    expect(credits?.writing).toBeDefined();
+    expect(credits?.art).toBeDefined();
+    expect(credits?.music).toBeDefined();
+    expect(credits?.thanks).toBeDefined();
+  });
+
+  // ── AC-2: Starting map resolution ──
+
+  test('getStartingMap resolves to emberwatch_village', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const startingMap = loader.getStartingMap();
+    expect(startingMap.file).toBe('maps/emberwatch_village.json');
+    expect(startingMap.name).toBe('Emberwatch Village');
+  });
+
+  // ── AC-3: NPC cast with dialogue ──
+
+  test('quest giver NPC (village_elder) has all interaction dialogue', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const elder = loader.getNpc('village_elder');
+    expect(elder?.name).toBe('Elder Thalia');
+    expect(elder?.appearanceLayers?.length).toBeGreaterThanOrEqual(4);
+
+    // All dialogue keys resolve
+    const keys = [
+      'elder_thalia_greeting',
+      'elder_thalia_offer',
+      'elder_thalia_progress',
+      'elder_thalia_complete',
+      'elder_thalia_ending_renewed',
+      'elder_thalia_ending_sacrificed',
+      'elder_thalia_ending_shattered',
+    ];
+    for (const key of keys) {
+      expect(loader.getDialogue(key)).toBeDefined();
+    }
+  });
+
+  test('vendor NPC (traveling_merchant) has valid vendorInventory', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const merchant = loader.getNpc('traveling_merchant');
+    expect(merchant?.isVendor).toBe(true);
+    expect(merchant?.vendorInventory).toBeDefined();
+
+    const items = merchant?.vendorInventory?.split(/,\s*/) ?? [];
+    expect(items.length).toBeGreaterThanOrEqual(4);
+
+    // All vendor items exist in manifest.items
+    for (const itemId of items) {
+      expect(loader.getItem(itemId)).toBeDefined();
+    }
+  });
+
+  test('rival NPC (kade_blackthorn) has taunt and skill-check resolution dialogue', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getNpc('kade_blackthorn')?.name).toBe('Kade Blackthorn');
+    expect(loader.getDialogue('kade_blackthorn_taunt')).toBeDefined();
+    expect(loader.getDialogue('kade_blackthorn_persuasion_success')).toBeDefined();
+    expect(loader.getDialogue('kade_blackthorn_persuasion_failure')).toBeDefined();
+  });
+
+  test('shrine spirit NPC has ending-specific reaction dialogues', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getNpc('shrine_spirit')?.name).toBe('Vesperine Spirit');
+    expect(loader.getDialogue('shrine_spirit_greeting')).toBeDefined();
+    expect(loader.getDialogue('shrine_spirit_explanation')).toBeDefined();
+    expect(loader.getDialogue('shrine_spirit_ending_renewed')).toBeDefined();
+    expect(loader.getDialogue('shrine_spirit_ending_sacrificed')).toBeDefined();
+    expect(loader.getDialogue('shrine_spirit_ending_shattered')).toBeDefined();
+  });
+
+  // ── AC-4: Quest data ──
+
+  test('fading_ward quest has 3 objectives and 3 endings', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const quest = loader.getQuest('fading_ward');
+    expect(quest?.name).toBe('The Fading Ward');
+    expect(quest?.objectives.length).toBe(3);
+
+    const endingIds = Object.keys(quest?.endings ?? {});
+    expect(endingIds.length).toBe(3);
+    expect(endingIds).toContain('ward_renewed');
+    expect(endingIds).toContain('ward_sacrificed');
+    expect(endingIds).toContain('ward_shattered');
+  });
+
+  test('each fading_ward ending has title, narration (50+ chars), and worldStateFlag', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const quest = loader.getQuest('fading_ward');
+    const endings = quest?.endings ?? {};
+
+    for (const [_key, ending] of Object.entries(endings)) {
+      expect(ending.title.length).toBeGreaterThan(0);
+      expect(ending.narration.length).toBeGreaterThanOrEqual(50);
+      expect(ending.worldStateFlag).toMatch(/^emberwatch\.ending\./);
+    }
+  });
+
+  test('fading_ward rewards include at least one item and gold or xp', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const quest = loader.getQuest('fading_ward');
+    expect(quest?.rewards.length).toBeGreaterThan(0);
+
+    const rewardTypes = quest?.rewards.map((r) => r.type) ?? [];
+    const hasItem = rewardTypes.includes('item');
+    const hasGoldOrXp = rewardTypes.includes('gold') || rewardTypes.includes('xp');
+    expect(hasItem).toBe(true);
+    expect(hasGoldOrXp).toBe(true);
+  });
+
+  test('lost_pendant optional quest exists', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const quest = loader.getQuest('lost_pendant');
+    expect(quest?.name).toBe("The Merchant's Lost Pendant");
+    expect(quest?.objectives.length).toBe(2);
+  });
+
+  // ── AC-5: Encounter data ──
+
+  test('ruined_ward_encounter has complete resolution data', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const enc = loader.getEncounter('ruined_ward_encounter');
+    expect(enc?.name).toBe('Shade of the Ruined Shrine');
+    expect(enc?.mapId).toBe('ruined_ward_shrine');
+    expect(enc?.enemyNpcIds.length).toBeGreaterThanOrEqual(1);
+    expect(enc?.allowNonCombatResolution).toBe(true);
+  });
+
+  test('ruined_ward_encounter skill check is persuasion DC 14 charisma', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const enc = loader.getEncounter('ruined_ward_encounter');
+    const check = enc?.nonCombatSkillCheck;
+    expect(check?.skill).toBe('persuasion');
+    expect(check?.dc).toBe(14);
+    expect(check?.statModifier).toBe('charisma');
+  });
+
+  test('ruined_ward_encounter dialogue keys resolve', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const enc = loader.getEncounter('ruined_ward_encounter');
+    expect(loader.getDialogue(enc?.startDialogueKey ?? '')).toBeDefined();
+    expect(loader.getDialogue(enc?.victoryDialogueKey ?? '')).toBeDefined();
+    expect(loader.getDialogue(enc?.nonCombatSkillCheck?.successDialogueKey ?? '')).toBeDefined();
+    expect(loader.getDialogue(enc?.nonCombatSkillCheck?.failureDialogueKey ?? '')).toBeDefined();
+  });
+
+  test('ruined_ward_encounter has at least one guaranteed loot drop', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const enc = loader.getEncounter('ruined_ward_encounter');
+    expect(enc?.loot.length).toBeGreaterThanOrEqual(1);
+    const guaranteedLoot = enc?.loot.find((l) => l.dropChance === 1.0);
+    expect(guaranteedLoot).toBeDefined();
+  });
+
+  test('enemy NPCs in encounter have combatStats', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const enc = loader.getEncounter('ruined_ward_encounter');
+    for (const npcId of enc?.enemyNpcIds ?? []) {
+      const npc = loader.getNpc(npcId);
+      expect(npc?.combatStats).toBeDefined();
+      expect(npc?.combatStats?.hitPoints).toBeGreaterThan(0);
+    }
+  });
+
+  // ── AC-5: Item ID reconciliation ──
+
+  test('all item IDs in manifest resolve in ITEM_CATALOG', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    // All manifest item keys
+    for (const itemId of Object.keys(loader.manifest.items)) {
+      expect(ITEM_CATALOG_KEYS.has(itemId)).toBe(true);
+    }
+
+    // All vendorInventory items
+    for (const [_npcId, npc] of Object.entries(loader.manifest.npcs)) {
+      if (npc.vendorInventory) {
+        const vendorItems = npc.vendorInventory.split(/,\s*/);
+        for (const itemId of vendorItems) {
+          expect(ITEM_CATALOG_KEYS.has(itemId)).toBe(true);
+        }
+      }
+    }
+
+    // All loot items
+    for (const [_encId, enc] of Object.entries(loader.manifest.encounters ?? {})) {
+      for (const loot of enc.loot) {
+        expect(ITEM_CATALOG_KEYS.has(loot.itemId)).toBe(true);
+      }
+    }
+  });
+
+  // ── Loader accessor integration ──
+
+  test('getAllQuests returns 2 quests', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const allQuests = loader.getAllQuests();
+    expect(allQuests.length).toBe(2);
+  });
+
+  test('getAllEncounters returns 1 encounter', async () => {
+    const fetcher = createEmberwatchFetch();
+    const loader = await loadContentPack({
+      packId: 'emberwatch',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const allEncounters = loader.getAllEncounters();
+    expect(allEncounters.length).toBe(1);
   });
 });

--- a/packages/frontend/engine/src/assets/content_pack_loader.test.ts
+++ b/packages/frontend/engine/src/assets/content_pack_loader.test.ts
@@ -1,8 +1,10 @@
 // packages/frontend/engine/src/assets/content_pack_loader.test.ts
 //
 // Tests for content pack loader — manifest loading, URL resolution,
-// dialogue lookup, cache lifecycle, and error paths.
+// dialogue lookup, quest/encounter/credits accessors, cache lifecycle,
+// and error paths.
 // Contract: C-315 Define a Versioned Campaign Content Pack and Atomic Loader
+// Contract: C-316 Build the Authored Emberwatch Demo Adventure
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { clearContentPackCache, loadContentPack } from './content_pack_loader.ts';
@@ -450,5 +452,288 @@ describe('ContentPackLoader', () => {
     });
 
     expect(loader.getItem('nonexistent')).toBeUndefined();
+  });
+
+  // ── C-316: quest accessors ──
+
+  test('getQuest returns quest entry by ID', async () => {
+    const manifestWithQuests = {
+      ...validManifest,
+      quests: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        fading_ward: {
+          id: 'fading_ward',
+          name: 'The Fading Ward',
+          description: 'Investigate the failing ward.',
+          objectives: [{ text: 'Reach the Old Road', completeOnMapEnter: 'old_road' }],
+          offerDialogueKey: 'quest_offer',
+          progressDialogueKey: 'quest_progress',
+          rewards: [{ type: 'item', itemId: 'wardAmulet' }],
+          endings: {
+            good: {
+              title: 'Ward Renewed',
+              narration:
+                'The ward pulses with renewed vigor, protecting Emberwatch for another century.',
+              worldStateFlag: 'emberwatch.ending.renewed',
+            },
+          },
+        },
+      },
+    };
+    const { fetcher } = createFetchMock(manifestWithQuests);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const quest = loader.getQuest('fading_ward');
+    expect(quest?.id).toBe('fading_ward');
+    expect(quest?.name).toBe('The Fading Ward');
+    expect(quest?.objectives.length).toBe(1);
+  });
+
+  test('getQuest returns undefined for unknown quest ID', async () => {
+    const { fetcher } = createFetchMock(validManifest);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getQuest('nonexistent')).toBeUndefined();
+  });
+
+  test('getAllQuests returns all quest entries', async () => {
+    const manifestWithQuests = {
+      ...validManifest,
+      quests: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        main_quest: {
+          id: 'main_quest',
+          name: 'Main Quest',
+          description: 'Save the world.',
+          objectives: [{ text: 'Find the artifact', completeOnMapEnter: 'dungeon' }],
+          offerDialogueKey: 'offer',
+          progressDialogueKey: 'progress',
+          rewards: [],
+          endings: {},
+        },
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        side_quest: {
+          id: 'side_quest',
+          name: 'Side Quest',
+          description: 'Help the merchant.',
+          objectives: [{ text: 'Find the pendant', completeOnItemPickup: 'lostPendant' }],
+          offerDialogueKey: 'merchant_offer',
+          progressDialogueKey: 'merchant_progress',
+          rewards: [{ type: 'gold', amount: 50 }],
+          endings: {},
+        },
+      },
+    };
+    const { fetcher } = createFetchMock(manifestWithQuests);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const all = loader.getAllQuests();
+    expect(all.length).toBe(2);
+    expect(all.map((q) => q.id).sort()).toEqual(['main_quest', 'side_quest']);
+  });
+
+  test('getAllQuests returns empty array when no quests in manifest', async () => {
+    const { fetcher } = createFetchMock(validManifest);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getAllQuests()).toEqual([]);
+  });
+
+  // ── C-316: encounter accessors ──
+
+  test('getEncounter returns encounter entry by ID', async () => {
+    const manifestWithEncounters = {
+      ...validManifest,
+      encounters: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        ruined_ward_encounter: {
+          id: 'ruined_ward_encounter',
+          mapId: 'ruined_ward_shrine',
+          name: 'Shrine Guardian',
+          enemyNpcIds: ['shade_guardian'],
+          allowNonCombatResolution: true,
+          nonCombatSkillCheck: {
+            skill: 'persuasion',
+            dc: 14,
+            statModifier: 'charisma',
+            successDialogueKey: 'shade_persuaded',
+            failureDialogueKey: 'shade_enraged',
+          },
+          startDialogueKey: 'encounter_start',
+          victoryDialogueKey: 'encounter_victory',
+          loot: [{ itemId: 'wardShard', quantity: 1, dropChance: 1.0 }],
+        },
+      },
+    };
+    const { fetcher } = createFetchMock(manifestWithEncounters);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const enc = loader.getEncounter('ruined_ward_encounter');
+    expect(enc?.name).toBe('Shrine Guardian');
+    expect(enc?.enemyNpcIds).toEqual(['shade_guardian']);
+    expect(enc?.allowNonCombatResolution).toBe(true);
+    expect(enc?.nonCombatSkillCheck?.dc).toBe(14);
+  });
+
+  test('getEncounter returns undefined for unknown encounter ID', async () => {
+    const { fetcher } = createFetchMock(validManifest);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getEncounter('nonexistent')).toBeUndefined();
+  });
+
+  test('getAllEncounters returns all encounter entries', async () => {
+    const manifestWithEncounters = {
+      ...validManifest,
+      encounters: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        enc_1: {
+          id: 'enc_1',
+          mapId: 'village',
+          name: 'Encounter 1',
+          enemyNpcIds: ['bandit'],
+          allowNonCombatResolution: false,
+          startDialogueKey: 'start1',
+          victoryDialogueKey: 'victory1',
+          loot: [],
+        },
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        enc_2: {
+          id: 'enc_2',
+          mapId: 'dungeon',
+          name: 'Encounter 2',
+          enemyNpcIds: ['dragon'],
+          allowNonCombatResolution: false,
+          startDialogueKey: 'start2',
+          victoryDialogueKey: 'victory2',
+          loot: [],
+        },
+      },
+    };
+    const { fetcher } = createFetchMock(manifestWithEncounters);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const all = loader.getAllEncounters();
+    expect(all.length).toBe(2);
+    expect(all.map((e) => e.id).sort()).toEqual(['enc_1', 'enc_2']);
+  });
+
+  test('getAllEncounters returns empty array when no encounters in manifest', async () => {
+    const { fetcher } = createFetchMock(validManifest);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getAllEncounters()).toEqual([]);
+  });
+
+  // ── C-316: credits accessor ──
+
+  test('getCredits returns credits when present', async () => {
+    const manifestWithCredits = {
+      ...validManifest,
+      credits: {
+        design: ['Alice'],
+        writing: ['Bob'],
+        art: ['Carol'],
+        music: ['Dave'],
+        thanks: ['The community'],
+      },
+    };
+    const { fetcher } = createFetchMock(manifestWithCredits);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    const credits = loader.getCredits();
+    expect(credits?.design).toEqual(['Alice']);
+    expect(credits?.writing).toEqual(['Bob']);
+  });
+
+  test('getCredits returns undefined when not present', async () => {
+    const { fetcher } = createFetchMock(validManifest);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    expect(loader.getCredits()).toBeUndefined();
+  });
+
+  // ── C-316: dispose affects new accessors ──
+
+  test('dispose blocks getQuest, getEncounter, getAllQuests, getAllEncounters, getCredits', async () => {
+    const manifestWithAll = {
+      ...validManifest,
+      quests: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        test_quest: {
+          id: 'test_quest',
+          name: 'Test',
+          description: 'Test quest.',
+          objectives: [{ text: 'Do something', completeOnMapEnter: 'village' }],
+          offerDialogueKey: 'offer',
+          progressDialogueKey: 'progress',
+          rewards: [],
+          endings: {},
+        },
+      },
+      encounters: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        test_enc: {
+          id: 'test_enc',
+          mapId: 'village',
+          name: 'Test Enc',
+          enemyNpcIds: ['bandit'],
+          allowNonCombatResolution: false,
+          startDialogueKey: 'start',
+          victoryDialogueKey: 'victory',
+          loot: [],
+        },
+      },
+      credits: {
+        design: [],
+        writing: [],
+        art: [],
+        music: [],
+        thanks: [],
+      },
+    };
+    const { fetcher } = createFetchMock(manifestWithAll);
+    const loader = await loadContentPack({
+      packId: 'test-pack',
+      fetchFn: fetcher as unknown as typeof fetch,
+    });
+
+    loader.dispose();
+
+    expect(() => loader.getQuest('test_quest')).toThrow();
+    expect(() => loader.getEncounter('test_enc')).toThrow();
+    expect(() => loader.getAllQuests()).toThrow();
+    expect(() => loader.getAllEncounters()).toThrow();
+    expect(() => loader.getCredits()).toThrow();
   });
 });

--- a/packages/frontend/engine/src/assets/content_pack_loader.ts
+++ b/packages/frontend/engine/src/assets/content_pack_loader.ts
@@ -8,10 +8,13 @@
 
 import { ContentPackManifestSchema } from '@aikami/schemas';
 import type {
+  ContentPackCredits,
+  ContentPackEncounterEntry,
   ContentPackItemEntry,
   ContentPackManifest,
   ContentPackMapEntry,
   ContentPackNpcEntry,
+  ContentPackQuestEntry,
 } from '@aikami/types';
 import { toAppError } from '@aikami/utils';
 import { Value } from 'typebox/value';
@@ -43,6 +46,21 @@ export type ContentPackLoaderInterface = {
 
   /** Returns an item entry by ID, or undefined if not found */
   getItem(itemId: string): ContentPackItemEntry | undefined;
+
+  /** Returns a quest entry by ID, or undefined if not found */
+  getQuest(questId: string): ContentPackQuestEntry | undefined;
+
+  /** Returns an encounter entry by ID, or undefined if not found */
+  getEncounter(encounterId: string): ContentPackEncounterEntry | undefined;
+
+  /** Returns all quest entries in the pack */
+  getAllQuests(): ContentPackQuestEntry[];
+
+  /** Returns all encounter entries in the pack */
+  getAllEncounters(): ContentPackEncounterEntry[];
+
+  /** Returns credits or undefined if not present */
+  getCredits(): ContentPackCredits | undefined;
 
   /** Disposes per-instance resources (no-op if already disposed) */
   dispose(): void;
@@ -137,6 +155,36 @@ class ContentPackLoader implements ContentPackLoaderInterface {
   getItem(itemId: string): ContentPackItemEntry | undefined {
     this._assertNotDisposed();
     return this.manifest.items[itemId];
+  }
+
+  /** @inheritdoc */
+  getQuest(questId: string): ContentPackQuestEntry | undefined {
+    this._assertNotDisposed();
+    return this.manifest.quests?.[questId];
+  }
+
+  /** @inheritdoc */
+  getEncounter(encounterId: string): ContentPackEncounterEntry | undefined {
+    this._assertNotDisposed();
+    return this.manifest.encounters?.[encounterId];
+  }
+
+  /** @inheritdoc */
+  getAllQuests(): ContentPackQuestEntry[] {
+    this._assertNotDisposed();
+    return Object.values(this.manifest.quests ?? {});
+  }
+
+  /** @inheritdoc */
+  getAllEncounters(): ContentPackEncounterEntry[] {
+    this._assertNotDisposed();
+    return Object.values(this.manifest.encounters ?? {});
+  }
+
+  /** @inheritdoc */
+  getCredits(): ContentPackCredits | undefined {
+    this._assertNotDisposed();
+    return this.manifest.credits;
   }
 
   /** @inheritdoc */

--- a/packages/shared/schemas/src/lib/game/content_pack.test.ts
+++ b/packages/shared/schemas/src/lib/game/content_pack.test.ts
@@ -1,7 +1,8 @@
-// packages/shared/schemas/src/lib/content_pack.test.ts
+// packages/shared/schemas/src/lib/game/content_pack.test.ts
 //
 // Tests for ContentPackManifest schema validation.
 // Contract: C-315 Define a Versioned Campaign Content Pack and Atomic Loader
+// Contract: C-316 Build the Authored Emberwatch Demo Adventure
 
 import { describe, expect, test } from 'bun:test';
 import { Value } from 'typebox/value';
@@ -233,6 +234,308 @@ describe('ContentPackManifestSchema', () => {
     expect(npc.appearanceLayers).toEqual([1, 2, 3]);
     expect(npc.isVendor).toBe(true);
     expect(npc.vendorInventory).toBe('generalStore');
+  });
+
+  // ── C-316: vendorInventory pattern validation ──
+
+  test('should accept vendorInventory with comma-separated item IDs', () => {
+    const manifest = {
+      ...validManifest,
+      npcs: {
+        merchant: {
+          name: 'Merchant',
+          isVendor: true,
+          vendorInventory: 'ironSword,healthPotion,woodenShield',
+        },
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    expect(result.npcs.merchant.vendorInventory).toBe('ironSword,healthPotion,woodenShield');
+  });
+
+  test('should accept vendorInventory with spaces after commas', () => {
+    const manifest = {
+      ...validManifest,
+      npcs: {
+        merchant: {
+          name: 'Merchant',
+          isVendor: true,
+          vendorInventory: 'ironSword, healthPotion, woodenShield',
+        },
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    expect(result.npcs.merchant.vendorInventory).toBe('ironSword, healthPotion, woodenShield');
+  });
+
+  test('should reject vendorInventory with invalid characters', () => {
+    const manifest = {
+      ...validManifest,
+      npcs: {
+        merchant: {
+          name: 'Merchant',
+          isVendor: true,
+          vendorInventory: 'iron sword',
+        },
+      },
+    };
+    expect(() => Value.Parse(ContentPackManifestSchema, manifest)).toThrow();
+  });
+
+  // ── C-316: combatStats on NPC ──
+
+  test('should accept NPC with combatStats', () => {
+    const manifest = {
+      ...validManifest,
+      npcs: {
+        bandit: {
+          name: 'Bandit',
+          combatStats: {
+            hitPoints: 20,
+            armorClass: 12,
+            attackBonus: 3,
+            damage: '1d6+2',
+            initiativeBonus: 1,
+            xpValue: 50,
+          },
+        },
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    const stats = result.npcs.bandit.combatStats;
+    expect(stats?.hitPoints).toBe(20);
+    expect(stats?.armorClass).toBe(12);
+    expect(stats?.attackBonus).toBe(3);
+    expect(stats?.damage).toBe('1d6+2');
+    expect(stats?.initiativeBonus).toBe(1);
+    expect(stats?.xpValue).toBe(50);
+  });
+
+  test('should accept NPC with minimal combatStats (no optional fields)', () => {
+    const manifest = {
+      ...validManifest,
+      npcs: {
+        bandit: {
+          name: 'Bandit',
+          combatStats: {
+            hitPoints: 10,
+            armorClass: 10,
+            attackBonus: 0,
+            damage: '1d4',
+          },
+        },
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    expect(result.npcs.bandit.combatStats?.hitPoints).toBe(10);
+  });
+
+  test('should reject combatStats with invalid damage pattern', () => {
+    const manifest = {
+      ...validManifest,
+      npcs: {
+        bandit: {
+          name: 'Bandit',
+          combatStats: {
+            hitPoints: 10,
+            armorClass: 10,
+            attackBonus: 0,
+            damage: 'invalid',
+          },
+        },
+      },
+    };
+    expect(() => Value.Parse(ContentPackManifestSchema, manifest)).toThrow();
+  });
+
+  test('should accept damage patterns: 1d4, 2d6, 1d8+2', () => {
+    const patterns = ['1d4', '2d6', '1d8+2', '3d10+5'];
+    for (const damage of patterns) {
+      const manifest = {
+        ...validManifest,
+        npcs: {
+          bandit: {
+            name: 'Bandit',
+            combatStats: {
+              hitPoints: 10,
+              armorClass: 10,
+              attackBonus: 0,
+              damage,
+            },
+          },
+        },
+      };
+      const result = Value.Parse(ContentPackManifestSchema, manifest);
+      expect(result.npcs.bandit.combatStats?.damage).toBe(damage);
+    }
+  });
+
+  // ── C-316: manifest with quests, encounters, credits ──
+
+  test('should accept manifest with quests field', () => {
+    const manifest = {
+      ...validManifest,
+      quests: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        fading_ward: {
+          id: 'fading_ward',
+          name: 'The Fading Ward',
+          description: 'Investigate the failing ward magic.',
+          objectives: [{ text: 'Reach the Old Road', completeOnMapEnter: 'old_road' }],
+          offerDialogueKey: 'elder_offer',
+          progressDialogueKey: 'elder_progress',
+          rewards: [{ type: 'item', itemId: 'wardAmulet' }],
+          endings: {
+            renewed: {
+              title: 'Ward Renewed',
+              narration:
+                'The ward pulses with renewed vigor, its blue light spreading across the shrine and into the valley beyond, protecting Emberwatch for another century.',
+              worldStateFlag: 'emberwatch.ending.renewed',
+            },
+          },
+        },
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    const quest = result.quests?.fading_ward;
+    expect(quest?.id).toBe('fading_ward');
+    expect(quest?.name).toBe('The Fading Ward');
+    expect(quest?.objectives.length).toBe(1);
+    expect(Object.keys(quest?.endings ?? {}).length).toBe(1);
+  });
+
+  test('should accept manifest without quests field (optional)', () => {
+    const result = Value.Parse(ContentPackManifestSchema, validManifest);
+    expect(result.quests).toBeUndefined();
+  });
+
+  test('should accept manifest with encounters field', () => {
+    const manifest = {
+      ...validManifest,
+      encounters: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        ruined_ward_encounter: {
+          id: 'ruined_ward_encounter',
+          mapId: 'ruined_ward_shrine',
+          name: 'Shrine Guardian',
+          enemyNpcIds: ['shade_guardian'],
+          allowNonCombatResolution: true,
+          nonCombatSkillCheck: {
+            skill: 'persuasion',
+            dc: 14,
+            statModifier: 'charisma',
+            successDialogueKey: 'shade_persuaded',
+            failureDialogueKey: 'shade_enraged',
+          },
+          startDialogueKey: 'encounter_start',
+          victoryDialogueKey: 'encounter_victory',
+          loot: [{ itemId: 'wardShard', quantity: 1, dropChance: 1.0 }],
+        },
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    const enc = result.encounters?.ruined_ward_encounter;
+    expect(enc?.name).toBe('Shrine Guardian');
+    expect(enc?.allowNonCombatResolution).toBe(true);
+    expect(enc?.enemyNpcIds).toEqual(['shade_guardian']);
+    expect(enc?.nonCombatSkillCheck?.dc).toBe(14);
+  });
+
+  test('should accept manifest without encounters field (optional)', () => {
+    const result = Value.Parse(ContentPackManifestSchema, validManifest);
+    expect(result.encounters).toBeUndefined();
+  });
+
+  test('should accept manifest with credits field', () => {
+    const manifest = {
+      ...validManifest,
+      credits: {
+        design: ['Alice'],
+        writing: ['Bob'],
+        art: ['Carol'],
+        music: ['Dave'],
+        thanks: ['Open source community'],
+      },
+    };
+    const result = Value.Parse(ContentPackManifestSchema, manifest);
+    expect(result.credits?.design).toEqual(['Alice']);
+    expect(result.credits?.writing).toEqual(['Bob']);
+  });
+
+  test('should accept manifest without credits field (optional)', () => {
+    const result = Value.Parse(ContentPackManifestSchema, validManifest);
+    expect(result.credits).toBeUndefined();
+  });
+
+  test('should reject quest with fewer than 1 objective', () => {
+    const manifest = {
+      ...validManifest,
+      quests: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        empty_quest: {
+          id: 'empty_quest',
+          name: 'Empty',
+          description: 'No objectives.',
+          objectives: [],
+          offerDialogueKey: 'offer',
+          progressDialogueKey: 'progress',
+          rewards: [],
+          endings: {},
+        },
+      },
+    };
+    expect(() => Value.Parse(ContentPackManifestSchema, manifest)).toThrow();
+  });
+
+  test('should reject encounter with no enemy NPC IDs', () => {
+    const manifest = {
+      ...validManifest,
+      encounters: {
+        // biome-ignore lint/style/useNamingConvention: JSON manifest key
+        no_enemies: {
+          id: 'no_enemies',
+          mapId: 'village',
+          name: 'No Enemies',
+          enemyNpcIds: [],
+          allowNonCombatResolution: false,
+          startDialogueKey: 'start',
+          victoryDialogueKey: 'victory',
+          loot: [],
+        },
+      },
+    };
+    expect(() => Value.Parse(ContentPackManifestSchema, manifest)).toThrow();
+  });
+
+  test('should accept all five skill stat values', () => {
+    const stats = ['strength', 'dexterity', 'intelligence', 'charisma', 'wisdom'] as const;
+    for (const stat of stats) {
+      const manifest = {
+        ...validManifest,
+        encounters: {
+          // biome-ignore lint/style/useNamingConvention: JSON manifest key
+          test_enc: {
+            id: 'test_enc',
+            mapId: 'village',
+            name: 'Test',
+            enemyNpcIds: ['bandit'],
+            allowNonCombatResolution: true,
+            nonCombatSkillCheck: {
+              skill: 'test',
+              dc: 10,
+              statModifier: stat,
+              successDialogueKey: 'success',
+              failureDialogueKey: 'failure',
+            },
+            startDialogueKey: 'start',
+            victoryDialogueKey: 'victory',
+            loot: [],
+          },
+        },
+      };
+      const result = Value.Parse(ContentPackManifestSchema, manifest);
+      expect(result.encounters?.test_enc.nonCombatSkillCheck?.statModifier).toBe(stat);
+    }
   });
 
   // ── Optional item fields ──

--- a/packages/shared/schemas/src/lib/game/content_pack.ts
+++ b/packages/shared/schemas/src/lib/game/content_pack.ts
@@ -1,8 +1,10 @@
-// packages/shared/schemas/src/lib/content_pack.ts
+// packages/shared/schemas/src/lib/game/content_pack.ts
 //
 // Content Pack Manifest schema — validates versioned content pack manifests.
-// These manifests declare maps, NPCs, items, and dialogues for a game world.
+// These manifests declare maps, NPCs, items, dialogues, quests, encounters,
+// and credits for a game world.
 // Contract: C-315 Define a Versioned Campaign Content Pack and Atomic Loader
+// Contract: C-316 Build the Authored Emberwatch Demo Adventure
 
 import Type, { type Static } from 'typebox';
 
@@ -12,6 +14,12 @@ import Type, { type Static } from 'typebox';
 
 const SEMVER_PATTERN =
   '^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$';
+
+// ---------------------------------------------------------------------------
+// Vendor inventory item ID pattern (comma-separated alphanumeric + underscore)
+// ---------------------------------------------------------------------------
+
+const VENDOR_ITEM_ID_PATTERN = '^[a-zA-Z0-9_]+(,\\s*[a-zA-Z0-9_]+)*$';
 
 // ---------------------------------------------------------------------------
 // ContentPackMapEntry — a single map in the content pack
@@ -33,6 +41,30 @@ export const ContentPackMapEntrySchema = Type.Object({
 export type ContentPackMapEntry = Static<typeof ContentPackMapEntrySchema>;
 
 // ---------------------------------------------------------------------------
+// ContentPackCombatStats — combat stats for NPCs (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackCombatStatsSchema = Type.Object({
+  /** Max HP */
+  hitPoints: Type.Number({ minimum: 1, description: 'Max HP' }),
+  /** AC — d20 attack must meet or exceed */
+  armorClass: Type.Number({ minimum: 0, description: 'Armor class' }),
+  /** Added to d20 attack roll */
+  attackBonus: Type.Number({ description: 'Attack bonus' }),
+  /** Damage dice e.g. "1d6+2" */
+  damage: Type.String({
+    pattern: '^\\d+d\\d+(\\+\\d+)?$',
+    description: 'Damage dice e.g. "1d6+2"',
+  }),
+  /** Added to initiative roll */
+  initiativeBonus: Type.Optional(Type.Number({ default: 0, description: 'Initiative bonus' })),
+  /** XP granted on defeat */
+  xpValue: Type.Optional(Type.Number({ default: 0, description: 'XP granted on defeat' })),
+});
+
+export type ContentPackCombatStats = Static<typeof ContentPackCombatStatsSchema>;
+
+// ---------------------------------------------------------------------------
 // ContentPackNpcEntry — NPC definition in the pack
 // ---------------------------------------------------------------------------
 
@@ -47,8 +79,15 @@ export const ContentPackNpcEntrySchema = Type.Object({
   ),
   /** Whether this NPC is a vendor */
   isVendor: Type.Optional(Type.Boolean({ description: 'Whether this NPC is a vendor' })),
-  /** Vendor inventory reference */
-  vendorInventory: Type.Optional(Type.String({ description: 'Vendor inventory reference key' })),
+  /** Comma-separated item IDs e.g. "ironSword,healthPotion" */
+  vendorInventory: Type.Optional(
+    Type.String({
+      pattern: VENDOR_ITEM_ID_PATTERN,
+      description: 'Comma-separated item IDs e.g. "ironSword,healthPotion"',
+    }),
+  ),
+  /** Combat stats for enemy NPCs (C-316) */
+  combatStats: Type.Optional(ContentPackCombatStatsSchema),
 });
 
 export type ContentPackNpcEntry = Static<typeof ContentPackNpcEntrySchema>;
@@ -81,6 +120,229 @@ export const ContentPackItemEntrySchema = Type.Object({
 });
 
 export type ContentPackItemEntry = Static<typeof ContentPackItemEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackQuestObjective — a single quest objective (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackQuestObjectiveSchema = Type.Object({
+  /** Display text for the objective */
+  text: Type.String({ minLength: 1, description: 'Display text for the objective' }),
+  /** Map ID that completes this objective on enter */
+  completeOnMapEnter: Type.Optional(
+    Type.String({ description: 'Map ID that completes this objective on enter' }),
+  ),
+  /** NPC ID that completes this objective on interact */
+  completeOnNpcInteract: Type.Optional(
+    Type.String({ description: 'NPC ID that completes this objective on interact' }),
+  ),
+  /** Encounter ID that completes this objective */
+  completeOnEncounterComplete: Type.Optional(
+    Type.String({ description: 'Encounter ID that completes this objective' }),
+  ),
+  /** Item ID that completes this objective on pickup */
+  completeOnItemPickup: Type.Optional(
+    Type.String({ description: 'Item ID that completes this objective on pickup' }),
+  ),
+});
+
+export type ContentPackQuestObjective = Static<typeof ContentPackQuestObjectiveSchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackQuestRewardType — reward category (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackQuestRewardTypeSchema = Type.Union([
+  Type.Literal('item'),
+  Type.Literal('gold'),
+  Type.Literal('xp'),
+  Type.Literal('equipment'),
+]);
+
+export type ContentPackQuestRewardType = Static<typeof ContentPackQuestRewardTypeSchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackQuestReward — a quest completion reward (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackQuestRewardSchema = Type.Object({
+  /** Reward type */
+  type: ContentPackQuestRewardTypeSchema,
+  /** Item ID for item/equipment rewards */
+  itemId: Type.Optional(Type.String({ description: 'Item ID for item/equipment rewards' })),
+  /** Gold or XP amount */
+  amount: Type.Optional(Type.Number({ minimum: 1, description: 'Gold or XP amount' })),
+});
+
+export type ContentPackQuestReward = Static<typeof ContentPackQuestRewardSchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackQuestEnding — a quest ending variation (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackQuestEndingSchema = Type.Object({
+  /** Ending title */
+  title: Type.String({ minLength: 1, description: 'Ending title' }),
+  /** Authored narration text (50+ chars) */
+  narration: Type.String({ minLength: 50, description: 'Authored narration text (50+ chars)' }),
+  /** NPC reaction dialogue key */
+  reactionDialogueKey: Type.Optional(Type.String({ description: 'NPC reaction dialogue key' })),
+  /** World-state flag set on activation */
+  worldStateFlag: Type.String({
+    minLength: 1,
+    pattern: '^[a-zA-Z0-9_.]+$',
+    description: 'World-state flag set on activation',
+  }),
+});
+
+export type ContentPackQuestEnding = Static<typeof ContentPackQuestEndingSchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackQuestEntry — a quest definition (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackQuestEntrySchema = Type.Object({
+  /** Unique quest identifier */
+  id: Type.String({ minLength: 1, description: 'Unique quest identifier' }),
+  /** Quest display name */
+  name: Type.String({ minLength: 1, description: 'Quest display name' }),
+  /** Quest flavor text */
+  description: Type.String({ minLength: 1, description: 'Quest flavor text' }),
+  /** Quest objectives (at least 1) */
+  objectives: Type.Array(ContentPackQuestObjectiveSchema, {
+    minItems: 1,
+    description: 'Quest objectives',
+  }),
+  /** Dialogue key when quest is offered */
+  offerDialogueKey: Type.String({ description: 'Dialogue key when quest is offered' }),
+  /** Dialogue key while quest is active */
+  progressDialogueKey: Type.String({ description: 'Dialogue key while quest is active' }),
+  /** Completion rewards */
+  rewards: Type.Array(ContentPackQuestRewardSchema, { description: 'Completion rewards' }),
+  /** Ending variations keyed by ending ID */
+  endings: Type.Record(Type.String(), ContentPackQuestEndingSchema, {
+    description: 'Ending variations keyed by ending ID',
+  }),
+});
+
+export type ContentPackQuestEntry = Static<typeof ContentPackQuestEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackSkillStat — skill stat for skill checks (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackSkillStatSchema = Type.Union([
+  Type.Literal('strength'),
+  Type.Literal('dexterity'),
+  Type.Literal('intelligence'),
+  Type.Literal('charisma'),
+  Type.Literal('wisdom'),
+]);
+
+export type ContentPackSkillStat = Static<typeof ContentPackSkillStatSchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackSkillCheck — a skill check definition (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackSkillCheckSchema = Type.Object({
+  /** Skill label e.g. "persuasion" */
+  skill: Type.String({ minLength: 1, description: 'Skill label e.g. "persuasion"' }),
+  /** Difficulty class — d20 must meet or exceed */
+  dc: Type.Number({ minimum: 1, description: 'Difficulty class' }),
+  /** Stat modifier applied to the roll */
+  statModifier: ContentPackSkillStatSchema,
+  /** Dialogue on skill check success */
+  successDialogueKey: Type.String({ description: 'Dialogue on skill check success' }),
+  /** Dialogue on skill check failure */
+  failureDialogueKey: Type.String({ description: 'Dialogue on skill check failure' }),
+});
+
+export type ContentPackSkillCheck = Static<typeof ContentPackSkillCheckSchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackLootEntry — a loot drop entry (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackLootEntrySchema = Type.Object({
+  /** Item ID dropped */
+  itemId: Type.String({ minLength: 1, description: 'Item ID dropped' }),
+  /** Quantity dropped */
+  quantity: Type.Number({ minimum: 1, description: 'Quantity dropped' }),
+  /** Drop probability 0.0–1.0 */
+  dropChance: Type.Number({
+    minimum: 0,
+    maximum: 1,
+    description: 'Drop probability 0.0–1.0',
+  }),
+});
+
+export type ContentPackLootEntry = Static<typeof ContentPackLootEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackEncounterEntry — a combat encounter definition (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackEncounterEntrySchema = Type.Object({
+  /** Unique encounter identifier */
+  id: Type.String({ minLength: 1, description: 'Unique encounter identifier' }),
+  /** Map ID where this encounter triggers */
+  mapId: Type.String({ minLength: 1, description: 'Map ID where this encounter triggers' }),
+  /** Encounter display name */
+  name: Type.String({ minLength: 1, description: 'Encounter display name' }),
+  /** NPC IDs that participate as enemies */
+  enemyNpcIds: Type.Array(Type.String(), {
+    minItems: 1,
+    description: 'NPC IDs that participate as enemies',
+  }),
+  /** Whether non-combat resolution is available */
+  allowNonCombatResolution: Type.Boolean({
+    description: 'Whether non-combat resolution is available',
+  }),
+  /** Skill check for non-combat resolution */
+  nonCombatSkillCheck: Type.Optional(ContentPackSkillCheckSchema),
+  /** Dialogue on encounter start */
+  startDialogueKey: Type.String({ description: 'Dialogue on encounter start' }),
+  /** Dialogue on combat victory */
+  victoryDialogueKey: Type.String({ description: 'Dialogue on combat victory' }),
+  /** Dialogue on non-combat success */
+  nonCombatSuccessDialogueKey: Type.Optional(
+    Type.String({ description: 'Dialogue on non-combat success' }),
+  ),
+  /** Loot dropped on victory */
+  loot: Type.Array(ContentPackLootEntrySchema, { description: 'Loot dropped on victory' }),
+});
+
+export type ContentPackEncounterEntry = Static<typeof ContentPackEncounterEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// ContentPackCredits — adventure credits (C-316)
+// ---------------------------------------------------------------------------
+
+export const ContentPackCreditsSchema = Type.Object({
+  /** Adventure design credits */
+  design: Type.Array(Type.String(), { description: 'Adventure design credits' }),
+  /** Writing credits */
+  writing: Type.Array(Type.String(), { description: 'Writing credits' }),
+  /** Art asset credits */
+  art: Type.Array(Type.String(), { description: 'Art asset credits' }),
+  /** Music credits */
+  music: Type.Array(Type.String(), { description: 'Music credits' }),
+  /** Special thanks */
+  thanks: Type.Array(Type.String(), { description: 'Special thanks' }),
+});
+
+export type ContentPackCredits = Static<typeof ContentPackCreditsSchema>;
+
+// ---------------------------------------------------------------------------
+// Internal: record schema helpers for quests and encounters in manifest
+// ---------------------------------------------------------------------------
+
+export const ManifestQuestMapSchema = Type.Record(Type.String(), ContentPackQuestEntrySchema);
+export const ManifestEncounterMapSchema = Type.Record(
+  Type.String(),
+  ContentPackEncounterEntrySchema,
+);
 
 // ---------------------------------------------------------------------------
 // ContentPackManifest — top-level content pack manifest
@@ -116,6 +378,12 @@ export const ContentPackManifestSchema = Type.Object({
   dialogues: Type.Record(Type.String(), Type.String(), {
     description: 'Dialogue fallback strings keyed by dialogue key',
   }),
+  /** Optional: quest definitions, keyed by quest ID (C-316) */
+  quests: Type.Optional(ManifestQuestMapSchema),
+  /** Optional: encounter definitions, keyed by encounter ID (C-316) */
+  encounters: Type.Optional(ManifestEncounterMapSchema),
+  /** Optional: adventure credits (C-316) */
+  credits: Type.Optional(ContentPackCreditsSchema),
 });
 
 export type ContentPackManifest = Static<typeof ContentPackManifestSchema>;

--- a/packages/shared/types/src/lib/game/content_pack.ts
+++ b/packages/shared/types/src/lib/game/content_pack.ts
@@ -1,20 +1,35 @@
-// packages/shared/types/src/lib/content_pack.ts
+// packages/shared/types/src/lib/game/content_pack.ts
 //
 // Content Pack types — derived from TypeBox schemas in @aikami/schemas.
 // Single source of truth for content pack data shapes.
 // Contract: C-315 Define a Versioned Campaign Content Pack and Atomic Loader
+// Contract: C-316 Build the Authored Emberwatch Demo Adventure
 
 import type {
+  ContentPackCombatStatsSchema,
+  ContentPackCreditsSchema,
+  ContentPackEncounterEntrySchema,
   ContentPackItemEntrySchema,
+  ContentPackLootEntrySchema,
   ContentPackManifestSchema,
   ContentPackMapEntrySchema,
   ContentPackNpcEntrySchema,
+  ContentPackQuestEndingSchema,
+  ContentPackQuestEntrySchema,
+  ContentPackQuestObjectiveSchema,
+  ContentPackQuestRewardSchema,
+  ContentPackQuestRewardTypeSchema,
+  ContentPackSkillCheckSchema,
+  ContentPackSkillStatSchema,
   ItemTypeSchema,
 } from '@aikami/schemas';
 import type { Static } from 'typebox';
 
 /** A single map entry in a content pack manifest. */
 export type ContentPackMapEntry = Static<typeof ContentPackMapEntrySchema>;
+
+/** Combat stats on an NPC (C-316). */
+export type ContentPackCombatStats = Static<typeof ContentPackCombatStatsSchema>;
 
 /** An NPC definition in a content pack manifest. */
 export type ContentPackNpcEntry = Static<typeof ContentPackNpcEntrySchema>;
@@ -24,6 +39,36 @@ export type ItemType = Static<typeof ItemTypeSchema>;
 
 /** An item definition in a content pack manifest. */
 export type ContentPackItemEntry = Static<typeof ContentPackItemEntrySchema>;
+
+/** A single quest objective (C-316). */
+export type ContentPackQuestObjective = Static<typeof ContentPackQuestObjectiveSchema>;
+
+/** Quest reward categories (C-316). */
+export type ContentPackQuestRewardType = Static<typeof ContentPackQuestRewardTypeSchema>;
+
+/** A quest completion reward (C-316). */
+export type ContentPackQuestReward = Static<typeof ContentPackQuestRewardSchema>;
+
+/** A quest ending variation (C-316). */
+export type ContentPackQuestEnding = Static<typeof ContentPackQuestEndingSchema>;
+
+/** A quest definition (C-316). */
+export type ContentPackQuestEntry = Static<typeof ContentPackQuestEntrySchema>;
+
+/** Skill stat for skill checks (C-316). */
+export type ContentPackSkillStat = Static<typeof ContentPackSkillStatSchema>;
+
+/** A skill check definition (C-316). */
+export type ContentPackSkillCheck = Static<typeof ContentPackSkillCheckSchema>;
+
+/** A loot drop entry (C-316). */
+export type ContentPackLootEntry = Static<typeof ContentPackLootEntrySchema>;
+
+/** A combat encounter definition (C-316). */
+export type ContentPackEncounterEntry = Static<typeof ContentPackEncounterEntrySchema>;
+
+/** Adventure credits (C-316). */
+export type ContentPackCredits = Static<typeof ContentPackCreditsSchema>;
 
 /** Top-level content pack manifest. */
 export type ContentPackManifest = Static<typeof ContentPackManifestSchema>;


### PR DESCRIPTION
…C-316)

Extend content pack schema with quests, encounters, credits fields, combatStats on NPC entries, and vendorInventory pattern validation. Add 5 loader accessor methods (getQuest, getEncounter, getAllQuests, getAllEncounters, getCredits). Create 3 authored Tiled JSON maps (Emberwatch Village, Old Road, Ruined Ward Shrine) with NPC spawns, transitions, and collision layers. Author complete manifest.json v2.0.0: 7 NPCs, 8 items, 27 dialogue strings, 2 quests (Fading Ward main + Lost Pendant optional), 1 encounter with persuasion DC 14 skill check, loot table, credits. Extend ITEM_CATALOG with 3 Emberwatch items. All 96 tests pass (38 schema + 35 loader + 23 integration). validate() passes all 4 projects.