### PR TITLE
C-320: Unified AI Provider Gateway (Offline / BYOK / Service)

### DIFF
--- a/.context/llms.txt
+++ b/.context/llms.txt
@@ -1,8 +1,8 @@
 # Aikami Knowledge Index
 
 > **AI-first entry point.** Read this file first.
-> Generated: 2026-07-16
-> Files: 273 across 14 categories
+> Generated: 2026-07-17
+> Files: 274 across 14 categories
 
 ## Quick Start (Read These First)
 
@@ -263,6 +263,7 @@ Monorepo: SvelteKit Client × Firebase backend × Bun runtime × Moon orchestrat
 - [Contract C-317: Rebuild the Start Menu Around Campaigns, Not Personas](contracts/C-317-rebuild-the-start-menu-around-campaigns-not-personas.md)
 - [Contract C-318: Add One-Screen Capability Setup and an Offline Demo Fallback](contracts/C-318-add-one-screen-capability-setup-and-an-offline-demo-fallback.md)
 - [Contract C-319: Replace `/setup` with Fast Character Onboarding](contracts/C-319-replace-setup-with-fast-character-onboarding.md)
+- [Contract C-320: Build the Unified AI Provider Gateway (Offline / BYOK / Service)](contracts/C-320-build-the-unified-ai-provider-gateway-offline-byok-service.md)
 - [Contracts — Aikami Feature Development](contracts/INDEX.md)
 - [Contract Implementation Archive](contracts/PROGRESS_ARCHIVE.md)
 - [Contract Implementation Progress](contracts/PROGRESS.md)

--- a/.envrc
+++ b/.envrc
@@ -1,22 +1,4 @@
-#!/usr/bin/env bash
-# ─── Aikami .envrc ──────────────────────────────────────────────────────
-#
-# Deterministic development environment via nix-direnv + Nix Flakes.
-#
-# All logic lives in scripts/direnv/bootstrap.sh — the single source
-# of truth for direnv configuration. Bun scripts handle secrets loading
-# (scripts/src/lib/env/secrets.ts) and runtime validation
-# (scripts/src/lib/env/check.ts).
-#
-# See scripts/direnv/bootstrap.sh for the full implementation.
-# ────────────────────────────────────────────────────────────────────────
+# Workspace direnv — delegate to repo root where flake.nix is Git-tracked
+source_env /home/sonny/Development/Projects/passion/aikami
 
-set -euo pipefail
-
-# ── Early exit: already loaded ─────────────────────────────────────────
-if [ -n "${AIKAMI_ENV_LOADED:-}" ]; then
-  return 0
-fi
-
-# ── Source the bootstrap script ────────────────────────────────────────
-source "${PWD}/scripts/direnv/bootstrap.sh"
+export CONTRACT_PIPELINE_WORKTREE=1

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,22 @@
-# Workspace direnv — delegate to repo root where flake.nix is Git-tracked
-source_env /home/sonny/Development/Projects/passion/aikami
+#!/usr/bin/env bash
+# ─── Aikami .envrc ──────────────────────────────────────────────────────
+#
+# Deterministic development environment via nix-direnv + Nix Flakes.
+#
+# All logic lives in scripts/direnv/bootstrap.sh — the single source
+# of truth for direnv configuration. Bun scripts handle secrets loading
+# (scripts/src/lib/env/secrets.ts) and runtime validation
+# (scripts/src/lib/env/check.ts).
+#
+# See scripts/direnv/bootstrap.sh for the full implementation.
+# ────────────────────────────────────────────────────────────────────────
 
-export CONTRACT_PIPELINE_WORKTREE=1
+set -euo pipefail
+
+# ── Early exit: already loaded ─────────────────────────────────────────
+if [ -n "${AIKAMI_ENV_LOADED:-}" ]; then
+  return 0
+fi
+
+# ── Source the bootstrap script ────────────────────────────────────────
+source "${PWD}/scripts/direnv/bootstrap.sh"

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -41,6 +41,7 @@ projects:
   frontend-dataconnect: "packages/frontend/dataconnect"
   frontend-services: "packages/frontend/services"
   frontend-utils: "packages/frontend/utils"
+  frontend-ai-gateway: "packages/frontend/ai-gateway"
   frontend-repositories: "packages/frontend/repositories"
   frontend-configs: "packages/frontend/configs"
 

--- a/apps/frontend/client/src/lib/services/ai/ai_gateway_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/ai/ai_gateway_service.svelte.ts
@@ -115,8 +115,7 @@ class AiGatewayService
 
     const textAdapter = createOpenAiCompatibleTextAdapter({
       getApiKey: (provider) => this._getTextApiKey(provider),
-      supportsStructuredOutput: (provider) =>
-        PROVIDER_MODEL_FETCH[provider]?.chatTestOpenAiCompat ?? false,
+      supportsStructuredOutput: () => false,
       getDefaultEndpoint: (provider) => this._getDefaultTextEndpoint(provider),
       onSchemaCacheSize: (size) => {
         (globalThis as Record<string, unknown>).__text_service_compiled_schema_cache_size = size;
@@ -224,8 +223,13 @@ class AiGatewayService
           endpoint: match.endpoint || '',
         });
       }
-      // Model not found in config — use it verbatim with a provider-agnostic fallback
-      return this._toTextResolution({ provider: 'unknown', model: explicitModel, endpoint: '' });
+      // Model not found in config — use it verbatim with the active provider/endpoint
+      const resolved = configService.getActiveTextProvider();
+      return this._toTextResolution({
+        provider: resolved.provider,
+        model: explicitModel,
+        endpoint: resolved.endpoint,
+      });
     }
 
     const resolved = configService.getActiveTextProvider();

--- a/apps/frontend/client/src/lib/services/ai/ai_gateway_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/ai/ai_gateway_service.svelte.ts
@@ -1,0 +1,302 @@
+// apps/frontend/client/src/lib/services/ai/ai_gateway_service.svelte.ts
+//
+// Client wiring of the unified AI Provider Gateway (C-320). Composes the
+// gateway core from @aikami/frontend/ai-gateway with:
+// - text adapters (offline = Ollama/local OpenAI-compatible, byok = cloud
+//   endpoints with vault keys) — one shared OpenAI-compatible transport;
+// - a `service` text adapter over the Firebase `ai` callable (legacy
+//   ai_service behavior);
+// - image/voice adapters delegating to the existing ComfyUI and Kokoro
+//   services unchanged;
+// - detection wiring with the same ping semantics as capability_service.
+//
+// Mode is resolved once per capability at this boundary — call sites never
+// re-check providers.
+// Contract: C-320
+
+import {
+  type AiImageGenerationOptions,
+  type AiImageGenerationResult,
+  type AiProviderGateway,
+  type AiTextGenerationOptions,
+  type AiTextGenerationResult,
+  type AiVoiceGenerationOptions,
+  type AiVoiceGenerationResult,
+  createAdapterRegistry,
+  createAiProviderGateway,
+  createDelegatingImageAdapter,
+  createDelegatingVoiceAdapter,
+  createOpenAiCompatibleTextAdapter,
+  createServiceTextAdapter,
+  detectImageAvailability,
+  detectTextAvailability,
+  detectVoiceAvailability,
+} from '@aikami/frontend/ai-gateway';
+import {
+  BaseFrontendClass,
+  type BaseFrontendClassInterface,
+  type BaseFrontendClassOptions,
+  firebaseFunctionsService,
+} from '@aikami/frontend/services';
+import type {
+  AIMessageData,
+  AiCapability,
+  AiDetectionResult,
+  AiModeResolution,
+} from '@aikami/types';
+import { ttsService } from '$lib/services/audio/tts_service.svelte.ts';
+import { configService } from '$lib/services/config/config_service.svelte.ts';
+import { PROVIDER_MODEL_FETCH } from '$lib/services/config/provider_endpoints';
+import { imageGenerationService } from '$lib/services/image/image_generation_service.svelte.ts';
+import { aiSettingsService } from '$lib/services/settings/ai_settings.svelte.ts';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Providers served by the `offline` adapter family (localhost, no key). */
+const LOCAL_TEXT_PROVIDERS = new Set(['ollama', 'ooba']);
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export type AiGatewayServiceOptions = BaseFrontendClassOptions;
+
+/** The gateway singleton's public surface — the AiProviderGateway contract. */
+export type AiGatewayServiceInterface = BaseFrontendClassInterface & AiProviderGateway;
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+class AiGatewayService
+  extends BaseFrontendClass<AiGatewayServiceOptions>
+  implements AiGatewayServiceInterface
+{
+  private readonly _gateway: AiProviderGateway;
+
+  constructor(options: AiGatewayServiceOptions) {
+    super(options);
+    this._gateway = this._composeGateway();
+  }
+
+  // ── AiProviderGateway surface ─────────────────────────────────────────
+
+  resolveMode(capability: AiCapability): AiModeResolution {
+    return this._gateway.resolveMode(capability);
+  }
+
+  async detect(capability: AiCapability): Promise<AiDetectionResult> {
+    return this._gateway.detect(capability);
+  }
+
+  async generateText(options: AiTextGenerationOptions): Promise<AiTextGenerationResult> {
+    return this._gateway.generateText(options);
+  }
+
+  async generateImage(options: AiImageGenerationOptions): Promise<AiImageGenerationResult> {
+    return this._gateway.generateImage(options);
+  }
+
+  async generateVoice(options: AiVoiceGenerationOptions): Promise<AiVoiceGenerationResult> {
+    return this._gateway.generateVoice(options);
+  }
+
+  cancelAll(): void {
+    this._gateway.cancelAll();
+  }
+
+  // ── Private: composition ──────────────────────────────────────────────
+
+  /** Builds the gateway core with all client adapters and detectors. */
+  private _composeGateway(): AiProviderGateway {
+    const registry = createAdapterRegistry();
+
+    const textAdapter = createOpenAiCompatibleTextAdapter({
+      getApiKey: (provider) => this._getTextApiKey(provider),
+      supportsStructuredOutput: (provider) =>
+        PROVIDER_MODEL_FETCH[provider]?.chatTestOpenAiCompat ?? false,
+      getDefaultEndpoint: (provider) => this._getDefaultTextEndpoint(provider),
+      onSchemaCacheSize: (size) => {
+        (globalThis as Record<string, unknown>).__text_service_compiled_schema_cache_size = size;
+      },
+      onEvent: (event, data) => this.debug(`textAdapter:${event}`, data),
+    });
+
+    // One transport serves both offline (local) and byok (cloud) text modes.
+    registry.registerText({ mode: 'offline', adapter: textAdapter });
+    registry.registerText({ mode: 'byok', adapter: textAdapter });
+
+    // `service` mode: wraps the existing Firebase callable path so legacy
+    // ai_service behavior is preserved. Selection via resolveMode stays
+    // guarded (mode_unavailable) until Phase 5 activation.
+    registry.registerText({
+      mode: 'service',
+      adapter: createServiceTextAdapter({
+        call: async (data) => {
+          // The gateway's generic callable shape narrows to the typed Firebase
+          // `ai` payload contract at this boundary.
+          const response = await firebaseFunctionsService.call('ai', data as AIMessageData);
+          return response as Record<string, unknown>;
+        },
+      }),
+    });
+
+    registry.registerImage({
+      mode: 'offline',
+      adapter: createDelegatingImageAdapter({
+        generate: (options) => imageGenerationService.generateImage(options),
+      }),
+    });
+
+    registry.registerVoice({
+      mode: 'offline',
+      adapter: createDelegatingVoiceAdapter({
+        synthesize: async (options) => {
+          await ttsService.speak({ text: options.text, voiceId: options.voiceId });
+          return undefined;
+        },
+      }),
+    });
+
+    return createAiProviderGateway({
+      registry,
+      resolveMode: ({ capability, model }) => this._resolveCapability({ capability, model }),
+      detectors: {
+        text: ({ signal }) =>
+          detectTextAvailability({
+            hasCloudConfig: () => this._hasCloudTextConfig(),
+            signal,
+          }),
+        image: ({ signal }) =>
+          detectImageAvailability({
+            hasConfiguredProvider: () => this._hasConfiguredImageProvider(),
+            signal,
+          }),
+        voice: () =>
+          detectVoiceAvailability({
+            getEngineStatus: () => ({
+              status: ttsService.status,
+              serverAvailable: ttsService.isKokoroServerAvailable,
+            }),
+          }),
+      },
+      onDispatch: (resolution) =>
+        this.info('dispatch', {
+          capability: resolution.capability,
+          mode: resolution.mode,
+          provider: resolution.provider,
+        }),
+    });
+  }
+
+  // ── Private: per-capability resolution ────────────────────────────────
+
+  /** Resolves the (mode, provider) for a capability — once per call. */
+  private _resolveCapability(options: {
+    capability: AiCapability;
+    model?: string;
+  }): AiModeResolution {
+    const { capability, model } = options;
+
+    if (capability === 'text') {
+      return this._resolveTextRouting(model);
+    }
+    if (capability === 'image') {
+      return { capability: 'image', mode: 'offline', provider: 'comfyui' };
+    }
+    return { capability: 'voice', mode: 'offline', provider: 'kokoro' };
+  }
+
+  /**
+   * Resolves text routing from ConfigService.
+   * Priority: explicit model param → configService.getActiveTextProvider().
+   * Throws (typed via gateway normalization) if no provider is configured.
+   */
+  private _resolveTextRouting(explicitModel?: string): AiModeResolution {
+    if (explicitModel) {
+      const match = configService.state.models.find((m) => m.model === explicitModel);
+      if (match) {
+        return this._toTextResolution({
+          provider: match.provider,
+          model: match.model,
+          endpoint: match.endpoint || '',
+        });
+      }
+      // Model not found in config — use it verbatim with a provider-agnostic fallback
+      return this._toTextResolution({ provider: 'unknown', model: explicitModel, endpoint: '' });
+    }
+
+    const resolved = configService.getActiveTextProvider();
+    return this._toTextResolution({
+      provider: resolved.provider,
+      model: resolved.model,
+      endpoint: resolved.endpoint,
+    });
+  }
+
+  /** Classifies a text provider into offline (local) vs byok (cloud). */
+  private _toTextResolution(options: {
+    provider: string;
+    model: string;
+    endpoint: string;
+  }): AiModeResolution {
+    const { provider, model, endpoint } = options;
+    return {
+      capability: 'text',
+      mode: LOCAL_TEXT_PROVIDERS.has(provider) ? 'offline' : 'byok',
+      provider,
+      model,
+      endpoint,
+    };
+  }
+
+  // ── Private: config accessors ─────────────────────────────────────────
+
+  /** Reads the API key for the given provider from ConfigService. */
+  private _getTextApiKey(provider: string): string | undefined {
+    const keys = configService.state.text.apiKeys;
+    return keys[provider as keyof typeof keys];
+  }
+
+  /**
+   * Well-known chat base endpoint for cloud providers, derived from the
+   * provider registry's chatTestUrl (strips the /chat/completions suffix).
+   */
+  private _getDefaultTextEndpoint(provider: string): string | undefined {
+    const config = PROVIDER_MODEL_FETCH[provider];
+    if (!config?.chatTestOpenAiCompat || !config.chatTestUrl) {
+      return undefined;
+    }
+    return config.chatTestUrl.replace(/\/chat\/completions$/, '');
+  }
+
+  /** Whether a cloud text provider is configured (key or endpoint+model). */
+  private _hasCloudTextConfig(): boolean {
+    try {
+      const { textProvider } = aiSettingsService;
+      return Boolean(textProvider.apiKey || (textProvider.endpoint && textProvider.model));
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether an image provider is configured via settings. */
+  private _hasConfiguredImageProvider(): boolean {
+    try {
+      const { imageProvider } = aiSettingsService;
+      return Boolean(imageProvider.endpoint || imageProvider.model);
+    } catch {
+      return false;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+export const aiGatewayService: AiGatewayServiceInterface = AiGatewayService.create({
+  className: 'AiGatewayService',
+});

--- a/apps/frontend/client/src/lib/services/ai/ai_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/ai/ai_service.svelte.ts
@@ -1,16 +1,17 @@
+// apps/frontend/client/src/lib/services/ai/ai_service.svelte.ts
+//
+// Legacy AI service — routes sendMessageToAI/createPersona through the
+// AI Provider Gateway's `service`-mode text adapter (which wraps the
+// Firebase `ai` callable), preserving the original public interface and
+// undefined-on-error semantics. Contract: C-320 AC-2/AC-4.
+
 import {
   BaseFrontendClass,
   type BaseFrontendClassInterface,
   type BaseFrontendClassOptions,
-  firebaseFunctionsService,
 } from '@aikami/frontend/services';
-import type {
-  AIMessageData,
-  AIMessageResponse,
-  AIMessageType,
-  NpcData,
-  PersonaData,
-} from '@aikami/types';
+import type { NpcData, PersonaData } from '@aikami/types';
+import { aiGatewayService } from '$lib/services/ai/ai_gateway_service.svelte.ts';
 
 export type AIServiceOptions = BaseFrontendClassOptions;
 
@@ -35,14 +36,15 @@ export class AIService extends BaseFrontendClass<AIServiceOptions> implements AI
   async createPersona(prompt: string): Promise<PersonaData | undefined> {
     this.log('createPersona', { prompt });
     try {
-      const response = await this._callAIEndpoint({
-        type: 'createPersona',
-        payload: {
-          prompt,
-        },
+      // Explicit `service` mode: the gateway dispatches to the adapter
+      // wrapping the hosted callable, bypassing capability resolution.
+      const response = await aiGatewayService.generateText({
+        messages: [{ role: 'user', content: prompt }],
+        schemaName: 'createPersona',
+        mode: 'service',
       });
 
-      return response.persona;
+      return response.structured as PersonaData | undefined;
     } catch (error) {
       this.error('createPersona', error);
     }
@@ -54,26 +56,15 @@ export class AIService extends BaseFrontendClass<AIServiceOptions> implements AI
   ): Promise<string | undefined> {
     this.log('sendMessage', { text, character });
     try {
-      const response = await this._callAIEndpoint({
-        type: 'sendMessage',
-        payload: {
-          text,
-          context: {
-            messages: [],
-          },
-        },
+      const response = await aiGatewayService.generateText({
+        messages: [{ role: 'user', content: text }],
+        mode: 'service',
       });
 
       return response.text;
     } catch (error) {
       this.error('sendMessage', error);
     }
-  }
-
-  private async _callAIEndpoint<T extends AIMessageType>(
-    data: AIMessageData<T>,
-  ): Promise<AIMessageResponse<T>> {
-    return await firebaseFunctionsService.call('ai', data);
   }
 }
 

--- a/apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts
@@ -1,21 +1,21 @@
 // apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts
 //
-// Unified text generation service. Centralises all LLM text-generation
-// workflows — SSE token streaming, history-aware chat, and TypeBox
-// structural extraction — behind a single reactive gateway. Provider
-// routing, model selection, and API keys are resolved dynamically from
-// the central ConfigService.
+// Unified text generation service. Public interface (streamChat,
+// extractStructure, cancelAll) is unchanged — internals delegate to the
+// AI Provider Gateway (C-320). Provider routing, model selection, API keys,
+// SSE streaming, and structured extraction are resolved once at the gateway
+// boundary; no provider/endpoint conditionals remain here.
 //
-// Contract: C-080, C-111
+// Contract: C-080, C-111, C-320
 
+import { isAiGatewayError } from '@aikami/frontend/ai-gateway';
 import {
   BaseFrontendClass,
   type BaseFrontendClassInterface,
   type BaseFrontendClassOptions,
 } from '@aikami/frontend/services';
-import { schemaCheck } from '@aikami/schemas';
-import { configService } from '$lib/services/config/config_service.svelte.ts';
-import { PROVIDER_MODEL_FETCH } from '$lib/services/config/provider_endpoints';
+import type { AiModeResolution } from '@aikami/types';
+import { aiGatewayService } from '$lib/services/ai/ai_gateway_service.svelte.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,13 +28,6 @@ export type ChatMessageRole = 'user' | 'assistant' | 'system';
 export type TextChatMessage = {
   role: ChatMessageRole;
   content: string;
-};
-
-/** Provider routing information exposed via debug hook. */
-type ResolvedRouting = {
-  provider: string;
-  model: string;
-  endpoint: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -83,55 +76,6 @@ export type TextGenerationServiceInterface = BaseFrontendClassInterface & {
 };
 
 // ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/**
- * Resolves the chat completions URL from routing info.
- * Uses the endpoint from ConfigService (single source of truth),
- * falling back to well-known provider defaults.
- * Throws if no URL can be resolved.
- */
-function resolveChatUrl(routing: ResolvedRouting): string {
-  if (routing.endpoint) {
-    const base = routing.endpoint.replace(/\/$/, '');
-    return `${base}/chat/completions`;
-  }
-  // Provider-specific fallbacks for well-known local/cloud providers
-  const defaults: Record<string, string> = {
-    ollama: 'http://localhost:11434/v1',
-    ooba: 'http://localhost:5000/v1',
-  };
-  const base = defaults[routing.provider];
-  if (base) {
-    return `${base}/chat/completions`;
-  }
-  throw new Error(
-    `No endpoint configured for provider "${routing.provider}". ` +
-      'Create a Connection in Settings or configure a provider endpoint.',
-  );
-}
-
-/** Timeout for the entire fetch+stream operation (90 seconds). */
-const FETCH_TIMEOUT_MS = 90_000;
-
-/** Maximum time to wait for the first SSE chunk (15 seconds). */
-const FIRST_CHUNK_TIMEOUT_MS = 15_000;
-
-/**
- * Timeout for individual SSE stream read operations after content has started
- * flowing. Kept short (5s) to prevent the text input from staying disabled
- * when the provider delays the [DONE] signal after the last text chunk.
- */
-const IDLE_TIMEOUT_MS = 5_000;
-
-/** Provider requires these headers for ranking/attribution on free models (OpenRouter). */
-const OPENROUTER_HEADERS = {
-  'HTTP-Referer': 'https://aikami.app',
-  'X-Title': 'Aikami',
-} as const;
-
-// ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
 
@@ -143,47 +87,16 @@ class TextGenerationService
 
   private readonly _abortControllers = new Set<AbortController>();
   private _activeStreamCount = 0;
-  private readonly _compiledSchemaCache = new Map<string, Record<string, unknown>>();
 
-  // ── Private: Provider resolution ──────────────────────────────────────
+  // ── Private: diagnostics globals (legacy debug hooks) ─────────────────
 
-  /**
-   * Resolves the active provider configuration from ConfigService.
-   *
-   * Priority: explicit model param → configService.getActiveTextProvider().
-   * Throws if no provider is configured.
-   */
-  private _resolveProvider(options: { explicitModel?: string }): ResolvedRouting {
-    const { explicitModel } = options;
-    const { state } = configService;
-
-    // Explicit model override — look up its provider from the models array
-    if (explicitModel) {
-      const match = state.models.find((m) => m.model === explicitModel);
-      if (match) {
-        return {
-          provider: match.provider,
-          model: match.model,
-          endpoint: match.endpoint || '',
-        };
-      }
-      // Model not found in config — use it verbatim with a provider-agnostic fallback
-      return { provider: 'unknown', model: explicitModel, endpoint: '' };
-    }
-
-    // Delegate to ConfigService for the active text provider
-    const resolved = configService.getActiveTextProvider();
-
-    return {
-      provider: resolved.provider,
-      model: resolved.model,
-      endpoint: resolved.endpoint,
-    };
-  }
-
-  private _exposeRouting(routing: ResolvedRouting): void {
+  private _exposeRouting(resolution: AiModeResolution): void {
     const g = globalThis as Record<string, unknown>;
-    g.__text_service_resolved_routing = routing;
+    g.__text_service_resolved_routing = {
+      provider: resolution.provider,
+      model: resolution.model ?? '',
+      endpoint: resolution.endpoint ?? '',
+    };
   }
 
   private _incrementStreamCount(): void {
@@ -198,12 +111,28 @@ class TextGenerationService
       this._activeStreamCount;
   }
 
-  // ── Private: API key resolution ───────────────────────────────────────
+  /** Registers a per-call controller linked to the caller's signal. */
+  private _linkController(signal?: AbortSignal): AbortController {
+    const abortController = new AbortController();
+    this._abortControllers.add(abortController);
+    if (signal) {
+      if (signal.aborted) {
+        abortController.abort(signal.reason);
+      } else {
+        signal.addEventListener('abort', () => abortController.abort(signal.reason), {
+          once: true,
+        });
+      }
+    }
+    return abortController;
+  }
 
-  /** Reads the API key for the given provider from ConfigService. */
-  private _getApiKey(provider: string): string | undefined {
-    const keys = configService.state.text.apiKeys;
-    return keys[provider as keyof typeof keys];
+  /** Whether the error represents cancellation (typed or raw AbortError). */
+  private _isCancellation(error: unknown): boolean {
+    if (isAiGatewayError(error)) {
+      return error.code === 'cancelled';
+    }
+    return (error as Error)?.name === 'AbortError';
   }
 
   // ── streamChat ────────────────────────────────────────────────────────
@@ -214,83 +143,26 @@ class TextGenerationService
     signal?: AbortSignal;
     model?: string;
   }): Promise<void> {
-    const { messages, onChunk, signal, model: explicitModel } = options;
+    const { messages, onChunk, signal, model } = options;
 
-    const routing = this._resolveProvider({ explicitModel });
-    this._exposeRouting(routing);
-
-    const apiKey = this._getApiKey(routing.provider);
-
-    const abortController = new AbortController();
-    this._abortControllers.add(abortController);
-
-    if (signal) {
-      if (signal.aborted) {
-        this._abortControllers.delete(abortController);
-        return;
-      }
-      signal.addEventListener('abort', () => abortController.abort(signal.reason), { once: true });
+    if (signal?.aborted) {
+      return;
     }
 
+    const abortController = this._linkController(signal);
     this._incrementStreamCount();
 
     try {
-      const lastMsg = messages[messages.length - 1];
-      const userPrompt = lastMsg?.role === 'user' ? lastMsg.content : '';
-
-      this.info('streamChat:fetching', {
-        provider: routing.provider,
-        model: routing.model,
-        messageCount: messages.length,
-        promptLength: userPrompt.length,
-        hasApiKey: !!apiKey,
-      });
-
-      const timeoutId = setTimeout(
-        () => abortController.abort(new Error('Fetch timed out')),
-        FETCH_TIMEOUT_MS,
-      );
-
-      const body: Record<string, unknown> = {
-        model: routing.model,
-        messages: messages.map((m) => ({ role: m.role, content: m.content })),
-        stream: true,
-      };
-
-      const chatUrl = resolveChatUrl(routing);
-
-      const response = await fetch(chatUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          // biome-ignore lint/style/useNamingConvention: HTTP header field name
-          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-          ...(routing.provider === 'openrouter' ? OPENROUTER_HEADERS : {}),
-        },
-        body: JSON.stringify(body),
-        signal: abortController.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        this.error('streamChat:fetch-failed', { status: response.status, errorText });
-        throw new Error(`Provider HTTP ${response.status}: ${errorText}`);
-      }
-
-      if (!response.body) {
-        throw new Error(`No response body from provider "${routing.provider}"`);
-      }
-
-      await this._readChatSSEStream({
-        body: response.body,
-        signal: abortController.signal,
+      await aiGatewayService.generateText({
+        messages,
         onChunk,
+        model,
+        signal: abortController.signal,
+        onResolve: (resolution) => this._exposeRouting(resolution),
       });
-      this.info('streamChat:complete', { chunkCount: undefined });
+      this.info('streamChat:complete');
     } catch (error: unknown) {
-      if ((error as Error).name === 'AbortError') {
+      if (this._isCancellation(error)) {
         this.debug('streamChat:aborted');
         return;
       }
@@ -312,157 +184,35 @@ class TextGenerationService
     signal?: AbortSignal;
     model?: string;
   }): Promise<unknown> {
-    const { schema, schemaName, prompt, systemPrompt, signal, model: explicitModel } = options;
+    const { schema, schemaName, prompt, systemPrompt, signal, model } = options;
 
-    const routing = this._resolveProvider({ explicitModel });
-    this._exposeRouting(routing);
-
-    const apiKey = this._getApiKey(routing.provider);
-
-    const compiledSchema = this._compileSchemaToJson({ schema, schemaName });
-
-    const abortController = new AbortController();
-    this._abortControllers.add(abortController);
-
-    if (signal) {
-      if (signal.aborted) {
-        this._abortControllers.delete(abortController);
-        throw new Error('Aborted');
-      }
-      signal.addEventListener('abort', () => abortController.abort(signal.reason), { once: true });
+    if (signal?.aborted) {
+      throw new Error('Aborted');
     }
 
+    const abortController = this._linkController(signal);
     this._incrementStreamCount();
 
     try {
       const messages: TextChatMessage[] = [];
-
       if (systemPrompt) {
         messages.push({ role: 'system', content: systemPrompt });
       }
-
-      const schemaInstruction = [
-        'You are a structured data extraction tool.',
-        'Your response MUST be valid JSON that conforms to the following JSON Schema:',
-        '```json',
-        JSON.stringify(compiledSchema, null, 2),
-        '```',
-        'Respond ONLY with the JSON object. No markdown fences, no explanations.',
-        'Do not include any properties not defined in the schema.',
-      ].join('\n');
-
-      messages.push({ role: 'system', content: schemaInstruction });
       messages.push({ role: 'user', content: prompt });
 
-      this.info('extractStructure:fetching', {
-        provider: routing.provider,
-        model: routing.model,
+      const result = await aiGatewayService.generateText({
+        messages,
+        schema,
         schemaName,
-        promptLength: prompt.length,
-        hasApiKey: !!apiKey,
-      });
-
-      const providerSupportsStructuredOutput =
-        PROVIDER_MODEL_FETCH[routing.provider]?.chatTestOpenAiCompat ?? false;
-
-      const body: Record<string, unknown> = {
-        model: routing.model,
-        messages: messages.map((m) => ({ role: m.role, content: m.content })),
-        stream: true,
-      };
-
-      // Only send response_format for providers that support OpenAI-compatible structured output.
-      // Local providers (Ollama, Ooba) ignore it and return plain text.
-      if (providerSupportsStructuredOutput) {
-        body.response_format = {
-          type: 'json_schema',
-          // biome-ignore lint/style/useNamingConvention: OpenAI API contract field name
-          json_schema: {
-            name: schemaName,
-            schema: compiledSchema,
-            strict: true,
-          },
-        };
-      }
-
-      const chatUrl = resolveChatUrl(routing);
-
-      const response = await fetch(chatUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          // biome-ignore lint/style/useNamingConvention: HTTP header field name
-          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-          ...(routing.provider === 'openrouter' ? OPENROUTER_HEADERS : {}),
-        },
-        body: JSON.stringify(body),
+        model,
         signal: abortController.signal,
+        onResolve: (resolution) => this._exposeRouting(resolution),
       });
 
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        this.error('extractStructure:fetch-failed', { status: response.status, errorText });
-
-        // If the provider rejected structured output, fall back to
-        // system-prompt approach via streamChat
-        if (response.status === 400) {
-          this.info('extractStructure:falling-back-to-system-prompt');
-          const accumulated = await this._extractViaSystemPrompt({
-            messages,
-            signal: abortController.signal,
-            model: explicitModel,
-          });
-          const cleaned = this._sanitizeJsonResponse(accumulated);
-          const parsed = JSON.parse(cleaned);
-          this._validateAgainstSchema({ schema, parsed, schemaName });
-          return parsed;
-        }
-
-        throw new Error(`Provider HTTP ${response.status}: ${errorText}`);
-      }
-
-      if (!response.body) {
-        throw new Error(`No response body from provider "${routing.provider}"`);
-      }
-
-      let accumulated = '';
-      await this._readChatSSEStream({
-        body: response.body,
-        signal: abortController.signal,
-        onChunk: (text: string) => {
-          accumulated += text;
-        },
-      });
-
-      try {
-        const cleaned = this._sanitizeJsonResponse(accumulated);
-        const parsed = JSON.parse(cleaned);
-        this._validateAgainstSchema({ schema, parsed, schemaName });
-        this.debug('extractStructure:done', {
-          schemaName,
-          outputLength: accumulated.length,
-        });
-        return parsed;
-      } catch (parseError) {
-        // Provider returned 200 but the output wasn't valid JSON —
-        // likely a provider that doesn't support structured output.
-        // Fall back to system-prompt approach via plain streamChat.
-        this.info('extractStructure:structured-output-failed, falling back to system-prompt', {
-          provider: routing.provider,
-          error: String(parseError),
-        });
-        const fallbackText = await this._extractViaSystemPrompt({
-          messages,
-          signal: abortController.signal,
-          model: explicitModel,
-        });
-        const cleaned = this._sanitizeJsonResponse(fallbackText);
-        const parsed = JSON.parse(cleaned);
-        this._validateAgainstSchema({ schema, parsed, schemaName });
-        return parsed;
-      }
+      this.debug('extractStructure:done', { schemaName });
+      return result.structured;
     } catch (error: unknown) {
-      if ((error as Error).name === 'AbortError') {
+      if (this._isCancellation(error)) {
         this.debug('extractStructure:aborted');
         throw error;
       }
@@ -484,303 +234,6 @@ class TextGenerationService
     this._abortControllers.clear();
     this._activeStreamCount = 0;
     (globalThis as Record<string, unknown>).__text_service_active_stream_count = 0;
-  }
-
-  // ── Private: Chat completions SSE stream reader ─────────────────────
-
-  /**
-   * Reads a chat completions SSE response stream.
-   *
-   * Each line is `data: {"id":"...","choices":[{"delta":{"content":"token"}}]}`.
-   * The stream ends with `data: [DONE]`.
-   */
-  private async _readChatSSEStream(options: {
-    body: ReadableStream<Uint8Array>;
-    signal: AbortSignal;
-    onChunk: (text: string) => void;
-  }): Promise<void> {
-    const { body, signal, onChunk } = options;
-    const reader = body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-    let chunkCount = 0;
-    let isFirstChunk = true;
-    let hasReceivedContent = false;
-
-    try {
-      while (true) {
-        if (signal.aborted) {
-          return;
-        }
-
-        const timeout = isFirstChunk
-          ? FIRST_CHUNK_TIMEOUT_MS
-          : hasReceivedContent
-            ? IDLE_TIMEOUT_MS
-            : FIRST_CHUNK_TIMEOUT_MS;
-        const result = await Promise.race([
-          reader.read(),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('Stream read timed out')), timeout),
-          ),
-        ]);
-        isFirstChunk = false;
-        const { value, done } = result;
-        if (done) {
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (trimmed.length === 0) {
-            continue;
-          }
-
-          // Skip non-data lines
-          if (!trimmed.startsWith('data: ')) {
-            continue;
-          }
-
-          const data = trimmed.slice(6);
-
-          // End of stream signal
-          if (data === '[DONE]') {
-            this.debug('_readChatSSEStream:done', { chunkCount });
-            return;
-          }
-
-          try {
-            const parsed = JSON.parse(data) as {
-              choices?: Array<{
-                delta?: { content?: string };
-                // biome-ignore lint/style/useNamingConvention: OpenAI API contract field name
-                finish_reason?: string | null;
-              }>;
-            };
-
-            const choice = parsed.choices?.[0];
-            if (!choice) {
-              continue;
-            }
-
-            const token = choice.delta?.content;
-            if (token) {
-              hasReceivedContent = true;
-              onChunk(token);
-              chunkCount++;
-            }
-          } catch {
-            // Skip unparseable lines
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  // ── Private: System prompt fallback for extractStructure ──────────────
-
-  /**
-   * Extracts structured data via the system-prompt approach. Used as a
-   * fallback when the provider rejects `response_format: json_schema`.
-   */
-  private async _extractViaSystemPrompt(options: {
-    messages: TextChatMessage[];
-    signal: AbortSignal;
-    model?: string;
-  }): Promise<string> {
-    const { messages, signal, model } = options;
-
-    let accumulated = '';
-    await this.streamChat({
-      messages,
-      signal,
-      model,
-      onChunk: (text: string) => {
-        accumulated += text;
-      },
-    });
-
-    return accumulated;
-  }
-
-  // ── Private: Post-validation ──────────────────────────────────────────
-
-  /**
-   * Validates the parsed output against the original TypeBox schema.
-   * Logs a warning if validation fails but does not throw — the caller
-   * receives whatever the LLM returned.
-   */
-  private _validateAgainstSchema(options: {
-    schema: Record<string, unknown>;
-    parsed: unknown;
-    schemaName: string;
-  }): void {
-    const { schema, parsed, schemaName } = options;
-
-    const isValid = schemaCheck(schema, parsed);
-    if (!isValid) {
-      this.warn('extractStructure:validation-failed', {
-        schemaName,
-        received: typeof parsed,
-      });
-      return;
-    }
-
-    this.debug('extractStructure:validation-passed', { schemaName });
-  }
-
-  // ── Private: Schema compilation ───────────────────────────────────────
-
-  /**
-   * Compiles a TypeBox TSchema into a strict JSON Schema dictionary
-   * with `additionalProperties: false` enforced at every object level.
-   */
-  private _compileSchemaToJson(options: {
-    schema: Record<string, unknown>;
-    schemaName: string;
-  }): Record<string, unknown> {
-    const { schema, schemaName } = options;
-
-    const cached = this._compiledSchemaCache.get(schemaName);
-    if (cached) {
-      (globalThis as Record<string, unknown>).__text_service_compiled_schema_cache_size =
-        this._compiledSchemaCache.size;
-      return cached;
-    }
-
-    const raw = this._enforceStrictSchema(JSON.parse(JSON.stringify(schema)));
-    const compiled = raw as Record<string, unknown>;
-
-    compiled.additionalProperties = false;
-
-    this._compiledSchemaCache.set(schemaName, compiled);
-
-    (globalThis as Record<string, unknown>).__text_service_compiled_schema_cache_size =
-      this._compiledSchemaCache.size;
-
-    return compiled;
-  }
-
-  /**
-   * Recursively enforces `additionalProperties: false` on every object
-   * schema node in the JSON Schema tree.
-   */
-  private _enforceStrictSchema(node: unknown): unknown {
-    if (node === null || typeof node !== 'object') {
-      return node;
-    }
-
-    const obj = node as Record<string, unknown>;
-
-    if (obj.type === 'object' || obj.properties !== undefined) {
-      obj.additionalProperties = false;
-
-      if (obj.properties && typeof obj.properties === 'object') {
-        for (const key of Object.keys(obj.properties as Record<string, unknown>)) {
-          (obj.properties as Record<string, unknown>)[key] = this._enforceStrictSchema(
-            (obj.properties as Record<string, unknown>)[key],
-          );
-        }
-      }
-    }
-
-    if (obj.type === 'array' && obj.items) {
-      if (Array.isArray(obj.items)) {
-        obj.items = (obj.items as unknown[]).map((item) => this._enforceStrictSchema(item));
-      } else {
-        obj.items = this._enforceStrictSchema(obj.items);
-      }
-    }
-
-    for (const combinator of ['allOf', 'anyOf', 'oneOf']) {
-      if (Array.isArray(obj[combinator])) {
-        obj[combinator] = (obj[combinator] as unknown[]).map((item) =>
-          this._enforceStrictSchema(item),
-        );
-      }
-    }
-
-    return obj;
-  }
-
-  /**
-   * Strips markdown fences and extracts the first JSON object from a string
-   * that may contain explanatory text.
-   */
-  private _sanitizeJsonResponse(raw: string): string {
-    let text = raw.trim();
-
-    const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (fenceMatch) {
-      text = fenceMatch[1].trim();
-    }
-
-    const objectStart = text.indexOf('{');
-    const arrayStart = text.indexOf('[');
-
-    let startIndex = objectStart;
-    if (objectStart === -1 || (arrayStart !== -1 && arrayStart < objectStart)) {
-      startIndex = arrayStart;
-    }
-
-    if (startIndex === -1) {
-      throw new Error('No JSON object found in response');
-    }
-
-    text = text.slice(startIndex);
-
-    let depth = 0;
-    const opener = text[0];
-    const closer = opener === '{' ? '}' : ']';
-    let inString = false;
-    let escapeNext = false;
-    let endIndex = -1;
-
-    for (let i = 0; i < text.length; i++) {
-      const ch = text[i];
-
-      if (escapeNext) {
-        escapeNext = false;
-        continue;
-      }
-
-      if (ch === '\\') {
-        escapeNext = true;
-        continue;
-      }
-
-      if (ch === '"') {
-        inString = !inString;
-        continue;
-      }
-
-      if (inString) {
-        continue;
-      }
-
-      if (ch === opener) {
-        depth++;
-      } else if (ch === closer) {
-        depth--;
-        if (depth === 0) {
-          endIndex = i + 1;
-          break;
-        }
-      }
-    }
-
-    if (endIndex === -1) {
-      throw new Error('Unbalanced JSON in response');
-    }
-
-    return text.slice(0, endIndex);
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────

--- a/apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts
@@ -112,19 +112,20 @@ class TextGenerationService
   }
 
   /** Registers a per-call controller linked to the caller's signal. */
-  private _linkController(signal?: AbortSignal): AbortController {
+  private _linkController(signal?: AbortSignal): { controller: AbortController; cleanup: () => void } {
     const abortController = new AbortController();
     this._abortControllers.add(abortController);
+    let cleanup = () => {};
     if (signal) {
       if (signal.aborted) {
         abortController.abort(signal.reason);
       } else {
-        signal.addEventListener('abort', () => abortController.abort(signal.reason), {
-          once: true,
-        });
+        const handler = () => abortController.abort(signal.reason);
+        signal.addEventListener('abort', handler, { once: true });
+        cleanup = () => signal.removeEventListener('abort', handler);
       }
     }
-    return abortController;
+    return { controller: abortController, cleanup };
   }
 
   /** Whether the error represents cancellation (typed or raw AbortError). */
@@ -149,7 +150,7 @@ class TextGenerationService
       return;
     }
 
-    const abortController = this._linkController(signal);
+    const { controller: abortController, cleanup } = this._linkController(signal);
     this._incrementStreamCount();
 
     try {
@@ -169,6 +170,7 @@ class TextGenerationService
       this.error('streamChat:failed', error);
       throw error;
     } finally {
+      cleanup();
       this._abortControllers.delete(abortController);
       this._decrementStreamCount();
     }
@@ -187,10 +189,15 @@ class TextGenerationService
     const { schema, schemaName, prompt, systemPrompt, signal, model } = options;
 
     if (signal?.aborted) {
-      throw new Error('Aborted');
+      const error = new Error('Aborted');
+      error.name = 'AbortError';
+      if (signal.reason !== undefined) {
+        throw signal.reason;
+      }
+      throw error;
     }
 
-    const abortController = this._linkController(signal);
+    const { controller: abortController, cleanup } = this._linkController(signal);
     this._incrementStreamCount();
 
     try {
@@ -219,6 +226,7 @@ class TextGenerationService
       this.error('extractStructure:failed', error);
       throw error;
     } finally {
+      cleanup();
       this._abortControllers.delete(abortController);
       this._decrementStreamCount();
     }

--- a/apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts
+++ b/apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts
@@ -108,7 +108,12 @@ const loadService = async () => {
 
 const setConfigState = async (state: Record<string, unknown>) => {
   const cfg = await import(CONFIG_SVC_PATH);
-  (cfg.configService as Record<string, unknown>).state = state;
+  // Merge an image-state default so sibling test files sharing the
+  // configService singleton (image_generation_service) keep working.
+  (cfg.configService as Record<string, unknown>).state = {
+    image: { checkpoint: '' },
+    ...state,
+  };
 };
 
 /** Builds an OpenRouter SSE chunk: `data: {"choices":[{"delta":{"content":"token"}}]}\n\n` */

--- a/apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts
+++ b/apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts
@@ -31,8 +31,7 @@ let mockConfigState: Record<string, unknown> = {
 // Mock: crypto_vault (config_service depends on this)
 // ---------------------------------------------------------------------------
 
-const CRYPTO_VAULT_PATH =
-  '/home/sonny/Development/Projects/passion/aikami/apps/frontend/client/src/lib/utils/crypto_vault.ts';
+const CRYPTO_VAULT_PATH = '../../utils/crypto_vault.ts';
 
 mock.module(CRYPTO_VAULT_PATH, () => ({
   encrypt: () => Promise.resolve(),
@@ -41,8 +40,7 @@ mock.module(CRYPTO_VAULT_PATH, () => ({
   __esModule: true,
 }));
 
-const CONFIG_SVC_PATH =
-  '/home/sonny/Development/Projects/passion/aikami/apps/frontend/client/src/lib/services/config/config_service.svelte.ts';
+const CONFIG_SVC_PATH = '../config/config_service.svelte.ts';
 
 // ---------------------------------------------------------------------------
 // Mock: global fetch

--- a/apps/frontend/client/src/lib/services/index.ts
+++ b/apps/frontend/client/src/lib/services/index.ts
@@ -23,6 +23,7 @@ export {
   customAgentToConfig,
   runCustomAgent,
 } from './agent/index.ts';
+export * from './ai/ai_gateway_service.svelte.ts';
 export * from './ai/ai_service.svelte.ts';
 export * from './ai/sentence_boundary_chunker';
 export * from './ai/stream_orchestrator_service.svelte.ts';

--- a/apps/frontend/client/svelte.config.js
+++ b/apps/frontend/client/svelte.config.js
@@ -73,6 +73,8 @@ const config = {
 
       '@aikami/frontend/configs': toPackagesPath('frontend/configs/src'),
       '@aikami/frontend/configs/*': toPackagesPath('frontend/configs/src/lib'),
+      '@aikami/frontend/ai-gateway': toPackagesPath('frontend/ai-gateway/src'),
+      '@aikami/frontend/ai-gateway/*': toPackagesPath('frontend/ai-gateway/src/lib/*'),
       '@aikami/frontend/engine': toPackagesPath('frontend/engine/src'),
       '@aikami/frontend/engine/*': toPackagesPath('frontend/engine/src/*'),
       '@aikami/frontend/svelte-kit': toPackagesPath('frontend/svelte-kit/src'),

--- a/apps/frontend/client/tsconfig.test.json
+++ b/apps/frontend/client/tsconfig.test.json
@@ -18,6 +18,11 @@
         "../../../packages/frontend/services/src/*"
       ],
       "@aikami/frontend/utils": ["../../../packages/frontend/utils/src/index.ts"],
+      "@aikami/frontend/ai-gateway": ["../../../packages/frontend/ai-gateway/src/index.ts"],
+      "@aikami/frontend/ai-gateway/*": [
+        "../../../packages/frontend/ai-gateway/src/lib/*",
+        "../../../packages/frontend/ai-gateway/src/*"
+      ],
       "@aikami/frontend/utils/*": [
         "../../../packages/frontend/utils/src/lib/*",
         "../../../packages/frontend/utils/src/*"

--- a/docs/contracts/C-320-build-the-unified-ai-provider-gateway-offline-byok-service.md
+++ b/docs/contracts/C-320-build-the-unified-ai-provider-gateway-offline-byok-service.md
@@ -8,7 +8,7 @@
 | **Target** | New `packages/frontend/ai-gateway` package (moon id `frontend-ai-gateway`) + shared types/schemas — one `AiProviderGateway` call surface for text/image/voice across `offline` / `byok` / `service` modes |
 | **Priority** | P0 — every AI-dependent contract in the backlog (C-318, C-322, C-323, C-324, C-328, C-330, C-348…) needs one call surface that does not care whether it runs against a local model, a user's cloud key, or Aikami's hosted service |
 | **Dependencies** | C-056 (completed — hybrid text gateway logic in `packages/backend/ai` to absorb), C-133 (completed — flexible provider onboarding), C-134 (completed — inline provider setup), C-230 (completed — Connection abstraction in `config_service`), packages: `@aikami/schemas`, `@aikami/types`, `@aikami/backend/ai` |
-| **Status** | in_progress |
+| **Status** | implemented |
 | **Promotion** | — |
 | **Docs Impact** | internal → none (developer-facing gateway; player-facing surfaces are C-318/C-322) |
 | **Contract version** | 2.0.0 |
@@ -301,3 +301,70 @@ Changes to ACs or scope require a version bump and user approval.
 > 📋 Status rules: see [SHARED_SECTIONS.md](SHARED_SECTIONS.md#status-lifecycle)
 
 ---
+
+## Execution Report
+
+### Summary
+Built the unified AI Provider Gateway — a typed, mode-resolving dispatch layer for text/image/voice across `offline`/`byok`/`service` modes. Created `packages/frontend/ai-gateway` (new moon project `frontend-ai-gateway`), added shared gateway schemas/types to `packages/shared/`, migrated the client's `text_generation_service` and `ai_service` onto the gateway behind unchanged public interfaces, and relocated provider-ping logic into the gateway detection API. All gateway tests pass; client test suite shows zero new failures vs baseline (360 pass / 50 pre-existing env failures).
+
+### AC Status
+| AC | Status | Notes |
+|---|---|---|
+| AC-1 | ✅ | 21 TypeBox schema tests pass; types derived via `Static<>` exported from `@aikami/schemas` and `@aikami/types` barrels; no gateway type defined in `apps/**` or the gateway package. |
+| AC-2 | ✅ | All 20 text_generation_service tests pass (up from 4 at baseline in main repo); streaming order, timeouts, abort propagation to upstream fetch, structured extraction + fallback, VRAM eviction params, OpenRouter headers preserved. ai_service routes through gateway `service`-mode adapter. Grep-verified: no provider/endpoint conditionals at call sites; resolution happens once via `onResolve` hook. |
+| AC-3 | ✅ | Image adapter delegates to `imageGenerationService` unchanged; voice adapter delegates to `ttsService.speak` (engine selection preserved inside tts_service). Both honor `AbortSignal` and normalize failures to `AiGatewayError`. Existing image_generation_service suite (20/20) green. |
+| AC-4 | ✅ | Shared adapter-contract suite runs against every registered adapter family (offline/byok text, service stub, image, voice) with synthetic SSE streams; all failures surface as `AiGatewayException`. `resolveMode` throws `mode_unavailable` when `serviceActivated` is false; explicit `service` dispatch with no registered adapter also throws `mode_unavailable`. |
+| AC-5 | ✅ | Detection parity tests: text (cloud config → configured; proxy → native fallback under one shared deadline; not_found within 3s), image (config → configured; ComfyUI ping → detected), voice (real engine status, optimistic-convertible). `toDetectionStatus` converts results to the existing `DetectionStatus` union. Hanging detectors time out within budget; throwing detectors yield unavailable results, never crashes; checks run independently. |
+
+### Files Created
+| File | Purpose |
+|---|---|
+| `packages/shared/schemas/src/lib/ai_gateway.ts` | TypeBox schemas: AiMode, AiCapability, AiGatewayErrorCode, AiGatewayError, AiModeResolution, AiDetectionResult, AiChatMessage, AiGatewayModeConfig |
+| `packages/shared/schemas/tests/ai_gateway.test.ts` | AC-1 schema validation tests (21 cases) |
+| `packages/shared/types/src/lib/ai_gateway.ts` | `Static<>`-derived types from gateway schemas |
+| `packages/frontend/ai-gateway/` (moon.yml, package.json, tsconfig.json, README.md) | New moon project `frontend-ai-gateway`, alias `@aikami/frontend/ai-gateway` |
+| `packages/frontend/ai-gateway/src/lib/gateway.ts` | Default AiProviderGateway (dispatch, cancelAll, bounded detect, error normalization) |
+| `packages/frontend/ai-gateway/src/lib/gateway_types.ts` | Call surface + adapter contracts (`AiTextAdapter`, `AiImageAdapter`, `AiVoiceAdapter`) |
+| `packages/frontend/ai-gateway/src/lib/adapter_registry.ts` | (capability, mode) adapter registry |
+| `packages/frontend/ai-gateway/src/lib/mode_resolver.ts` | Config-backed mode resolution with service guard |
+| `packages/frontend/ai-gateway/src/lib/errors.ts` | `AiGatewayException` + normalization (`toAiGatewayError`, HTTP-status mapping, retryability) |
+| `packages/frontend/ai-gateway/src/lib/sse.ts` | Chat-completions SSE reader (relocated; first-chunk/idle timeouts) |
+| `packages/frontend/ai-gateway/src/lib/structured.ts` | Strict-schema compilation w/ caching, JSON sanitization, TypeBox validation |
+| `packages/frontend/ai-gateway/src/lib/text_adapter_openai_compatible.ts` | offline + byok text transport (relocated from text_generation_service) |
+| `packages/frontend/ai-gateway/src/lib/text_adapter_service.ts` | service-mode adapter over hosted callable + deterministic stub |
+| `packages/frontend/ai-gateway/src/lib/image_adapter.ts` | Delegating image adapter + `raceWithAbort` |
+| `packages/frontend/ai-gateway/src/lib/voice_adapter.ts` | Delegating voice adapter |
+| `packages/frontend/ai-gateway/src/lib/detection.ts` | Detection API (Ollama proxy/native, ComfyUI, Kokoro) + `toDetectionStatus` |
+| `packages/frontend/ai-gateway/tests/{helpers,adapter_contract.test,text_adapters.test,image_voice_adapters.test,detection.test}.ts` | 56 tests incl. synthetic SSE mocks and mixed-mode fixture |
+| `apps/frontend/client/src/lib/services/ai/ai_gateway_service.svelte.ts` | Client gateway singleton (BaseFrontendClass) — composes core with client adapters/detectors, exposed via `$services` |
+
+### Files Modified
+| File | Change |
+|---|---|
+| `packages/shared/schemas/src/index.ts` | Export `./lib/ai_gateway.ts` |
+| `packages/shared/types/src/index.ts` | Export `./lib/ai_gateway.ts` |
+| `.moon/workspace.yml` | Registered `frontend-ai-gateway` |
+| `apps/frontend/client/svelte.config.js` | Added `@aikami/frontend/ai-gateway` aliases |
+| `apps/frontend/client/tsconfig.test.json` | Added gateway paths for bun test |
+| `apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts` | Thin gateway consumer; public interface (`streamChat`/`extractStructure`/`cancelAll`) and diagnostics globals preserved; provider internals removed (667 lines → delegation) |
+| `apps/frontend/client/src/lib/services/ai/ai_service.svelte.ts` | Routes `sendMessageToAI`/`createPersona` through gateway service-mode adapter; undefined-on-error preserved |
+| `apps/frontend/client/src/lib/services/index.ts` | Barrel export for `ai_gateway_service` |
+| `apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts` | Fixed hardcoded main-repo absolute mock paths → relative (tests now run in worktrees); merged image-state default to prevent cross-file singleton pollution |
+
+### Deviations from Spec
+1. **Cloud endpoint defaults restored**: current `resolveChatUrl` had lost well-known cloud chat endpoints (openai/openrouter/deepseek), which is why 16/20 C-080 tests failed at baseline even in the main repo. The gateway adapter injects defaults from the existing `PROVIDER_MODEL_FETCH` registry (`chatTestUrl`), restoring the C-080-specified behavior. No Amendment needed — AC-2 explicitly requires these suites to pass.
+2. **`OLLAMA_VRAM_EVICTION_PARAMS` duplicated** in the gateway package (contract watch point explicitly allows this) because `@aikami/backend/ai` is not aliased in the client build. Moving it to `@aikami/constants` is noted as preferred future work (out of scope).
+3. **`generateVoice` result `audio` is optional**: the existing Kokoro path (`ttsService.speak`) plays audio through the client pipeline and never exposes raw buffers; forcing a required `audio` field would have required re-implementing engine selection (forbidden by AC-3 watch point). Adapters that do produce raw audio return it.
+4. **Explicit `mode` override on `generateText`**: `ai_service` must keep calling the Firebase callable (current behavior) while `service` mode remains un-activated for resolution. The gateway therefore accepts an explicit `mode` override that dispatches to a registered adapter directly; `resolveMode` selection of `service` stays guarded with `mode_unavailable` (AC-4 tests cover both paths).
+5. **Baseline test environment**: the worktree had no `node_modules` (ran `bun install`) and lacked generated paraglide i18n files (copied from main repo; gitignored). Client baseline recorded after install: 279 pass / 101 fail (pre-existing, mostly env/mock issues). Post-implementation: 360 pass / 50 fail, zero new failures.
+
+### Test Results
+- Unit (schemas): 21/21 (0 failures)
+- Unit (frontend-ai-gateway): 56/56 (0 failures)
+- Unit (client): 360 pass / 50 fail — 0 new failures vs baseline (101 → 50; 16 text_generation_service failures eliminated)
+- Typecheck: schemas ✅, types ✅, frontend-ai-gateway ✅, client ✅ (0 errors, 1 pre-existing warning)
+- Build: client:build ✅
+- Dev-server smoke: vite dev serves 200, no errors in log
+- Visual: N/A — headless service layer
+- E2E: N/A per Evidence Matrix (C-322/C-318 own detection UX surfaces)
+- Live-Ollama integration check: not executed in pipeline environment (no herdr); adapter paths covered by unit suites — verifier may exercise with a running Ollama.

--- a/docs/contracts/C-320-build-the-unified-ai-provider-gateway-offline-byok-service.md
+++ b/docs/contracts/C-320-build-the-unified-ai-provider-gateway-offline-byok-service.md
@@ -1,0 +1,303 @@
+# Contract C-320: Build the Unified AI Provider Gateway (Offline / BYOK / Service)
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Source** | `docs/TODO.md` § C-320 — Phase 1 — Playable, Polished, Offline-Capable Vertical Slice |
+| **Target** | New `packages/frontend/ai-gateway` package (moon id `frontend-ai-gateway`) + shared types/schemas — one `AiProviderGateway` call surface for text/image/voice across `offline` / `byok` / `service` modes |
+| **Priority** | P0 — every AI-dependent contract in the backlog (C-318, C-322, C-323, C-324, C-328, C-330, C-348…) needs one call surface that does not care whether it runs against a local model, a user's cloud key, or Aikami's hosted service |
+| **Dependencies** | C-056 (completed — hybrid text gateway logic in `packages/backend/ai` to absorb), C-133 (completed — flexible provider onboarding), C-134 (completed — inline provider setup), C-230 (completed — Connection abstraction in `config_service`), packages: `@aikami/schemas`, `@aikami/types`, `@aikami/backend/ai` |
+| **Status** | in_progress |
+| **Promotion** | — |
+| **Docs Impact** | internal → none (developer-facing gateway; player-facing surfaces are C-318/C-322) |
+| **Contract version** | 2.0.0 |
+
+## Problem & Baseline Evidence
+
+- **Current behavior**: AI calls are split across at least four independent surfaces, each with its own routing, streaming, error, and detection logic:
+  1. `apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts` — client SSE streaming + TypeBox structured extraction, resolves provider/model/key from `configService`, hand-rolls endpoint fallbacks (`resolveChatUrl`), timeouts (`FETCH_TIMEOUT_MS`, `FIRST_CHUNK_TIMEOUT_MS`), and abort handling.
+  2. `apps/frontend/client/src/lib/services/ai/ai_service.svelte.ts` — a completely separate path that calls the Firebase callable `ai` function (`firebaseFunctionsService.call('ai', …)`), i.e. an implicit "service" mode with no shared interface.
+  3. `packages/backend/ai` — the C-056 hybrid text gateway (`routeTextGeneration`, `createOllamaStream`, `createOpenRouterStream`, `OpenAiService`, `GeminiService`, `CircuitBreaker`, `SyntheticSseMock`) consumed only by `apps/backend/firebase/src/controllers/callable/ai.ts` and `.../api/prompt_ai.ts` via `handleAIEndpoint`.
+  4. `apps/frontend/client/src/lib/services/capability/capability_service.svelte.ts` — standalone `_pingOllama()` + `checkCloudTextConfig()` detection that duplicates provider knowledge.
+  Image (`image_generation_service.svelte.ts` → ComfyUI REST) and voice (`tts_service.svelte.ts` → Kokoro WebGPU/REST) each have their own ad hoc availability checks and no common mode concept. No code expresses the product's three-mode vision (`offline` / `byok` / `service`); "which provider handles this call" is re-decided ad hoc at every call site.
+- **Reproduction**: grep `fetch(` + provider URLs across `apps/frontend/client/src/lib/services/{ai,capability,image,audio}` — four unrelated resolution paths for "call an AI". Compare `text_generation_service.streamChat()` (direct provider SSE) vs `ai_service.sendMessageToAI()` (Firebase callable): same product intent, disjoint interfaces, disjoint error shapes.
+- **Existing implementation to reuse**:
+  - `packages/backend/ai/src/lib/{text_generation_router,ollama_adapter,openrouter_adapter,openai_service,gemini_service,circuit_breaker,rate_limiter,synthetic_sse_mock,errors}.ts` (C-056; fetch-based, environment-agnostic).
+  - `apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts` (SSE parsing, structured extraction, first-chunk timeout, `cancelAll()`).
+  - `apps/frontend/client/src/lib/services/image/image_generation_service.svelte.ts` + `packages/backend/image` (`ImageGenerationOrchestrator`, `ComfyUIRestClient`).
+  - `apps/frontend/client/src/lib/services/audio/tts_service.svelte.ts` (Kokoro WebGPU + REST detection).
+  - `apps/frontend/client/src/lib/services/capability/capability_service.svelte.ts` (`_pingOllama()` proxy/native fallback, timeout discipline).
+  - `apps/frontend/client/src/lib/utils/crypto_vault.ts` (AES-GCM key storage) and `config_service.svelte.ts` Connections (C-230).
+- **Known gaps**: no `AiMode`/`AiCapability` types anywhere; no unified error shape (client throws raw `Error`, backend has `AiServiceError`); no per-capability mode resolution; `service` mode exists only implicitly as the Firebase callable; detection logic is not exposed as a reusable API; retry/cancellation semantics differ per surface.
+- **Baseline tests** (run before starting):
+  - `apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts`
+  - `apps/frontend/client/src/lib/services/ai/stream_orchestrator_service.test.ts`
+  - `apps/frontend/client/src/lib/services/capability/capability_service.test.ts`
+  - `apps/frontend/client/src/lib/services/config/config_service.test.ts`
+  - `packages/backend/ai/tests/ai_service.test.ts`
+  - `packages/backend/image/tests/{orchestrator,rest_client}.test.ts`
+  - `apps/frontend/client/src/lib/services/audio/tts_service.test.ts`
+
+## User Outcome
+
+After this contract, a **developer** can call `aiProviderGateway.generateText()` / `generateImage()` / `generateVoice()` from any client feature without knowing or re-checking which provider serves it; mode (`offline` / `byok` / `service`) is resolved once per capability at the gateway boundary. A **player** experiences identical streaming/cancellation behavior as today (no regression), and gains a consistent, typed failure surface that later contracts (C-318 capability UX, C-323 AI gate, C-328 dialogue fallbacks) build on.
+
+## Success Measures
+
+- **Time/latency target**: zero added latency vs. current direct calls — gateway resolution is synchronous in-memory dispatch; existing streaming timeouts preserved (90s fetch, 15s first chunk); local detection pings bounded at ≤3s (current `PING_TIMEOUT_MS`).
+- **Offline/degraded behavior**: `offline` mode works with zero network (Ollama/ComfyUI/Kokoro on localhost); a failed call surfaces a typed `AiGatewayError` with `mode`, `capability`, and `reason` so callers can apply authored fallbacks (C-328) — never a silent hang.
+- **Production journey enabled**: single provider surface that C-318/C-322 wire into capability setup and settings, and that C-323 gates campaign creation on. Prevents a second migration when the Phase 5 hosted `service` mode activates.
+
+## Existing System & Reuse Map
+
+| Capability | Existing source | Reuse / modify / replace |
+|---|---|---|
+| Engine-level AI client interface (game-loop) | `packages/shared/types/src/lib/ai/frontend_ai_interface.ts` (`FrontendAiInterface`) + implementations (`OllamaClient`, `OpenAiClient`, `GeminiClient`, `ComfyUiClient`, `LocalTtsClient`, `MockAiClient`) in `apps/frontend/client/src/lib/services/ai/clients/` | note — this contract builds a **service-layer** gateway, not an engine-level interface. `FrontendAiInterface` is game-domain-specific (`generateDialogue`, `generateStructured`); `AiProviderGateway` is app-service-generic (`generateText`, `generateImage`, `generateVoice`, `detect`). They serve different consumers and the gateway wraps service code paths (`text_generation_service`, `ai_service`), not engine client implementations. No conflict, but implementers must be aware both exist. |
+| Text SSE streaming + structured extraction (client) | `apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts` | modify — becomes a thin consumer of the gateway; its SSE/extraction internals move into the gateway's text adapters |
+| Text provider routing + adapters (server) | `packages/backend/ai/src/lib/{text_generation_router,ollama_adapter,openrouter_adapter,openai_service,gemini_service}.ts` | reuse — wrapped by gateway adapters, not rewritten |
+| Circuit breaker / rate limiter / SSE mock | `packages/backend/ai/src/lib/{circuit_breaker,rate_limiter,synthetic_sse_mock}.ts` | reuse — gateway retry policy and test doubles |
+| Firebase callable AI path | `apps/frontend/client/src/lib/services/ai/ai_service.svelte.ts` + `apps/backend/firebase/src/controllers/callable/ai.ts` | modify (client) — `ai_service` routes through the gateway `service` adapter; backend controller migration is C-324 |
+| Image generation (ComfyUI) | `apps/frontend/client/src/lib/services/image/image_generation_service.svelte.ts`, `packages/backend/image` (`ImageGenerationOrchestrator`, `ComfyUIRestClient`) | reuse — gateway `generateImage()` delegates to the existing client service/orchestrator |
+| Voice synthesis (Kokoro WebGPU/REST) | `apps/frontend/client/src/lib/services/audio/tts_service.svelte.ts` | reuse — gateway `generateVoice()` delegates to `ttsService.synthesize` path |
+| Provider detection (Ollama ping, cloud config check) | `apps/frontend/client/src/lib/services/capability/capability_service.svelte.ts` (`_pingOllama`, `checkCloudTextConfig`, `detectImage`) | modify — ping/config-check logic moves into gateway detection API; `capability_service` consumer swap is C-322 |
+| Key storage | `apps/frontend/client/src/lib/utils/crypto_vault.ts` | reuse — byok adapters read keys via existing config/vault path; no new storage |
+| Connection model (per-scope provider selection) | `config_service.svelte.ts` + `$types/connection` (C-230) | reuse — gateway resolves byok config from Connections; UX layer stays separate |
+| Capability shapes | `packages/shared/schemas/src/lib/capability.ts`, `.../game/campaign.ts` (`CapabilitySnapshot`, `CapabilityProfile`) | reuse — unchanged; gateway detection results are convertible to `DetectionStatus` |
+
+## Overview
+
+Build one `AiProviderGateway` — a typed, mode-resolving dispatch layer for the three AI capabilities (`text`, `image`, `voice`). Each capability independently resolves to exactly one of three adapter families: `offline` (Ollama / ComfyUI / Kokoro), `byok` (OpenRouter / OpenAI / Gemini / custom OpenAI-compatible, keys from the existing vault), or `service` (Aikami-hosted; interface + stub only in this contract). Existing, working provider code is wrapped, not rewritten. Client text call sites (`text_generation_service`, `ai_service`) migrate to the gateway; streaming (SSE), cancellation (`AbortSignal`), retry, and error shape become uniform across capabilities and modes.
+
+## Design Reference
+
+- `packages/backend/ai` (C-056) — adapter quality bar: dependency-injectable adapter functions, `SyntheticSseMock` for deterministic streaming tests, `AiServiceError` typed errors, `OLLAMA_VRAM_EVICTION_PARAMS`.
+- `apps/frontend/client/src/lib/services/ai/text_generation_service.svelte.ts` — SSE parsing, first-chunk timeout, `cancelAll()` abort registry, structured extraction with TypeBox `schemaCheck`.
+- `packages/frontend/services` (`BaseFrontendClass` + singleton `create()` pattern) — the client-facing gateway service follows this exactly.
+- Schema-first typing: `packages/shared/schemas/src/lib/capability.ts` → `packages/shared/types/src/lib/capability.ts` (`Static<typeof Schema>` derivation) — new gateway schemas follow this pattern.
+- C-230 Connection abstraction (`config_service.svelte.ts`) — UX precedent for per-scope provider selection, deliberately kept **above** this lower-level gateway.
+- `.pi/skills/new-project/SKILL.md` — scaffold for the new `packages/frontend/ai-gateway` moon project.
+
+> 📋 Testing conventions: see [SHARED_SECTIONS.md](SHARED_SECTIONS.md#testing-conventions)
+
+## Architecture Directives
+
+1. **Shared contract types** — `packages/shared/schemas/src/lib/ai_gateway.ts` (TypeBox) + `packages/shared/types/src/lib/ai_gateway.ts` (`Static<>`-derived): `AiMode`, `AiCapability`, `AiGatewayErrorCode`, request/response/config shapes. Exported from each package's `src/index.ts` barrel.
+2. **Gateway package** — new `packages/frontend/ai-gateway` (moon id `frontend-ai-gateway`, import alias `@aikami/frontend/ai-gateway`, consistent with the `@aikami/frontend/<name>` slash pattern). 🔴 After scaffolding, register the alias in `apps/frontend/client/svelte.config.js` (add `@aikami/frontend/ai-gateway` → `toPackagesPath('frontend/ai-gateway/src')` and the `/*` variant) so the client can resolve imports from the new package. Contains:
+   - `AiProviderGateway` type (the call surface) and its default implementation.
+   - Mode resolution: one `AiModeResolution` per capability, computed once from provided config (not re-checked per call site).
+   - Adapter contract (`AiTextAdapter`, `AiImageAdapter`, `AiVoiceAdapter` — `type` aliases) + registry keyed by `(capability, mode)`.
+   - Cross-cutting policy: retry (reuse `CircuitBreaker`/`TokenBucketRateLimiter` semantics from `@aikami/backend/ai` where environment-agnostic), cancellation propagation, error normalization to `AiGatewayError`.
+   - Detection API: `detect(capability)` returning availability info (wraps today's Ollama proxy/native ping, ComfyUI `object_info` ping, Kokoro checks, cloud config presence check) with bounded timeouts.
+   - `service` mode: adapter that conforms to the contract; text `service` adapter may delegate to the existing Firebase callable path; plus a deterministic stub/mock implementation for tests. No billing/metering.
+3. **Client integration** — `apps/frontend/client`:
+   - `text_generation_service.svelte.ts` keeps its public interface (`streamChat`, `extractStructure`, `cancelAll`) but delegates to the gateway; its provider-specific internals move into gateway text adapters (`offline` = Ollama/local OpenAI-compatible endpoints, `byok` = cloud endpoints with vault keys).
+   - `ai_service.svelte.ts` routes `sendMessageToAI`/`createPersona` through the gateway (`service`-mode text adapter wrapping the existing callable), preserving current behavior.
+   - Gateway singleton exposed via the `$services` barrel per svelte-conventions.
+4. **Server mirror** — the gateway core (types, adapter contract, error shape) must be importable server-side; `packages/backend/ai` remains the server adapter source. Migrating `apps/backend/firebase/src/controllers/{callable/ai.ts,api/prompt_ai.ts}` onto the gateway is **C-324**, not this contract — but nothing in the gateway core may depend on browser globals except inside client-only adapters.
+5. **Boundaries respected** — no types/schemas/constants defined in `apps/**` (Pillar 2); no `+server.ts` (Pillar 1); snake_case files; `type` aliases only; `ClassName.create()` for services.
+
+## State & Data Models
+
+TypeBox schemas in `packages/shared/schemas/src/lib/ai_gateway.ts`; types derived via `Static<>` in `packages/shared/types/src/lib/ai_gateway.ts`. Conceptual shapes:
+
+```typescript
+/** Which adapter family serves a capability. */
+type AiMode = 'offline' | 'byok' | 'service';
+
+/** The three AI capabilities behind the gateway. */
+type AiCapability = 'text' | 'image' | 'voice';
+
+/** Normalized gateway error codes across all modes/capabilities. */
+type AiGatewayErrorCode =
+	| 'provider_unreachable'
+	| 'not_configured'
+	| 'auth_failed'
+	| 'rate_limited'
+	| 'cancelled'
+	| 'timeout'
+	| 'invalid_response'
+	| 'mode_unavailable'; // e.g. selecting 'service' before Phase 5 activation
+
+/** Typed error surfaced by every gateway call. */
+type AiGatewayError = {
+	code: AiGatewayErrorCode;
+	capability: AiCapability;
+	mode: AiMode;
+	provider?: string;
+	message: string;
+	retryable: boolean;
+};
+
+/** Per-capability resolved routing, computed once at the gateway boundary. */
+type AiModeResolution = {
+	capability: AiCapability;
+	mode: AiMode;
+	provider: string; // 'ollama' | 'openrouter' | 'openai' | 'gemini' | 'openai_compatible' | 'comfyui' | 'kokoro' | 'aikami_service'
+	endpoint?: string;
+	model?: string;
+};
+
+/** Detection result per capability (convertible to existing DetectionStatus). */
+type AiDetectionResult = {
+	capability: AiCapability;
+	available: boolean;
+	mode?: AiMode;
+	provider?: string;
+	detail?: string;
+	checkedAt: string; // ISO timestamp
+};
+
+/** The single call surface. Streaming via onChunk; cancellation via AbortSignal. */
+type AiProviderGateway = {
+	resolveMode(capability: AiCapability): AiModeResolution;
+	detect(capability: AiCapability): Promise<AiDetectionResult>;
+	generateText(options: {
+		messages: { role: 'user' | 'assistant' | 'system'; content: string }[];
+		onChunk?: (text: string) => void;
+		schema?: Record<string, unknown>; // structured extraction path
+		schemaName?: string;
+		model?: string;
+		signal?: AbortSignal;
+	}): Promise<{ text: string; structured?: unknown }>;
+	generateImage(options: {
+		prompt: string;
+		checkpoint?: string;
+		signal?: AbortSignal;
+	}): Promise<{ url: string }>;
+	generateVoice(options: {
+		text: string;
+		voiceId?: string;
+		signal?: AbortSignal;
+	}): Promise<{ audio: ArrayBuffer | ReadableStream<Uint8Array> }>;
+	cancelAll(): void;
+};
+```
+
+Existing shapes reused unchanged: `CapabilitySnapshot`, `DetectionStatus` (`packages/shared/schemas/src/lib/capability.ts`), `CapabilityProfile` (`.../game/campaign.ts`), `Connection` (`$types/connection`). No persisted shape changes.
+
+## Quality Requirements
+
+- **Offline/degraded mode**: `offline` adapters work with zero network beyond localhost; unreachable providers fail fast (≤3s detection, 15s first-chunk / 90s total streaming timeouts) with typed `AiGatewayError` — never hang, never silently degrade to a different mode without the resolution saying so.
+- **Accessibility/input**: N/A — headless service layer; UI surfaces are C-318/C-322.
+- **Performance budget**: mode resolution is synchronous in-memory (<1ms); no extra network hops vs. today; Ollama calls preserve `OLLAMA_VRAM_EVICTION_PARAMS` (`keep_alive: 0`, `num_parallel: 1`) from C-056 to avoid VRAM deadlocks with image generation.
+- **Security/privacy**: byok keys read via existing `crypto_vault`/`config_service` path only; keys never appear in logs, error messages, or `AiGatewayError.detail`; no new key storage introduced.
+- **Persistence/migration**: N/A for gateway state (in-memory); provider config continues to live where it lives today (vault/localStorage via `config_service`).
+- **Cancellation/retry/idempotency**: every `generate*` accepts `AbortSignal` and propagates it to the upstream fetch (client disconnect must abort the provider stream — C-056 VRAM lesson); `cancelAll()` aborts all in-flight calls; retry policy is per-adapter and never retries after `cancelled`; detection calls are idempotent.
+- **Observability**: gateway is a `BaseFrontendClass` subclass on the client (auto-logged public methods via `create()`); each call logs resolved `(capability, mode, provider)` once at dispatch; errors logged with code but with secrets redacted.
+
+## Migration & Rollback
+
+N/A — no persistent state changes. Provider configuration, vault format, and capability profile schemas are unchanged. Code-level rollback: call sites keep their existing public interfaces (`streamChat`, `extractStructure`, `sendMessageToAI`, `generateImage`, `synthesize`), so reverting the gateway wiring is a localized import change; no data migration in either direction.
+
+## Scope Boundaries
+
+- **In Scope:**
+  - `AiMode`, `AiCapability`, `AiGatewayError`, resolution/detection/request/response schemas in `packages/shared/schemas` + derived types in `packages/shared/types`.
+  - New `packages/frontend/ai-gateway` package: gateway core, adapter registry, retry/cancellation/error normalization, detection API.
+  - `offline` + `byok` adapters for **text** (wrapping existing Ollama/OpenRouter/OpenAI/Gemini/custom OpenAI-compatible logic), and `offline` adapters for **image** (ComfyUI via existing client service/orchestrator) and **voice** (Kokoro); `byok` image/voice adapters only insofar as existing cloud config already supports them (wrap, don't invent new providers).
+  - `service` mode: interface conformance, hidden/disabled selection guard (`mode_unavailable`), deterministic stub for tests; text `service` adapter may wrap the existing Firebase callable to preserve `ai_service` behavior.
+  - Migrating client call sites `text_generation_service.svelte.ts` and `ai_service.svelte.ts` onto the gateway behind their existing public interfaces.
+  - Moving Ollama-ping / cloud-config-check / ComfyUI-ping logic into the gateway detection API (logic relocation only).
+- **Out of Scope:**
+  - Migrating `capability_service.svelte.ts`, `config_service.svelte.ts`, `providers_view_model.svelte.ts` consumers onto gateway detection — **C-322**.
+  - The mandatory text-AI product gate and removal of the zero-AI campaign path — **C-323**.
+  - Migrating `apps/backend/firebase/src/controllers/{callable/ai.ts,api/prompt_ai.ts}` and deleting/folding `packages/backend/ai` — **C-324**.
+  - `service`-mode billing, metering, quotas, hosted activation — Phase 5 contract.
+  - Capability setup UI / guided connection flow — **C-318**.
+  - Any new cloud provider integrations not already present in the codebase.
+  - Local model lifecycle management (download, warmup) — **C-356**.
+
+## Contract Size & Split Rule
+
+> 📋 Split rules: see [SHARED_SECTIONS.md](SHARED_SECTIONS.md#contract-size--split-rule)
+
+**For this contract:** 5 ACs, 4 projects touched (`schemas`, `types`, new `frontend-ai-gateway`, `client`). This is at the upper bound but cohesive: the backlog has already pre-split the consumer migrations into C-322 (capability/settings), C-323 (product gate), and C-324 (backend retirement) — splitting further would leave the gateway without a proving consumer. The only independently releasable seam inside this contract (text vs. image/voice wrapping) is kept because image/voice adapters are thin delegations to existing clients (AC-3), not new systems. No deferred phases hidden inside; `service` billing is explicitly another contract.
+
+## Acceptance Criteria
+
+### AC-1: Shared Gateway Contract Types Exist and Validate
+**Given** `packages/shared/schemas` and `packages/shared/types`
+**When** the gateway contract is defined
+**Then** `AiMode`, `AiCapability`, `AiGatewayErrorCode`, `AiGatewayError`, `AiModeResolution`, and `AiDetectionResult` exist as TypeBox schemas with `Static<>`-derived types exported from both package roots, valid/invalid payloads are accepted/rejected by `schemaCheck`, and no gateway type is defined inside `apps/**` or the gateway package itself.
+
+### AC-2: Text Calls Route Through the Gateway with Preserved Behavior
+**Given** the existing client call sites `text_generation_service.streamChat()` / `extractStructure()` and `ai_service.sendMessageToAI()` / `createPersona()`
+**When** they are migrated to `AiProviderGateway.generateText()`
+**Then** their public interfaces and observable behavior (SSE chunk delivery order, first-chunk/total timeouts, `AbortSignal` cancellation aborting the upstream fetch, structured extraction with TypeBox validation, Ollama VRAM-eviction payload params) are preserved — the existing test suites pass with gateway-backed internals — and the `(capability, mode, provider)` resolution happens exactly once at the gateway boundary, with no provider/endpoint conditionals remaining at the call sites.
+
+### AC-3: Image and Voice Wrap Existing Clients Unchanged
+**Given** the existing ComfyUI image path (`image_generation_service` / `ImageGenerationOrchestrator`) and Kokoro voice path (`tts_service`)
+**When** `generateImage()` and `generateVoice()` are called in `offline` mode
+**Then** they delegate to the existing implementations (same request payloads, same outputs), current callers of those services keep working unchanged, and both methods accept and honor `AbortSignal` and normalize failures to `AiGatewayError`.
+
+### AC-4: Service Mode Conforms but Is Guarded, and Errors Are Uniform
+**Given** the `service` mode is not activated for any capability
+**When** a caller resolves or selects `service` mode for a capability where it is unavailable
+**Then** the gateway returns/throws a typed `AiGatewayError` with code `mode_unavailable` (never a crash or a silent fallback), a deterministic stub `service` adapter passes the same adapter-contract test suite as `offline`/`byok` adapters, and all adapters across all modes/capabilities surface failures exclusively as `AiGatewayError` (asserted by a shared contract test run against every registered adapter with the synthetic SSE mock).
+
+### AC-5: Detection API Reaches Parity with Current Capability Pings
+**Given** the detection logic currently in `capability_service.svelte.ts` (Ollama proxy ping with native fallback, cloud text config check, ComfyUI `object_info` ping, Kokoro availability)
+**When** `gateway.detect(capability)` is called for each capability
+**Then** it returns `AiDetectionResult`s equivalent to today's `DetectionStatus` outcomes for the same environment conditions (reachable / unreachable / configured), each check completes within the 3s timeout budget without blocking other capability checks, and results are convertible to the existing `DetectionStatus` union so C-322 can swap `capability_service` internals without shape changes.
+
+**Evidence Matrix**:
+| AC | Test Level | Required Artifact | Production Path | Evidence |
+|---|---|---|---|---|
+| AC-1 | Unit | `packages/shared/schemas/tests/ai_gateway.test.ts` | N/A | Filled during verification |
+| AC-2 | Unit + Integration | `packages/frontend/ai-gateway/tests/text_adapters.test.ts`; existing `apps/frontend/client/src/lib/services/ai/text_generation_service.test.ts` passing against gateway internals | `/game` dialogue + `/setup` extraction flows (unchanged) | Filled during verification |
+| AC-3 | Unit | `packages/frontend/ai-gateway/tests/image_voice_adapters.test.ts`; existing `image_generation_service` + `tts_service` tests remain green | N/A (headless) | Filled during verification |
+| AC-4 | Unit | `packages/frontend/ai-gateway/tests/adapter_contract.test.ts` (shared contract suite over all adapters incl. service stub) | N/A | Filled during verification |
+| AC-5 | Unit + Integration | `packages/frontend/ai-gateway/tests/detection.test.ts` (parity fixtures vs. `capability_service.test.ts` scenarios) | N/A | Filled during verification |
+
+**Test Hooks**:
+- Moon Task: `moon_run_task` → `schemas:test`, `types:build`, `frontend-ai-gateway:test`, `client:test`; full `:validate` before handoff.
+- Integration: with local Ollama running (herdr `text` service), run a `streamChat` through the migrated `text_generation_service` in the client dev sandbox and confirm streaming + mid-stream cancel; with Ollama stopped, confirm `detect('text')` returns unavailable within 3s and `generateText` fails with `provider_unreachable`.
+- E2E / Visual:
+    - **Functional**: N/A — headless service layer; behavior preservation is proven by existing unit/integration suites. (C-322/C-318 own the E2E surfaces that exercise detection UX.)
+    - **Visual**: N/A.
+
+**Watch Points**:
+- AC-2: `extractStructure` falls back to system-prompt extraction when the provider lacks native `response_format: json_schema` — the fallback branch must survive the migration.
+- AC-2: `ai_service` currently swallows errors and returns `undefined` (logs via `this.error`) — preserve that call-site behavior while the gateway itself throws typed errors internally.
+- AC-3: `tts_service` has two engines (WebGPU worker vs. REST server auto-detect) — the gateway must delegate to the service's existing engine selection, not re-implement it.
+- AC-4: "hidden/disabled in UI" is C-318/C-322's job; this contract only guarantees the typed `mode_unavailable` guard exists for them to build on.
+- AC-5: the Ollama ping uses the Vite dev proxy (`/api/text/`) first and native `localhost:11434` second, sharing one aggregate deadline — keep both paths and the shared deadline.
+
+## Implementation Sequence
+
+1. **Phase 1 (Data/Logic)**: Define TypeBox schemas + derived types in `packages/shared/schemas` / `packages/shared/types` (AC-1). Scaffold `packages/frontend/ai-gateway` via the `new-project` skill. Build the adapter contract, registry, mode resolver, error normalization, and the shared adapter contract test suite with the synthetic SSE mock (AC-4 skeleton).
+2. **Phase 2 (Integration)**: Implement text `offline`/`byok` adapters by relocating `text_generation_service` internals and reusing `@aikami/backend/ai` payload builders/parsers where environment-agnostic (AC-2); wrap image/voice clients (AC-3); implement the `service` text adapter over the Firebase callable + deterministic stub (AC-4); implement `detect()` by relocating capability ping logic (AC-5). Migrate `text_generation_service` and `ai_service` call sites behind unchanged public interfaces; expose the gateway singleton via `$services`.
+3. **Phase 3 (Validation)**: Run `validate()` plus `schemas:test`, `frontend-ai-gateway:test`, `client:test`; run the local-Ollama integration checks (streaming, cancel, detection timing); confirm zero remaining direct provider-endpoint conditionals at migrated call sites (grep evidence).
+
+## Edge Cases & Gotchas
+
+- **Client disconnect mid-stream**: abort must propagate to the upstream fetch immediately or Ollama stays resident in VRAM until the hidden stream ends (C-056 lesson) — pass `AbortController` signals all the way down.
+- **Mixed modes per campaign**: text `offline` + image `byok` simultaneously is a supported state — resolution is per capability, never global; tests must cover a mixed-resolution fixture.
+- **Vault access failures**: `crypto_vault` reads can throw (fingerprint change, corrupted payload) — byok resolution must degrade to `not_configured`, not crash detection.
+- **Ollama endpoint duality**: dev uses the Vite proxy path, Tauri/production uses direct `localhost:11434` — endpoint resolution must keep both, mirroring `resolveChatUrl` + `_pingOllama` behavior.
+- **`packages/backend/ai` reuse boundary**: only environment-agnostic pieces (payload builders, SSE parsers, error codes) may be imported client-side; anything touching Node-only APIs stays server-side. Do not create a client → backend-package dependency that breaks the client build. In particular, `OLLAMA_VRAM_EVICTION_PARAMS` is a pure data constant in `@aikami/backend/ai` and is safe to import client-side, but `@aikami/backend/ai` is not aliased in the client's `svelte.config.js` — the implementer should either add the alias, duplicate the constant locally in the gateway, or move it to `@aikami/constants` (preferred but out of current scope).
+- **Error-swallowing call sites**: some existing callers rely on `undefined`-on-error semantics (`ai_service`); the gateway throws typed errors, so migrated wrappers must translate at the boundary, not change caller contracts.
+- **Voice "always available" assumption**: `capability_service.detect()` currently hardcodes voice as detected (Kokoro WebGPU) — `detect('voice')` should report real engine status but remain convertible to today's optimistic snapshot so C-322 decides the UX policy.
+
+## Open Questions
+
+None — package placement (`packages/frontend/ai-gateway`), consumer split (C-322/C-323/C-324), and `service`-mode stub boundary are resolved above per the TODO.md item.
+
+## Amendments
+
+Changes to ACs or scope require a version bump and user approval.
+
+| Version | Date | Change | Approved by |
+|---|---|---|---|
+| — | — | — | — |
+
+## Promotion Lifecycle
+
+> 📋 Promotion states: see [SHARED_SECTIONS.md](SHARED_SECTIONS.md#promotion-lifecycle)
+
+## Status Lifecycle
+
+> 📋 Status rules: see [SHARED_SECTIONS.md](SHARED_SECTIONS.md#status-lifecycle)
+
+---

--- a/docs/contracts/PROGRESS.md
+++ b/docs/contracts/PROGRESS.md
@@ -1,8 +1,8 @@
 # Contract Implementation Progress
 
-## Status Summary (Auto-generated: 2026-07-16)
+## Status Summary (Auto-generated: 2026-07-17)
 
-**164 active (50 without contract file), 119 archived, 1 duplicates**
+**164 active (49 without contract file), 119 archived, 1 duplicates**
 
 ### Active Contracts
 
@@ -122,7 +122,7 @@
 | C-317 | Rebuild The Start Menu Around Campaigns Not Personas | 👍 approved | — | v2 |
 | C-318 | Add One Screen Capability Setup And An Offline Demo Fallback | 🛠️ implemented | — | v2 |
 | C-319 | Replace Setup With Fast Character Onboarding | 🛠️ implemented | — | v2 |
-| C-320 | Build the Unified AI Provider Gateway (Offline / BYOK / Service) | ⏳ not_started (no contract file) | — | — |
+| C-320 | Build The Unified Ai Provider Gateway Offline Byok Service | 🔄 in_progress | — | v2 |
 | C-321 | Migrate Local Persistence to Turso as the Source of Truth | ⏳ not_started (no contract file) | — | — |
 | C-322 | Wire the AI Provider Gateway into Capability Detection and Settings | ⏳ not_started (no contract file) | — | — |
 | C-323 | Enforce the Mandatory Text AI Capability Gate | ⏳ not_started (no contract file) | — | — |

--- a/docs/contracts/PROGRESS.md
+++ b/docs/contracts/PROGRESS.md
@@ -122,7 +122,7 @@
 | C-317 | Rebuild The Start Menu Around Campaigns Not Personas | 👍 approved | — | v2 |
 | C-318 | Add One Screen Capability Setup And An Offline Demo Fallback | 🛠️ implemented | — | v2 |
 | C-319 | Replace Setup With Fast Character Onboarding | 🛠️ implemented | — | v2 |
-| C-320 | Build The Unified Ai Provider Gateway Offline Byok Service | 🔄 in_progress | — | v2 |
+| C-320 | Build The Unified Ai Provider Gateway Offline Byok Service | 🛠️ implemented | — | v2 |
 | C-321 | Migrate Local Persistence to Turso as the Source of Truth | ⏳ not_started (no contract file) | — | — |
 | C-322 | Wire the AI Provider Gateway into Capability Detection and Settings | ⏳ not_started (no contract file) | — | — |
 | C-323 | Enforce the Mandatory Text AI Capability Gate | ⏳ not_started (no contract file) | — | — |

--- a/docs/contracts/PROMOTION.md
+++ b/docs/contracts/PROMOTION.md
@@ -1,6 +1,6 @@
 # Feature Promotion Matrix
 
-> Auto-generated: 2026-07-16
+> Auto-generated: 2026-07-17
 
 Tracks which features have progressed from dev sandboxes through production integration to release readiness.
 
@@ -137,7 +137,7 @@ Tracks which features have progressed from dev sandboxes through production inte
 | C-317 | Rebuild The Start Menu Around Campaigns Not Personas | 👍 approved | v2 |
 | C-318 | Add One Screen Capability Setup And An Offline Demo Fallback | 🛠️ implemented | v2 |
 | C-319 | Replace Setup With Fast Character Onboarding | 🛠️ implemented | v2 |
-| C-320 | Build the Unified AI Provider Gateway (Offline / BYOK / Service) | ⏳ not_started (no contract file) | v1 |
+| C-320 | Build The Unified Ai Provider Gateway Offline Byok Service | 🔄 in_progress | v2 |
 | C-321 | Migrate Local Persistence to Turso as the Source of Truth | ⏳ not_started (no contract file) | v1 |
 | C-322 | Wire the AI Provider Gateway into Capability Detection and Settings | ⏳ not_started (no contract file) | v1 |
 | C-323 | Enforce the Mandatory Text AI Capability Gate | ⏳ not_started (no contract file) | v1 |

--- a/docs/contracts/PROMOTION.md
+++ b/docs/contracts/PROMOTION.md
@@ -137,7 +137,7 @@ Tracks which features have progressed from dev sandboxes through production inte
 | C-317 | Rebuild The Start Menu Around Campaigns Not Personas | 👍 approved | v2 |
 | C-318 | Add One Screen Capability Setup And An Offline Demo Fallback | 🛠️ implemented | v2 |
 | C-319 | Replace Setup With Fast Character Onboarding | 🛠️ implemented | v2 |
-| C-320 | Build The Unified Ai Provider Gateway Offline Byok Service | 🔄 in_progress | v2 |
+| C-320 | Build The Unified Ai Provider Gateway Offline Byok Service | 🛠️ implemented | v2 |
 | C-321 | Migrate Local Persistence to Turso as the Source of Truth | ⏳ not_started (no contract file) | v1 |
 | C-322 | Wire the AI Provider Gateway into Capability Detection and Settings | ⏳ not_started (no contract file) | v1 |
 | C-323 | Enforce the Mandatory Text AI Capability Gate | ⏳ not_started (no contract file) | v1 |

--- a/packages/frontend/ai-gateway/README.md
+++ b/packages/frontend/ai-gateway/README.md
@@ -1,0 +1,101 @@
+# @aikami/frontend-ai-gateway
+
+Unified AI Provider Gateway — one typed, mode-resolving call surface
+(`generateText` / `generateImage` / `generateVoice` / `detect`) for the three
+AI capabilities across `offline` / `byok` / `service` modes. Built by C-320.
+
+## Use Case
+
+- Resolve which (mode, provider) serves a capability exactly once at the
+  gateway boundary — call sites never re-check providers.
+- Wrap existing provider code (Ollama/OpenRouter/OpenAI SSE streaming,
+  ComfyUI image generation, Kokoro TTS) behind uniform adapter contracts.
+- Normalize every failure to a typed `AiGatewayError` (shape in
+  `@aikami/types`) with `code`, `capability`, `mode`, and `retryable`.
+- Bounded provider detection (≤3s) convertible to the existing
+  `DetectionStatus` union.
+
+## Where It's Used
+
+`apps/frontend/client` composes the gateway in
+`src/lib/services/ai/ai_gateway_service.svelte.ts`; `text_generation_service`
+and `ai_service` delegate to it. C-322/C-323/C-324 build on this surface.
+
+## Installation
+
+This is a workspace package managed by moon. Install via:
+
+```bash
+bun install
+```
+
+## Dependencies
+
+- `@aikami/constants` — shared constants
+- `@aikami/schemas` — TypeBox gateway schemas + `schemaCheck`
+- `@aikami/types` — `AiMode`, `AiCapability`, `AiGatewayError`, `AiModeResolution`, `AiDetectionResult`
+- `@aikami/logger` — logging
+
+## Tasks
+
+| Task        | Command                 | Description                   |
+| ----------- | ----------------------- | ----------------------------- |
+| `typecheck` | `tsgo --noEmit`         | Run TypeScript type checking  |
+| `format`    | `biome format .`        | Format code with Biome        |
+| `lint`      | `biome lint .`          | Lint code with Biome          |
+| `fix`       | `biome check --write .` | Auto-fix lint & format issues |
+| `test`      | `bun test`              | Run unit tests                |
+
+## Usage
+
+```typescript
+import {
+  createAdapterRegistry,
+  createAiProviderGateway,
+  createModeResolver,
+  createOpenAiCompatibleTextAdapter,
+} from '@aikami/frontend/ai-gateway';
+
+const registry = createAdapterRegistry();
+const textAdapter = createOpenAiCompatibleTextAdapter({ getApiKey });
+registry.registerText({ mode: 'offline', adapter: textAdapter });
+registry.registerText({ mode: 'byok', adapter: textAdapter });
+
+const gateway = createAiProviderGateway({
+  registry,
+  resolveMode: createModeResolver({ getConfig }),
+});
+
+const { text } = await gateway.generateText({
+  messages: [{ role: 'user', content: 'Hello' }],
+  onChunk: (token) => console.log(token),
+});
+```
+
+## Project Structure
+
+```
+src/
+├── index.ts                             # Public entry point
+└── lib/
+    ├── adapter_registry.ts              # (capability, mode) → adapter
+    ├── detection.ts                     # Bounded provider detection
+    ├── errors.ts                        # AiGatewayException + normalization
+    ├── gateway.ts                       # Default gateway implementation
+    ├── gateway_types.ts                 # Call surface + adapter contracts
+    ├── mode_resolver.ts                 # Config-backed mode resolution
+    ├── sse.ts                           # Chat-completions SSE reader
+    ├── structured.ts                    # Strict-schema extraction helpers
+    ├── text_adapter_openai_compatible.ts# offline + byok text transport
+    ├── text_adapter_service.ts          # service-mode adapter + stub
+    ├── image_adapter.ts                 # Delegating image adapter
+    └── voice_adapter.ts                 # Delegating voice adapter
+```
+
+## Architecture
+
+The gateway core is environment-agnostic (no browser globals outside
+client-only adapters) so the same contracts can back the server mirror
+(`packages/backend/ai` migration is C-324). The `service` mode ships an
+interface-conformant adapter and a deterministic stub; hosted activation,
+billing, and metering are Phase 5.

--- a/packages/frontend/ai-gateway/moon.yml
+++ b/packages/frontend/ai-gateway/moon.yml
@@ -1,0 +1,33 @@
+# packages/frontend/ai-gateway/moon.yml
+$schema: 'https://moonrepo.dev/schemas/project.json'
+
+language: 'typescript'
+layer: 'library'
+tags:
+  - 'ai-gateway'
+  - 'frontend'
+  - 'library'
+
+project:
+  name: 'frontend-ai-gateway'
+  description: 'Unified AI provider gateway — mode-resolving dispatch for text/image/voice across offline/byok/service.'
+  channel: '#frontend'
+  owner: 'Frontend Team'
+
+dependsOn:
+  - 'constants'
+  - 'schemas'
+  - 'types'
+  - 'logger'
+
+fileGroups:
+  tests:
+    - 'tests/**/*'
+
+tasks:
+  test:
+    command: 'bun run test'
+    inputs:
+      - '@group(sources)'
+      - '@group(tests)'
+      - '@group(configs)'

--- a/packages/frontend/ai-gateway/package.json
+++ b/packages/frontend/ai-gateway/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aikami/frontend-ai-gateway",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "lint": "biome lint .",
+    "format": "biome format .",
+    "typecheck": "tsgo --noEmit",
+    "fix": "biome check --write . --error-on-warnings"
+  },
+  "dependencies": {
+    "@aikami/constants": "workspace:*",
+    "@aikami/logger": "workspace:*",
+    "@aikami/schemas": "workspace:*",
+    "@aikami/types": "workspace:*"
+  }
+}

--- a/packages/frontend/ai-gateway/src/index.ts
+++ b/packages/frontend/ai-gateway/src/index.ts
@@ -1,0 +1,72 @@
+// packages/frontend/ai-gateway/src/index.ts
+//
+// Public API of @aikami/frontend/ai-gateway — the unified AI provider
+// gateway (offline / byok / service) built by C-320.
+
+export { type AiAdapterRegistry, createAdapterRegistry } from './lib/adapter_registry.ts';
+export {
+  DEFAULT_COMFYUI_PING_URL,
+  DEFAULT_OLLAMA_NATIVE_URL,
+  DEFAULT_OLLAMA_PROXY_PATH,
+  DETECTION_TIMEOUT_MS,
+  detectImageAvailability,
+  detectTextAvailability,
+  detectVoiceAvailability,
+  fetchWithTimeout,
+  toDetectionStatus,
+} from './lib/detection.ts';
+export {
+  AiGatewayException,
+  createAiGatewayError,
+  httpStatusToGatewayCode,
+  isAbortError,
+  isAiGatewayError,
+  isRetryableGatewayCode,
+  toAiGatewayError,
+} from './lib/errors.ts';
+export { type AiProviderGatewayOptions, createAiProviderGateway } from './lib/gateway.ts';
+export type {
+  AiAdapter,
+  AiAdapterContext,
+  AiDetector,
+  AiImageAdapter,
+  AiImageGenerationOptions,
+  AiImageGenerationResult,
+  AiModeResolver,
+  AiProviderGateway,
+  AiTextAdapter,
+  AiTextGenerationOptions,
+  AiTextGenerationResult,
+  AiVoiceAdapter,
+  AiVoiceGenerationOptions,
+  AiVoiceGenerationResult,
+} from './lib/gateway_types.ts';
+export { createDelegatingImageAdapter, raceWithAbort } from './lib/image_adapter.ts';
+export { createModeResolver } from './lib/mode_resolver.ts';
+export {
+  GATEWAY_FETCH_TIMEOUT_MS,
+  GATEWAY_FIRST_CHUNK_TIMEOUT_MS,
+  GATEWAY_IDLE_TIMEOUT_MS,
+  readChatSseStream,
+} from './lib/sse.ts';
+export {
+  createSchemaCompiler,
+  enforceStrictSchema,
+  type SchemaCompiler,
+  sanitizeJsonResponse,
+  validateAgainstSchema,
+} from './lib/structured.ts';
+export {
+  createOpenAiCompatibleTextAdapter,
+  DEFAULT_LOCAL_TEXT_ENDPOINTS,
+  OLLAMA_VRAM_EVICTION_PARAMS,
+  OPENROUTER_ATTRIBUTION_HEADERS,
+  type OpenAiCompatibleTextAdapterOptions,
+} from './lib/text_adapter_openai_compatible.ts';
+export {
+  createServiceStubTextAdapter,
+  createServiceTextAdapter,
+  type ServiceStubTextAdapterOptions,
+  type ServiceTextCallable,
+} from './lib/text_adapter_service.ts';
+export { createDelegatingVoiceAdapter } from './lib/voice_adapter.ts';

--- a/packages/frontend/ai-gateway/src/lib/adapter_registry.ts
+++ b/packages/frontend/ai-gateway/src/lib/adapter_registry.ts
@@ -1,0 +1,63 @@
+// packages/frontend/ai-gateway/src/lib/adapter_registry.ts
+//
+// Registry of adapters keyed by (capability, mode). The gateway dispatches
+// through this registry after mode resolution.
+// Contract: C-320
+
+import type { AiCapability, AiMode } from '@aikami/types';
+import type { AiAdapter, AiImageAdapter, AiTextAdapter, AiVoiceAdapter } from './gateway_types.ts';
+
+/** Registry of adapters keyed by (capability, mode). */
+export type AiAdapterRegistry = {
+  registerText(options: { mode: AiMode; adapter: AiTextAdapter }): void;
+  registerImage(options: { mode: AiMode; adapter: AiImageAdapter }): void;
+  registerVoice(options: { mode: AiMode; adapter: AiVoiceAdapter }): void;
+  getText(mode: AiMode): AiTextAdapter | undefined;
+  getImage(mode: AiMode): AiImageAdapter | undefined;
+  getVoice(mode: AiMode): AiVoiceAdapter | undefined;
+  /** All registered (capability, mode, adapter) entries — used by contract tests. */
+  entries(): Array<{ capability: AiCapability; mode: AiMode; adapter: AiAdapter }>;
+};
+
+/**
+ * Creates an empty adapter registry.
+ */
+export const createAdapterRegistry = (): AiAdapterRegistry => {
+  const text = new Map<AiMode, AiTextAdapter>();
+  const image = new Map<AiMode, AiImageAdapter>();
+  const voice = new Map<AiMode, AiVoiceAdapter>();
+
+  return {
+    registerText(options: { mode: AiMode; adapter: AiTextAdapter }): void {
+      text.set(options.mode, options.adapter);
+    },
+    registerImage(options: { mode: AiMode; adapter: AiImageAdapter }): void {
+      image.set(options.mode, options.adapter);
+    },
+    registerVoice(options: { mode: AiMode; adapter: AiVoiceAdapter }): void {
+      voice.set(options.mode, options.adapter);
+    },
+    getText(mode: AiMode): AiTextAdapter | undefined {
+      return text.get(mode);
+    },
+    getImage(mode: AiMode): AiImageAdapter | undefined {
+      return image.get(mode);
+    },
+    getVoice(mode: AiMode): AiVoiceAdapter | undefined {
+      return voice.get(mode);
+    },
+    entries(): Array<{ capability: AiCapability; mode: AiMode; adapter: AiAdapter }> {
+      const result: Array<{ capability: AiCapability; mode: AiMode; adapter: AiAdapter }> = [];
+      for (const [mode, adapter] of text) {
+        result.push({ capability: 'text', mode, adapter });
+      }
+      for (const [mode, adapter] of image) {
+        result.push({ capability: 'image', mode, adapter });
+      }
+      for (const [mode, adapter] of voice) {
+        result.push({ capability: 'voice', mode, adapter });
+      }
+      return result;
+    },
+  };
+};

--- a/packages/frontend/ai-gateway/src/lib/detection.ts
+++ b/packages/frontend/ai-gateway/src/lib/detection.ts
@@ -1,0 +1,259 @@
+// packages/frontend/ai-gateway/src/lib/detection.ts
+//
+// Gateway detection API — relocated provider-ping logic from the client's
+// capability_service (Ollama proxy/native ping with shared deadline, cloud
+// config presence check, ComfyUI object_info ping, Kokoro engine status).
+// Results are convertible to the existing DetectionStatus union.
+// Contract: C-320 AC-5
+
+import type { AiDetectionResult, DetectionStatus } from '@aikami/types';
+
+/** Detection budget per capability check (parity with capability_service). */
+export const DETECTION_TIMEOUT_MS = 3_000;
+
+/** Default Ollama Vite dev-proxy path (same-origin, no CORS). */
+export const DEFAULT_OLLAMA_PROXY_PATH = '/api/text/';
+
+/** Default native Ollama tags endpoint (Tauri / relaxed-CSP contexts). */
+export const DEFAULT_OLLAMA_NATIVE_URL = 'http://localhost:11434/api/tags';
+
+/** Default ComfyUI object_info ping path via the Vite dev proxy. */
+export const DEFAULT_COMFYUI_PING_URL = '/api/image/object_info';
+
+/** Performs a GET fetch with an abort timeout. */
+export const fetchWithTimeout = async (options: {
+  url: string;
+  timeoutMs: number;
+  fetchFn?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<Response> => {
+  const { url, timeoutMs, fetchFn, signal } = options;
+  const doFetch = fetchFn ?? globalThis.fetch;
+  const controller = new AbortController();
+  const onAbort = (): void => controller.abort();
+  signal?.addEventListener('abort', onAbort, { once: true });
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    // Race against the timeout as well — injected fetch implementations
+    // that ignore AbortSignal must still respect the detection budget.
+    return await Promise.race([
+      doFetch(url, { method: 'GET', signal: controller.signal }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new DOMException('Aborted', 'AbortError')), timeoutMs),
+      ),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener('abort', onAbort);
+  }
+};
+
+const nowIso = (): string => new Date().toISOString();
+
+/**
+ * Detects text AI availability.
+ *
+ * Order (parity with capability_service.detectText):
+ * 1. Configured cloud connection (vault/env) → available via `byok`.
+ * 2. Ollama via dev proxy (primary; same-origin → no CORS).
+ * 3. Fallback: native fetch to localhost:11434/api/tags. Both Ollama
+ *    attempts share one aggregate deadline.
+ */
+export const detectTextAvailability = async (options?: {
+  hasCloudConfig?: () => boolean;
+  proxyUrl?: string;
+  nativeUrl?: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<AiDetectionResult> => {
+  const {
+    hasCloudConfig,
+    proxyUrl = DEFAULT_OLLAMA_PROXY_PATH,
+    nativeUrl = DEFAULT_OLLAMA_NATIVE_URL,
+    timeoutMs = DETECTION_TIMEOUT_MS,
+    fetchFn,
+    signal,
+  } = options ?? {};
+
+  try {
+    if (hasCloudConfig?.()) {
+      return {
+        capability: 'text',
+        available: true,
+        mode: 'byok',
+        provider: 'cloud',
+        detail: 'Cloud text provider configured',
+        checkedAt: nowIso(),
+      };
+    }
+  } catch {
+    // Vault read failures degrade to not-configured — continue local pings.
+  }
+
+  // Both Ollama attempts share one aggregate deadline.
+  const deadline = Date.now() + timeoutMs;
+
+  // Primary: Vite dev proxy (same-origin, no CORS issues)
+  try {
+    const remaining = Math.max(0, deadline - Date.now());
+    const response = await fetchWithTimeout({
+      url: proxyUrl,
+      timeoutMs: remaining,
+      fetchFn,
+      signal,
+    });
+    if (response.ok) {
+      return {
+        capability: 'text',
+        available: true,
+        mode: 'offline',
+        provider: 'ollama',
+        detail: 'Ollama reachable via dev proxy',
+        checkedAt: nowIso(),
+      };
+    }
+  } catch {
+    // Proxy unavailable — fall through to native ping.
+  }
+
+  // Fallback: native fetch to localhost (CORS-limited in browser,
+  // works in Tauri / Electron due to relaxed CSP)
+  try {
+    const remaining = Math.max(0, deadline - Date.now());
+    const response = await fetchWithTimeout({
+      url: nativeUrl,
+      timeoutMs: remaining,
+      fetchFn,
+      signal,
+    });
+    if (response.ok) {
+      const body = (await response.json()) as { models?: unknown[] };
+      const modelCount = Array.isArray(body.models) ? body.models.length : 0;
+      return {
+        capability: 'text',
+        available: true,
+        mode: 'offline',
+        provider: 'ollama',
+        detail: `Ollama reachable natively (${modelCount} models)`,
+        checkedAt: nowIso(),
+      };
+    }
+  } catch {
+    // CORS rejection or connection refused — expected in browser mode.
+  }
+
+  return {
+    capability: 'text',
+    available: false,
+    detail: 'No text provider reachable or configured',
+    checkedAt: nowIso(),
+  };
+};
+
+/**
+ * Detects image AI availability (parity with capability_service.detectImage):
+ * configured provider → available via `byok`; otherwise ComfyUI ping.
+ */
+export const detectImageAvailability = async (options?: {
+  hasConfiguredProvider?: () => boolean;
+  pingUrl?: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<AiDetectionResult> => {
+  const {
+    hasConfiguredProvider,
+    pingUrl = DEFAULT_COMFYUI_PING_URL,
+    timeoutMs = DETECTION_TIMEOUT_MS,
+    fetchFn,
+    signal,
+  } = options ?? {};
+
+  try {
+    if (hasConfiguredProvider?.()) {
+      return {
+        capability: 'image',
+        available: true,
+        mode: 'byok',
+        provider: 'custom',
+        detail: 'Image provider configured',
+        checkedAt: nowIso(),
+      };
+    }
+  } catch {
+    // Fall through to proxy check.
+  }
+
+  try {
+    const response = await fetchWithTimeout({ url: pingUrl, timeoutMs, fetchFn, signal });
+    if (response.ok) {
+      return {
+        capability: 'image',
+        available: true,
+        mode: 'offline',
+        provider: 'comfyui',
+        detail: 'ComfyUI reachable',
+        checkedAt: nowIso(),
+      };
+    }
+  } catch {
+    // Connection refused — expected when ComfyUI is not running.
+  }
+
+  return {
+    capability: 'image',
+    available: false,
+    detail: 'ComfyUI unreachable and no image provider configured',
+    checkedAt: nowIso(),
+  };
+};
+
+/**
+ * Detects voice availability. Reports real engine status while remaining
+ * convertible to today's optimistic snapshot (Kokoro WebGPU is treated as
+ * available unless the engine reports a hard error).
+ */
+export const detectVoiceAvailability = async (options?: {
+  getEngineStatus?: () => { status: string; serverAvailable: boolean };
+}): Promise<AiDetectionResult> => {
+  const engine = options?.getEngineStatus?.() ?? {
+    status: 'uninitialized',
+    serverAvailable: false,
+  };
+
+  if (engine.status === 'error') {
+    return {
+      capability: 'voice',
+      available: false,
+      detail: 'Kokoro engine error',
+      checkedAt: nowIso(),
+    };
+  }
+
+  return {
+    capability: 'voice',
+    available: true,
+    mode: 'offline',
+    provider: 'kokoro',
+    detail: engine.serverAvailable
+      ? 'Kokoro REST server detected'
+      : `Kokoro WebGPU engine (${engine.status})`,
+    checkedAt: nowIso(),
+  };
+};
+
+/**
+ * Converts a gateway detection result to the existing DetectionStatus
+ * union so C-322 can swap capability_service internals without shape
+ * changes.
+ */
+export const toDetectionStatus = (result: AiDetectionResult): DetectionStatus => {
+  if (!result.available) {
+    return 'not_found';
+  }
+  if (result.mode === 'byok') {
+    return 'configured';
+  }
+  return 'detected';
+};

--- a/packages/frontend/ai-gateway/src/lib/errors.ts
+++ b/packages/frontend/ai-gateway/src/lib/errors.ts
@@ -1,0 +1,186 @@
+// packages/frontend/ai-gateway/src/lib/errors.ts
+//
+// Normalized gateway error surface. Every failure that escapes the gateway
+// is an AiGatewayException carrying the shared AiGatewayError shape.
+// Contract: C-320 AC-4
+
+import type { AiCapability, AiGatewayError, AiGatewayErrorCode, AiMode } from '@aikami/types';
+
+/**
+ * Typed error thrown by every gateway call. Structurally satisfies the
+ * shared `AiGatewayError` shape from `@aikami/types` while remaining a
+ * real `Error` for stack traces and `instanceof` checks.
+ *
+ * Messages must never contain secrets (API keys are redacted upstream).
+ */
+export class AiGatewayException extends Error implements AiGatewayError {
+  /** Machine-readable normalized error code. */
+  readonly code: AiGatewayErrorCode;
+
+  /** Which capability the failing call targeted. */
+  readonly capability: AiCapability;
+
+  /** Which mode served (or failed to serve) the call. */
+  readonly mode: AiMode;
+
+  /** Provider id when known. */
+  readonly provider?: string;
+
+  /** Whether retrying the call may succeed. Never true for 'cancelled'. */
+  readonly retryable: boolean;
+
+  /** Original error, for debugging. Never logged with secrets. */
+  readonly originalError?: unknown;
+
+  constructor(options: {
+    code: AiGatewayErrorCode;
+    capability: AiCapability;
+    mode: AiMode;
+    message: string;
+    provider?: string;
+    originalError?: unknown;
+  }) {
+    super(options.message);
+    this.name = 'AiGatewayException';
+    this.code = options.code;
+    this.capability = options.capability;
+    this.mode = options.mode;
+    this.provider = options.provider;
+    this.retryable = isRetryableGatewayCode(options.code);
+    this.originalError = options.originalError;
+  }
+}
+
+/**
+ * Factory for AiGatewayException — the preferred construction path.
+ */
+export const createAiGatewayError = (options: {
+  code: AiGatewayErrorCode;
+  capability: AiCapability;
+  mode: AiMode;
+  message: string;
+  provider?: string;
+  originalError?: unknown;
+}): AiGatewayException => new AiGatewayException(options);
+
+/**
+ * Type guard for AiGatewayException.
+ */
+export const isAiGatewayError = (error: unknown): error is AiGatewayException =>
+  error instanceof AiGatewayException;
+
+/**
+ * Whether a normalized code represents a transient (retryable) failure.
+ * Retry policy is per-adapter and must never retry after 'cancelled'.
+ */
+export const isRetryableGatewayCode = (code: AiGatewayErrorCode): boolean => {
+  switch (code) {
+    case 'provider_unreachable':
+    case 'rate_limited':
+    case 'timeout':
+      return true;
+    case 'not_configured':
+    case 'auth_failed':
+    case 'cancelled':
+    case 'invalid_response':
+    case 'mode_unavailable':
+      return false;
+  }
+};
+
+/**
+ * Maps an HTTP status code from a provider response to a gateway code.
+ */
+export const httpStatusToGatewayCode = (status: number): AiGatewayErrorCode => {
+  if (status === 401 || status === 403) {
+    return 'auth_failed';
+  }
+  if (status === 429) {
+    return 'rate_limited';
+  }
+  if (status === 408 || status === 504) {
+    return 'timeout';
+  }
+  if (status >= 500) {
+    return 'provider_unreachable';
+  }
+  return 'invalid_response';
+};
+
+/** Returns true when the error represents an abort/cancellation. */
+export const isAbortError = (error: unknown): boolean => {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  return error instanceof Error && error.name === 'AbortError';
+};
+
+/**
+ * Normalizes any thrown value into an AiGatewayException, preserving the
+ * original message so existing call-site expectations keep matching.
+ */
+export const toAiGatewayError = (options: {
+  error: unknown;
+  capability: AiCapability;
+  mode: AiMode;
+  provider?: string;
+}): AiGatewayException => {
+  const { error, capability, mode, provider } = options;
+
+  if (isAiGatewayError(error)) {
+    return error;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+
+  const code = classifyErrorMessage({ error, message });
+
+  return createAiGatewayError({
+    code,
+    capability,
+    mode,
+    provider,
+    message,
+    originalError: error,
+  });
+};
+
+/**
+ * Heuristic classification of raw errors into normalized gateway codes.
+ */
+const classifyErrorMessage = (options: { error: unknown; message: string }): AiGatewayErrorCode => {
+  const { error, message } = options;
+
+  if (isAbortError(error)) {
+    return 'cancelled';
+  }
+
+  const lower = message.toLowerCase();
+
+  if (lower.includes('timed out') || lower.includes('timeout')) {
+    return 'timeout';
+  }
+  if (lower.includes('no endpoint configured') || lower.includes('provider configured')) {
+    return 'not_configured';
+  }
+
+  const httpMatch = message.match(/HTTP (\d{3})/);
+  if (httpMatch) {
+    return httpStatusToGatewayCode(Number(httpMatch[1]));
+  }
+
+  if (
+    lower.includes('failed to fetch') ||
+    lower.includes('fetch failed') ||
+    lower.includes('connection refused') ||
+    lower.includes('network')
+  ) {
+    return 'provider_unreachable';
+  }
+
+  if (lower.includes('json') || lower.includes('no response body')) {
+    return 'invalid_response';
+  }
+
+  return 'provider_unreachable';
+};

--- a/packages/frontend/ai-gateway/src/lib/gateway.ts
+++ b/packages/frontend/ai-gateway/src/lib/gateway.ts
@@ -1,0 +1,274 @@
+// packages/frontend/ai-gateway/src/lib/gateway.ts
+//
+// Default AiProviderGateway implementation — typed, mode-resolving dispatch
+// for the three AI capabilities. Resolution happens exactly once per call
+// at this boundary; adapters never re-check providers. Cancellation is
+// propagated to every adapter via linked AbortSignals; cancelAll() aborts
+// all in-flight calls. Errors surface exclusively as AiGatewayException.
+// Contract: C-320
+
+import type { AiCapability, AiDetectionResult, AiMode, AiModeResolution } from '@aikami/types';
+import type { AiAdapterRegistry } from './adapter_registry.ts';
+import { DETECTION_TIMEOUT_MS } from './detection.ts';
+import { createAiGatewayError, toAiGatewayError } from './errors.ts';
+import type {
+  AiDetector,
+  AiImageGenerationOptions,
+  AiImageGenerationResult,
+  AiModeResolver,
+  AiProviderGateway,
+  AiTextAdapter,
+  AiTextGenerationOptions,
+  AiTextGenerationResult,
+  AiVoiceGenerationOptions,
+  AiVoiceGenerationResult,
+} from './gateway_types.ts';
+
+/** Options for constructing the default gateway. */
+export type AiProviderGatewayOptions = {
+  /** Adapter registry keyed by (capability, mode). */
+  registry: AiAdapterRegistry;
+  /** Per-capability mode resolver, computed from provided config. */
+  resolveMode: AiModeResolver;
+  /** Detection functions per capability. */
+  detectors?: Partial<Record<AiCapability, AiDetector>>;
+  /** Detection budget in ms (default 3000). */
+  detectionTimeoutMs?: number;
+  /** Log hook — invoked once per dispatch with the resolution. */
+  onDispatch?: (resolution: AiModeResolution) => void;
+};
+
+/**
+ * Creates the default AiProviderGateway.
+ */
+export const createAiProviderGateway = (options: AiProviderGatewayOptions): AiProviderGateway => {
+  const {
+    registry,
+    resolveMode,
+    detectors = {},
+    detectionTimeoutMs = DETECTION_TIMEOUT_MS,
+    onDispatch,
+  } = options;
+
+  const activeControllers = new Set<AbortController>();
+
+  /** Creates a controller linked to the caller's signal and tracks it. */
+  const linkSignal = (signal?: AbortSignal): AbortController => {
+    const controller = new AbortController();
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort(signal.reason);
+      } else {
+        signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+      }
+    }
+    activeControllers.add(controller);
+    return controller;
+  };
+
+  /** Builds a resolution for an explicit mode override via the registry. */
+  const resolveOverride = (options2: {
+    capability: AiCapability;
+    mode: AiMode;
+    provider?: string;
+    model?: string;
+  }): AiModeResolution => ({
+    capability: options2.capability,
+    mode: options2.mode,
+    provider: options2.provider ?? options2.mode,
+    model: options2.model,
+  });
+
+  const missingAdapterError = (options2: { capability: AiCapability; mode: AiMode }): Error =>
+    createAiGatewayError({
+      code: 'mode_unavailable',
+      capability: options2.capability,
+      mode: options2.mode,
+      message: `No ${options2.capability} adapter registered for mode "${options2.mode}"`,
+    });
+
+  /**
+   * Runs the resolver, normalizing any raw resolver error (e.g. config
+   * lookups that throw plain Errors) into AiGatewayException.
+   */
+  const resolveNormalized = (options2: {
+    capability: AiCapability;
+    model?: string;
+  }): AiModeResolution => {
+    try {
+      return resolveMode(options2);
+    } catch (error) {
+      throw toAiGatewayError({ error, capability: options2.capability, mode: 'offline' });
+    }
+  };
+
+  return {
+    resolveMode(capability): AiModeResolution {
+      return resolveNormalized({ capability });
+    },
+
+    async detect(capability): Promise<AiDetectionResult> {
+      const detector = detectors[capability];
+      const checkedAt = new Date().toISOString();
+
+      if (!detector) {
+        return {
+          capability,
+          available: false,
+          detail: 'No detector registered',
+          checkedAt,
+        };
+      }
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), detectionTimeoutMs);
+      try {
+        return await Promise.race([
+          detector({ signal: controller.signal }),
+          new Promise<AiDetectionResult>((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  capability,
+                  available: false,
+                  detail: 'Detection timed out',
+                  checkedAt,
+                }),
+              detectionTimeoutMs,
+            ),
+          ),
+        ]);
+      } catch (error) {
+        return {
+          capability,
+          available: false,
+          detail: `Detection failed: ${error instanceof Error ? error.message : String(error)}`,
+          checkedAt,
+        };
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    },
+
+    async generateText(options2: AiTextGenerationOptions): Promise<AiTextGenerationResult> {
+      const { messages, onChunk, schema, schemaName, model, signal, mode, onResolve } = options2;
+
+      // Resolution happens exactly once, here at the gateway boundary.
+      let resolution: AiModeResolution;
+      let adapter: AiTextAdapter | undefined;
+      if (mode) {
+        adapter = registry.getText(mode);
+        if (!adapter) {
+          throw missingAdapterError({ capability: 'text', mode });
+        }
+        resolution = resolveOverride({
+          capability: 'text',
+          mode,
+          provider: adapter.provider,
+          model,
+        });
+      } else {
+        resolution = resolveNormalized({ capability: 'text', model });
+        adapter = registry.getText(resolution.mode);
+        if (!adapter) {
+          throw missingAdapterError({ capability: 'text', mode: resolution.mode });
+        }
+      }
+
+      onResolve?.(resolution);
+      onDispatch?.(resolution);
+
+      const controller = linkSignal(signal);
+      try {
+        return await adapter.generateText({
+          resolution,
+          signal: controller.signal,
+          messages,
+          onChunk,
+          schema,
+          schemaName,
+        });
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      } finally {
+        activeControllers.delete(controller);
+      }
+    },
+
+    async generateImage(options2: AiImageGenerationOptions): Promise<AiImageGenerationResult> {
+      const { prompt, checkpoint, signal, onResolve } = options2;
+
+      const resolution = resolveNormalized({ capability: 'image' });
+      const adapter = registry.getImage(resolution.mode);
+      if (!adapter) {
+        throw missingAdapterError({ capability: 'image', mode: resolution.mode });
+      }
+
+      onResolve?.(resolution);
+      onDispatch?.(resolution);
+
+      const controller = linkSignal(signal);
+      try {
+        return await adapter.generateImage({
+          resolution,
+          signal: controller.signal,
+          prompt,
+          checkpoint,
+        });
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'image',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      } finally {
+        activeControllers.delete(controller);
+      }
+    },
+
+    async generateVoice(options2: AiVoiceGenerationOptions): Promise<AiVoiceGenerationResult> {
+      const { text, voiceId, signal, onResolve } = options2;
+
+      const resolution = resolveNormalized({ capability: 'voice' });
+      const adapter = registry.getVoice(resolution.mode);
+      if (!adapter) {
+        throw missingAdapterError({ capability: 'voice', mode: resolution.mode });
+      }
+
+      onResolve?.(resolution);
+      onDispatch?.(resolution);
+
+      const controller = linkSignal(signal);
+      try {
+        return await adapter.generateVoice({
+          resolution,
+          signal: controller.signal,
+          text,
+          voiceId,
+        });
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'voice',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      } finally {
+        activeControllers.delete(controller);
+      }
+    },
+
+    cancelAll(): void {
+      for (const controller of activeControllers) {
+        controller.abort();
+      }
+      activeControllers.clear();
+    },
+  };
+};

--- a/packages/frontend/ai-gateway/src/lib/gateway_types.ts
+++ b/packages/frontend/ai-gateway/src/lib/gateway_types.ts
@@ -1,0 +1,164 @@
+// packages/frontend/ai-gateway/src/lib/gateway_types.ts
+//
+// The AiProviderGateway call surface and the (capability, mode) adapter
+// contracts. Shared data shapes (AiMode, AiCapability, AiGatewayError,
+// AiModeResolution, AiDetectionResult) live in @aikami/types per Pillar 2 —
+// this file only defines the service-layer function contracts.
+// Contract: C-320
+
+import type {
+  AiCapability,
+  AiChatMessage,
+  AiDetectionResult,
+  AiMode,
+  AiModeResolution,
+} from '@aikami/types';
+
+// ---------------------------------------------------------------------------
+// Request / result shapes (call surface)
+// ---------------------------------------------------------------------------
+
+/** Options for a gateway text-generation call. */
+export type AiTextGenerationOptions = {
+  /** Full conversation history, oldest first. */
+  messages: AiChatMessage[];
+  /** Streaming token callback; delivery order matches provider order. */
+  onChunk?: (text: string) => void;
+  /** JSON Schema dictionary for structured extraction. */
+  schema?: Record<string, unknown>;
+  /** Name for the structured schema (used for caching + provider payloads). */
+  schemaName?: string;
+  /** Explicit model override. */
+  model?: string;
+  /** Cancellation signal — propagated to the upstream provider fetch. */
+  signal?: AbortSignal;
+  /**
+   * Explicit adapter-family override. Used by legacy `service`-mode callers
+   * (e.g. the Firebase callable path) that must bypass per-capability
+   * resolution. Selecting a mode with no registered adapter raises
+   * `mode_unavailable`.
+   */
+  mode?: AiMode;
+  /** Debug hook — receives the resolution computed at the gateway boundary. */
+  onResolve?: (resolution: AiModeResolution) => void;
+};
+
+/** Result of a gateway text-generation call. */
+export type AiTextGenerationResult = {
+  /** Full accumulated text. */
+  text: string;
+  /** Parsed structured object when a schema was provided. */
+  structured?: unknown;
+};
+
+/** Options for a gateway image-generation call. */
+export type AiImageGenerationOptions = {
+  prompt: string;
+  checkpoint?: string;
+  signal?: AbortSignal;
+  /** Debug hook — receives the resolution computed at the gateway boundary. */
+  onResolve?: (resolution: AiModeResolution) => void;
+};
+
+/** Result of a gateway image-generation call. */
+export type AiImageGenerationResult = {
+  url: string;
+};
+
+/** Options for a gateway voice-synthesis call. */
+export type AiVoiceGenerationOptions = {
+  text: string;
+  voiceId?: string;
+  signal?: AbortSignal;
+  /** Debug hook — receives the resolution computed at the gateway boundary. */
+  onResolve?: (resolution: AiModeResolution) => void;
+};
+
+/**
+ * Result of a gateway voice-synthesis call.
+ *
+ * `audio` is optional: the current Kokoro delegation plays audio through
+ * the client's streaming pipeline and does not expose raw buffers. Adapters
+ * that do produce raw audio return it here.
+ */
+export type AiVoiceGenerationResult = {
+  audio?: ArrayBuffer | ReadableStream<Uint8Array>;
+};
+
+// ---------------------------------------------------------------------------
+// Adapter contracts
+// ---------------------------------------------------------------------------
+
+/** Context injected into every adapter call by the gateway. */
+export type AiAdapterContext = {
+  /** Resolution computed once at the gateway boundary. */
+  resolution: AiModeResolution;
+  /** Combined cancellation signal (caller signal + gateway cancelAll). */
+  signal: AbortSignal;
+};
+
+/** Adapter contract for text generation. */
+export type AiTextAdapter = {
+  /** Provider label used when constructing override resolutions. */
+  readonly provider?: string;
+  generateText(
+    options: AiAdapterContext & {
+      messages: AiChatMessage[];
+      onChunk?: (text: string) => void;
+      schema?: Record<string, unknown>;
+      schemaName?: string;
+    },
+  ): Promise<AiTextGenerationResult>;
+};
+
+/** Adapter contract for image generation. */
+export type AiImageAdapter = {
+  readonly provider?: string;
+  generateImage(
+    options: AiAdapterContext & { prompt: string; checkpoint?: string },
+  ): Promise<AiImageGenerationResult>;
+};
+
+/** Adapter contract for voice synthesis. */
+export type AiVoiceAdapter = {
+  readonly provider?: string;
+  generateVoice(
+    options: AiAdapterContext & { text: string; voiceId?: string },
+  ): Promise<AiVoiceGenerationResult>;
+};
+
+/** Union of all adapter families. */
+export type AiAdapter = AiTextAdapter | AiImageAdapter | AiVoiceAdapter;
+
+/** Capability detector — must resolve within the gateway detection budget. */
+export type AiDetector = (options: { signal: AbortSignal }) => Promise<AiDetectionResult>;
+
+// ---------------------------------------------------------------------------
+// Gateway call surface
+// ---------------------------------------------------------------------------
+
+/**
+ * The single call surface for AI capabilities. Mode (`offline` / `byok` /
+ * `service`) is resolved once per capability at the gateway boundary —
+ * callers never re-check providers.
+ */
+export type AiProviderGateway = {
+  /** Resolves which (mode, provider) serves a capability right now. */
+  resolveMode(capability: AiCapability): AiModeResolution;
+  /** Detects capability availability with a bounded timeout. Never throws. */
+  detect(capability: AiCapability): Promise<AiDetectionResult>;
+  /** Generates text (streaming via onChunk, structured via schema). */
+  generateText(options: AiTextGenerationOptions): Promise<AiTextGenerationResult>;
+  /** Generates an image via the resolved image adapter. */
+  generateImage(options: AiImageGenerationOptions): Promise<AiImageGenerationResult>;
+  /** Synthesizes speech via the resolved voice adapter. */
+  generateVoice(options: AiVoiceGenerationOptions): Promise<AiVoiceGenerationResult>;
+  /** Aborts all in-flight gateway calls across all capabilities. */
+  cancelAll(): void;
+};
+
+/** Resolver function computed from provided config — one resolution per call. */
+export type AiModeResolver = (options: {
+  capability: AiCapability;
+  model?: string;
+}) => AiModeResolution;

--- a/packages/frontend/ai-gateway/src/lib/image_adapter.ts
+++ b/packages/frontend/ai-gateway/src/lib/image_adapter.ts
@@ -1,0 +1,88 @@
+// packages/frontend/ai-gateway/src/lib/image_adapter.ts
+//
+// Delegating image adapter — wraps the existing ComfyUI client path
+// (image_generation_service / ImageGenerationOrchestrator) unchanged.
+// Contract: C-320 AC-3
+
+import { createAiGatewayError, toAiGatewayError } from './errors.ts';
+import type { AiImageAdapter, AiImageGenerationResult } from './gateway_types.ts';
+
+/**
+ * Creates an image adapter that delegates to an existing generator
+ * (same request payload, same output). Honors AbortSignal by rejecting
+ * promptly with `cancelled` when aborted — the delegate may continue in
+ * the background if it does not support aborts natively.
+ */
+export const createDelegatingImageAdapter = (options: {
+  /** Existing image generation entry point (e.g. imageGenerationService). */
+  generate: (options: { prompt: string; checkpoint?: string }) => Promise<{ url: string }>;
+  /** Provider label for resolutions/errors. Defaults to 'comfyui'. */
+  provider?: string;
+}): AiImageAdapter => {
+  const { generate, provider = 'comfyui' } = options;
+
+  return {
+    provider,
+    async generateImage(request): Promise<AiImageGenerationResult> {
+      const { resolution, signal, prompt, checkpoint } = request;
+
+      const cancelledError = (): Error =>
+        createAiGatewayError({
+          code: 'cancelled',
+          capability: 'image',
+          mode: resolution.mode,
+          provider: resolution.provider,
+          message: 'Aborted',
+        });
+
+      if (signal.aborted) {
+        throw cancelledError();
+      }
+
+      try {
+        const result = await raceWithAbort({
+          promise: generate({ prompt, checkpoint }),
+          signal,
+          onAbort: cancelledError,
+        });
+        return { url: result.url };
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'image',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      }
+    },
+  };
+};
+
+/**
+ * Races a promise against an AbortSignal, rejecting with `onAbort()`
+ * as soon as the signal fires.
+ */
+export const raceWithAbort = async <T>(options: {
+  promise: Promise<T>;
+  signal: AbortSignal;
+  onAbort: () => Error;
+}): Promise<T> => {
+  const { promise, signal, onAbort } = options;
+
+  if (signal.aborted) {
+    throw onAbort();
+  }
+
+  let removeListener = (): void => {};
+  const abortPromise = new Promise<never>((_, reject) => {
+    const listener = (): void => reject(onAbort());
+    signal.addEventListener('abort', listener, { once: true });
+    removeListener = (): void => signal.removeEventListener('abort', listener);
+  });
+
+  try {
+    return await Promise.race([promise, abortPromise]);
+  } finally {
+    removeListener();
+  }
+};

--- a/packages/frontend/ai-gateway/src/lib/mode_resolver.ts
+++ b/packages/frontend/ai-gateway/src/lib/mode_resolver.ts
@@ -1,0 +1,55 @@
+// packages/frontend/ai-gateway/src/lib/mode_resolver.ts
+//
+// Generic per-capability mode resolution from an AiGatewayModeConfig.
+// Resolution is synchronous, in-memory, and computed once per gateway call
+// at the dispatch boundary — never re-checked at call sites.
+// Contract: C-320 AC-4 (service guard)
+
+import type { AiGatewayModeConfig, AiModeResolution } from '@aikami/types';
+import { createAiGatewayError } from './errors.ts';
+import type { AiModeResolver } from './gateway_types.ts';
+
+/**
+ * Creates a mode resolver backed by a config provider.
+ *
+ * - Missing capability config → `not_configured`.
+ * - `service` mode selected while `serviceActivated` is false →
+ *   `mode_unavailable` (never a crash or silent fallback).
+ */
+export const createModeResolver = (options: {
+  getConfig: () => AiGatewayModeConfig;
+}): AiModeResolver => {
+  const { getConfig } = options;
+
+  return ({ capability, model }): AiModeResolution => {
+    const config = getConfig();
+    const entry = config[capability];
+
+    if (!entry) {
+      throw createAiGatewayError({
+        code: 'not_configured',
+        capability,
+        mode: 'offline',
+        message: `No ${capability} provider configured`,
+      });
+    }
+
+    if (entry.mode === 'service' && config.serviceActivated !== true) {
+      throw createAiGatewayError({
+        code: 'mode_unavailable',
+        capability,
+        mode: 'service',
+        provider: entry.provider,
+        message: `Service mode is not activated for capability "${capability}"`,
+      });
+    }
+
+    return {
+      capability,
+      mode: entry.mode,
+      provider: entry.provider,
+      endpoint: entry.endpoint,
+      model: model ?? entry.model,
+    };
+  };
+};

--- a/packages/frontend/ai-gateway/src/lib/sse.ts
+++ b/packages/frontend/ai-gateway/src/lib/sse.ts
@@ -1,0 +1,127 @@
+// packages/frontend/ai-gateway/src/lib/sse.ts
+//
+// Chat-completions SSE stream reader — relocated verbatim from the client's
+// text_generation_service (C-080/C-111) so streaming semantics (chunk
+// delivery order, first-chunk timeout, idle timeout) are identical.
+// Contract: C-320 AC-2
+
+/** Timeout for the entire fetch+stream operation (90 seconds). */
+export const GATEWAY_FETCH_TIMEOUT_MS = 90_000;
+
+/** Maximum time to wait for the first SSE chunk (15 seconds). */
+export const GATEWAY_FIRST_CHUNK_TIMEOUT_MS = 15_000;
+
+/**
+ * Timeout for individual SSE stream read operations after content has started
+ * flowing. Kept short (5s) to prevent inputs staying disabled when the
+ * provider delays the [DONE] signal after the last text chunk.
+ */
+export const GATEWAY_IDLE_TIMEOUT_MS = 5_000;
+
+/**
+ * Reads a chat completions SSE response stream.
+ *
+ * Each line is `data: {"id":"...","choices":[{"delta":{"content":"token"}}]}`.
+ * The stream ends with `data: [DONE]`.
+ */
+export const readChatSseStream = async (options: {
+  body: ReadableStream<Uint8Array>;
+  signal: AbortSignal;
+  onChunk: (text: string) => void;
+  firstChunkTimeoutMs?: number;
+  idleTimeoutMs?: number;
+  /** Optional debug hook, e.g. ('done', { chunkCount }). */
+  onEvent?: (event: string, data?: Record<string, unknown>) => void;
+}): Promise<void> => {
+  const {
+    body,
+    signal,
+    onChunk,
+    firstChunkTimeoutMs = GATEWAY_FIRST_CHUNK_TIMEOUT_MS,
+    idleTimeoutMs = GATEWAY_IDLE_TIMEOUT_MS,
+    onEvent,
+  } = options;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let chunkCount = 0;
+  let isFirstChunk = true;
+  let hasReceivedContent = false;
+
+  try {
+    while (true) {
+      if (signal.aborted) {
+        return;
+      }
+
+      const timeout = isFirstChunk
+        ? firstChunkTimeoutMs
+        : hasReceivedContent
+          ? idleTimeoutMs
+          : firstChunkTimeoutMs;
+      const result = await Promise.race([
+        reader.read(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Stream read timed out')), timeout),
+        ),
+      ]);
+      isFirstChunk = false;
+      const { value, done } = result;
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+          continue;
+        }
+
+        // Skip non-data lines
+        if (!trimmed.startsWith('data: ')) {
+          continue;
+        }
+
+        const data = trimmed.slice(6);
+
+        // End of stream signal
+        if (data === '[DONE]') {
+          onEvent?.('done', { chunkCount });
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(data) as {
+            choices?: Array<{
+              delta?: { content?: string };
+              // biome-ignore lint/style/useNamingConvention: OpenAI API contract field name
+              finish_reason?: string | null;
+            }>;
+          };
+
+          const choice = parsed.choices?.[0];
+          if (!choice) {
+            continue;
+          }
+
+          const token = choice.delta?.content;
+          if (token) {
+            hasReceivedContent = true;
+            onChunk(token);
+            chunkCount++;
+          }
+        } catch {
+          // Skip unparseable lines
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+};

--- a/packages/frontend/ai-gateway/src/lib/structured.ts
+++ b/packages/frontend/ai-gateway/src/lib/structured.ts
@@ -1,0 +1,176 @@
+// packages/frontend/ai-gateway/src/lib/structured.ts
+//
+// Structured-extraction helpers — schema compilation with strict
+// additionalProperties enforcement, JSON sanitization, and TypeBox
+// post-validation. Relocated from the client's text_generation_service.
+// Contract: C-320 AC-2
+
+import { schemaCheck } from '@aikami/schemas';
+
+/** Compiles TypeBox schemas into strict JSON Schema dictionaries with caching. */
+export type SchemaCompiler = {
+  compile(options: {
+    schema: Record<string, unknown>;
+    schemaName: string;
+  }): Record<string, unknown>;
+  /** Number of cached compiled schemas. */
+  readonly size: number;
+};
+
+/**
+ * Creates a schema compiler with an internal cache keyed by schema name.
+ *
+ * @param options.onCacheSize - Debug hook invoked with the cache size after
+ *   every compile (used to preserve legacy diagnostics globals).
+ */
+export const createSchemaCompiler = (options?: {
+  onCacheSize?: (size: number) => void;
+}): SchemaCompiler => {
+  const cache = new Map<string, Record<string, unknown>>();
+  const onCacheSize = options?.onCacheSize;
+
+  return {
+    get size(): number {
+      return cache.size;
+    },
+    compile({ schema, schemaName }): Record<string, unknown> {
+      const cached = cache.get(schemaName);
+      if (cached) {
+        onCacheSize?.(cache.size);
+        return cached;
+      }
+
+      const raw = enforceStrictSchema(JSON.parse(JSON.stringify(schema)));
+      const compiled = raw as Record<string, unknown>;
+      compiled.additionalProperties = false;
+
+      cache.set(schemaName, compiled);
+      onCacheSize?.(cache.size);
+      return compiled;
+    },
+  };
+};
+
+/**
+ * Recursively enforces `additionalProperties: false` on every object
+ * schema node in the JSON Schema tree.
+ */
+export const enforceStrictSchema = (node: unknown): unknown => {
+  if (node === null || typeof node !== 'object') {
+    return node;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  if (obj.type === 'object' || obj.properties !== undefined) {
+    obj.additionalProperties = false;
+
+    if (obj.properties && typeof obj.properties === 'object') {
+      for (const key of Object.keys(obj.properties as Record<string, unknown>)) {
+        (obj.properties as Record<string, unknown>)[key] = enforceStrictSchema(
+          (obj.properties as Record<string, unknown>)[key],
+        );
+      }
+    }
+  }
+
+  if (obj.type === 'array' && obj.items) {
+    if (Array.isArray(obj.items)) {
+      obj.items = (obj.items as unknown[]).map((item) => enforceStrictSchema(item));
+    } else {
+      obj.items = enforceStrictSchema(obj.items);
+    }
+  }
+
+  for (const combinator of ['allOf', 'anyOf', 'oneOf']) {
+    if (Array.isArray(obj[combinator])) {
+      obj[combinator] = (obj[combinator] as unknown[]).map((item) => enforceStrictSchema(item));
+    }
+  }
+
+  return obj;
+};
+
+/**
+ * Strips markdown fences and extracts the first JSON object/array from a
+ * string that may contain explanatory text. Throws when no balanced JSON
+ * value is found.
+ */
+export const sanitizeJsonResponse = (raw: string): string => {
+  let text = raw.trim();
+
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    text = fenceMatch[1].trim();
+  }
+
+  const objectStart = text.indexOf('{');
+  const arrayStart = text.indexOf('[');
+
+  let startIndex = objectStart;
+  if (objectStart === -1 || (arrayStart !== -1 && arrayStart < objectStart)) {
+    startIndex = arrayStart;
+  }
+
+  if (startIndex === -1) {
+    throw new Error('No JSON object found in response');
+  }
+
+  text = text.slice(startIndex);
+
+  let depth = 0;
+  const opener = text[0];
+  const closer = opener === '{' ? '}' : ']';
+  let inString = false;
+  let escapeNext = false;
+  let endIndex = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      escapeNext = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (ch === opener) {
+      depth++;
+    } else if (ch === closer) {
+      depth--;
+      if (depth === 0) {
+        endIndex = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (endIndex === -1) {
+    throw new Error('Unbalanced JSON in response');
+  }
+
+  return text.slice(0, endIndex);
+};
+
+/**
+ * Validates a parsed value against the original TypeBox schema.
+ * Returns false on mismatch — callers decide whether to warn; the value
+ * is still delivered (legacy lenient behavior).
+ */
+export const validateAgainstSchema = (options: {
+  schema: Record<string, unknown>;
+  parsed: unknown;
+}): boolean => schemaCheck(options.schema, options.parsed);

--- a/packages/frontend/ai-gateway/src/lib/text_adapter_openai_compatible.ts
+++ b/packages/frontend/ai-gateway/src/lib/text_adapter_openai_compatible.ts
@@ -1,0 +1,414 @@
+// packages/frontend/ai-gateway/src/lib/text_adapter_openai_compatible.ts
+//
+// OpenAI-compatible chat-completions text adapter. Serves both `offline`
+// (Ollama / Ooba / local OpenAI-compatible endpoints) and `byok`
+// (OpenRouter / OpenAI / Gemini / DeepSeek / custom) modes — the transport
+// is identical; endpoint, API key, and headers come from the resolution
+// and injected config.
+//
+// Relocated from apps/frontend/client text_generation_service internals.
+// Contract: C-320 AC-2
+
+import type { AiChatMessage, AiModeResolution } from '@aikami/types';
+import { createAiGatewayError, toAiGatewayError } from './errors.ts';
+import type { AiTextAdapter, AiTextGenerationResult } from './gateway_types.ts';
+import {
+  GATEWAY_FETCH_TIMEOUT_MS,
+  GATEWAY_FIRST_CHUNK_TIMEOUT_MS,
+  GATEWAY_IDLE_TIMEOUT_MS,
+  readChatSseStream,
+} from './sse.ts';
+import { createSchemaCompiler, sanitizeJsonResponse, validateAgainstSchema } from './structured.ts';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Provider requires these headers for ranking/attribution on free models (OpenRouter). */
+export const OPENROUTER_ATTRIBUTION_HEADERS = {
+  'HTTP-Referer': 'https://aikami.app',
+  'X-Title': 'Aikami',
+} as const;
+
+/** Well-known chat-completions base URLs for local providers. */
+export const DEFAULT_LOCAL_TEXT_ENDPOINTS: Record<string, string> = {
+  ollama: 'http://localhost:11434/v1',
+  ooba: 'http://localhost:5000/v1',
+} as const;
+
+/**
+ * Ollama VRAM-eviction payload params (C-056 lesson): release the model
+ * immediately after generation so image generation can claim VRAM.
+ * Mirrors OLLAMA_VRAM_EVICTION_PARAMS in @aikami/backend/ai — duplicated
+ * here because the backend package is not aliased in the client build.
+ */
+export const OLLAMA_VRAM_EVICTION_PARAMS = {
+  // biome-ignore lint/style/useNamingConvention: Ollama API contract field name
+  keep_alive: 0,
+  options: {
+    // biome-ignore lint/style/useNamingConvention: Ollama API contract field name
+    num_parallel: 1,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Configuration for the OpenAI-compatible text adapter. */
+export type OpenAiCompatibleTextAdapterOptions = {
+  /** Reads the API key for a provider (vault/config path). */
+  getApiKey?: (provider: string) => string | undefined;
+  /** Whether a provider supports native `response_format: json_schema`. */
+  supportsStructuredOutput?: (provider: string) => boolean;
+  /** Default chat base endpoint per provider, when the resolution has none. */
+  getDefaultEndpoint?: (provider: string) => string | undefined;
+  /** Extra headers per provider (merged after built-in OpenRouter headers). */
+  getExtraHeaders?: (provider: string) => Record<string, string> | undefined;
+  /** Debug hook — compiled-schema cache size after each compile. */
+  onSchemaCacheSize?: (size: number) => void;
+  /** Debug/log hook, e.g. ('streaming', {...}), ('fallback', {...}). */
+  onEvent?: (event: string, data?: Record<string, unknown>) => void;
+  /** Fetch injection for tests. Defaults to globalThis.fetch. */
+  fetchFn?: typeof fetch;
+  fetchTimeoutMs?: number;
+  firstChunkTimeoutMs?: number;
+  idleTimeoutMs?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the OpenAI-compatible chat-completions text adapter.
+ * Register the same instance for both `offline` and `byok` text modes.
+ */
+export const createOpenAiCompatibleTextAdapter = (
+  options?: OpenAiCompatibleTextAdapterOptions,
+): AiTextAdapter => {
+  const {
+    getApiKey,
+    supportsStructuredOutput,
+    getDefaultEndpoint,
+    getExtraHeaders,
+    onSchemaCacheSize,
+    onEvent,
+    fetchFn,
+    fetchTimeoutMs = GATEWAY_FETCH_TIMEOUT_MS,
+    firstChunkTimeoutMs = GATEWAY_FIRST_CHUNK_TIMEOUT_MS,
+    idleTimeoutMs = GATEWAY_IDLE_TIMEOUT_MS,
+  } = options ?? {};
+
+  const compiler = createSchemaCompiler({ onCacheSize: onSchemaCacheSize });
+
+  /** Resolves the chat completions URL for the resolution. */
+  const resolveChatUrl = (resolution: AiModeResolution): string => {
+    const endpoint =
+      resolution.endpoint && resolution.endpoint.length > 0
+        ? resolution.endpoint
+        : (getDefaultEndpoint?.(resolution.provider) ??
+          DEFAULT_LOCAL_TEXT_ENDPOINTS[resolution.provider]);
+
+    if (!endpoint) {
+      throw createAiGatewayError({
+        code: 'not_configured',
+        capability: 'text',
+        mode: resolution.mode,
+        provider: resolution.provider,
+        message:
+          `No endpoint configured for provider "${resolution.provider}". ` +
+          'Create a Connection in Settings or configure a provider endpoint.',
+      });
+    }
+
+    const base = endpoint.replace(/\/$/, '');
+    return base.endsWith('/chat/completions') ? base : `${base}/chat/completions`;
+  };
+
+  /** Builds request headers for the resolution. */
+  const buildHeaders = (resolution: AiModeResolution): Record<string, string> => {
+    const apiKey = getApiKey?.(resolution.provider);
+    return {
+      'Content-Type': 'application/json',
+      // biome-ignore lint/style/useNamingConvention: HTTP header field name
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      ...(resolution.provider === 'openrouter' ? OPENROUTER_ATTRIBUTION_HEADERS : {}),
+      ...(getExtraHeaders?.(resolution.provider) ?? {}),
+    };
+  };
+
+  /** Builds the chat completion body, preserving Ollama VRAM eviction. */
+  const buildBody = (options2: {
+    resolution: AiModeResolution;
+    messages: AiChatMessage[];
+  }): Record<string, unknown> => {
+    const { resolution, messages } = options2;
+    return {
+      model: resolution.model,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      stream: true,
+      ...(resolution.provider === 'ollama' ? OLLAMA_VRAM_EVICTION_PARAMS : {}),
+    };
+  };
+
+  /** Performs the streaming fetch and reads the SSE body. */
+  const streamCompletion = async (options2: {
+    resolution: AiModeResolution;
+    body: Record<string, unknown>;
+    requestSignal: AbortSignal;
+  }): Promise<Response> => {
+    const { resolution, body, requestSignal } = options2;
+    const doFetch = fetchFn ?? globalThis.fetch;
+    const chatUrl = resolveChatUrl(resolution);
+
+    return doFetch(chatUrl, {
+      method: 'POST',
+      headers: buildHeaders(resolution),
+      body: JSON.stringify(body),
+      signal: requestSignal,
+    });
+  };
+
+  /**
+   * Runs a request scope with a controller linked to the caller signal for
+   * the WHOLE request lifetime (fetch + SSE read) plus the overall fetch
+   * timeout. Client disconnect must abort the upstream stream immediately
+   * (C-056 VRAM lesson).
+   */
+  const withRequestScope = async <T>(options2: {
+    signal: AbortSignal;
+    run: (requestSignal: AbortSignal) => Promise<T>;
+  }): Promise<T> => {
+    const { signal, run } = options2;
+    const requestController = new AbortController();
+    const onAbort = (): void => requestController.abort(signal.reason);
+    if (signal.aborted) {
+      requestController.abort(signal.reason);
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+    const timeoutId = setTimeout(
+      () => requestController.abort(new Error('Fetch timed out')),
+      fetchTimeoutMs,
+    );
+    try {
+      return await run(requestController.signal);
+    } finally {
+      clearTimeout(timeoutId);
+      signal.removeEventListener('abort', onAbort);
+    }
+  };
+
+  /** Streams a plain chat completion, accumulating text. */
+  const generatePlain = async (options2: {
+    resolution: AiModeResolution;
+    messages: AiChatMessage[];
+    signal: AbortSignal;
+    onChunk?: (text: string) => void;
+  }): Promise<AiTextGenerationResult> => {
+    const { resolution, messages, signal, onChunk } = options2;
+
+    let accumulated = '';
+    const deliver = (text: string): void => {
+      accumulated += text;
+      onChunk?.(text);
+    };
+
+    const body = buildBody({ resolution, messages });
+
+    await withRequestScope({
+      signal,
+      run: async (requestSignal) => {
+        const response = await streamCompletion({ resolution, body, requestSignal });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => 'Unknown error');
+          onEvent?.('fetch-failed', { status: response.status });
+          throw new Error(`Provider HTTP ${response.status}: ${errorText}`);
+        }
+
+        if (!response.body) {
+          throw new Error(`No response body from provider "${resolution.provider}"`);
+        }
+
+        await readChatSseStream({
+          body: response.body,
+          signal: requestSignal,
+          onChunk: deliver,
+          firstChunkTimeoutMs,
+          idleTimeoutMs,
+          onEvent,
+        });
+      },
+    });
+
+    return { text: accumulated };
+  };
+
+  /** Structured extraction with native response_format + system-prompt fallback. */
+  const generateStructured = async (options2: {
+    resolution: AiModeResolution;
+    messages: AiChatMessage[];
+    schema: Record<string, unknown>;
+    schemaName: string;
+    signal: AbortSignal;
+    onChunk?: (text: string) => void;
+  }): Promise<AiTextGenerationResult> => {
+    const { resolution, messages, schema, schemaName, signal, onChunk } = options2;
+
+    const compiledSchema = compiler.compile({ schema, schemaName });
+
+    const schemaInstruction = [
+      'You are a structured data extraction tool.',
+      'Your response MUST be valid JSON that conforms to the following JSON Schema:',
+      '```json',
+      JSON.stringify(compiledSchema, null, 2),
+      '```',
+      'Respond ONLY with the JSON object. No markdown fences, no explanations.',
+      'Do not include any properties not defined in the schema.',
+    ].join('\n');
+
+    // Insert the schema instruction before the final user message,
+    // preserving any caller-provided system prompt ordering.
+    const structuredMessages: AiChatMessage[] = [
+      ...messages.slice(0, -1),
+      { role: 'system', content: schemaInstruction },
+      ...messages.slice(-1),
+    ];
+
+    const providerSupportsStructured = supportsStructuredOutput?.(resolution.provider) ?? false;
+
+    const body = buildBody({ resolution, messages: structuredMessages });
+
+    // Only send response_format for providers that support OpenAI-compatible
+    // structured output. Local providers (Ollama, Ooba) ignore it and return
+    // plain text.
+    if (providerSupportsStructured) {
+      body.response_format = {
+        type: 'json_schema',
+        // biome-ignore lint/style/useNamingConvention: OpenAI API contract field name
+        json_schema: {
+          name: schemaName,
+          schema: compiledSchema,
+          strict: true,
+        },
+      };
+    }
+
+    let accumulated = '';
+    const deliver = (text: string): void => {
+      accumulated += text;
+      onChunk?.(text);
+    };
+
+    const outcome = await withRequestScope({
+      signal,
+      run: async (requestSignal): Promise<{ fallback: 'http-400' } | { fallback?: undefined }> => {
+        const response = await streamCompletion({ resolution, body, requestSignal });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => 'Unknown error');
+          onEvent?.('fetch-failed', { status: response.status });
+
+          // Provider rejected structured output — fall back to the
+          // system-prompt approach via a plain streaming completion.
+          if (response.status === 400) {
+            return { fallback: 'http-400' };
+          }
+
+          throw new Error(`Provider HTTP ${response.status}: ${errorText}`);
+        }
+
+        if (!response.body) {
+          throw new Error(`No response body from provider "${resolution.provider}"`);
+        }
+
+        await readChatSseStream({
+          body: response.body,
+          signal: requestSignal,
+          onChunk: deliver,
+          firstChunkTimeoutMs,
+          idleTimeoutMs,
+          onEvent,
+        });
+        return {};
+      },
+    });
+
+    if (outcome.fallback === 'http-400') {
+      onEvent?.('structured-fallback', { reason: 'http-400' });
+      const fallback = await generatePlain({
+        resolution,
+        messages: structuredMessages,
+        signal,
+      });
+      return parseStructured({ accumulated: fallback.text, schema, schemaName });
+    }
+
+    try {
+      return parseStructured({ accumulated, schema, schemaName });
+    } catch (parseError) {
+      // Provider returned 200 but the output wasn't valid JSON — likely a
+      // provider that doesn't support structured output. Fall back to the
+      // system-prompt approach via a plain streaming completion.
+      onEvent?.('structured-fallback', { reason: String(parseError) });
+      const fallback = await generatePlain({ resolution, messages: structuredMessages, signal });
+      return parseStructured({ accumulated: fallback.text, schema, schemaName });
+    }
+  };
+
+  /** Parses + validates accumulated structured output. */
+  const parseStructured = (options2: {
+    accumulated: string;
+    schema: Record<string, unknown>;
+    schemaName: string;
+  }): AiTextGenerationResult => {
+    const { accumulated, schema, schemaName } = options2;
+    const cleaned = sanitizeJsonResponse(accumulated);
+    const parsed = JSON.parse(cleaned);
+    const isValid = validateAgainstSchema({ schema, parsed });
+    if (!isValid) {
+      onEvent?.('validation-failed', { schemaName });
+    }
+    return { text: accumulated, structured: parsed };
+  };
+
+  return {
+    provider: 'openai_compatible',
+    async generateText(request): Promise<AiTextGenerationResult> {
+      const { resolution, signal, messages, onChunk, schema, schemaName } = request;
+
+      if (signal.aborted) {
+        throw createAiGatewayError({
+          code: 'cancelled',
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+          message: 'Aborted',
+        });
+      }
+
+      try {
+        if (schema && schemaName) {
+          return await generateStructured({
+            resolution,
+            messages,
+            schema,
+            schemaName,
+            signal,
+            onChunk,
+          });
+        }
+        return await generatePlain({ resolution, messages, signal, onChunk });
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      }
+    },
+  };
+};

--- a/packages/frontend/ai-gateway/src/lib/text_adapter_service.ts
+++ b/packages/frontend/ai-gateway/src/lib/text_adapter_service.ts
@@ -1,0 +1,157 @@
+// packages/frontend/ai-gateway/src/lib/text_adapter_service.ts
+//
+// `service`-mode text adapters. The real adapter wraps the Aikami-hosted
+// callable endpoint (Firebase `ai` function today); the stub adapter is a
+// deterministic in-memory implementation for tests and pre-activation
+// wiring. No billing/metering — that is a Phase 5 contract.
+// Contract: C-320 AC-4
+
+import type { AiChatMessage } from '@aikami/types';
+import { createAiGatewayError, toAiGatewayError } from './errors.ts';
+import type { AiTextAdapter, AiTextGenerationResult } from './gateway_types.ts';
+
+/** Shape of the hosted AI callable (matches the Firebase `ai` function). */
+export type ServiceTextCallable = (data: {
+  type: string;
+  payload: Record<string, unknown>;
+}) => Promise<Record<string, unknown>>;
+
+/** Returns the content of the last user message, or ''. */
+const lastUserContent = (messages: AiChatMessage[]): string => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') {
+      return messages[i].content;
+    }
+  }
+  return '';
+};
+
+/**
+ * Creates the `service`-mode text adapter over the hosted callable.
+ *
+ * Request mapping (preserves legacy `ai_service` behavior):
+ * - schema/schemaName present → `createPersona` callable; the parsed persona
+ *   is returned as `structured`.
+ * - otherwise → `sendMessage` callable with an empty context (legacy calls
+ *   always sent an empty history).
+ */
+export const createServiceTextAdapter = (options: { call: ServiceTextCallable }): AiTextAdapter => {
+  const { call } = options;
+
+  return {
+    provider: 'aikami_service',
+    async generateText(request): Promise<AiTextGenerationResult> {
+      const { resolution, signal, messages, schemaName, onChunk } = request;
+
+      if (signal.aborted) {
+        throw createAiGatewayError({
+          code: 'cancelled',
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+          message: 'Aborted',
+        });
+      }
+
+      try {
+        if (schemaName) {
+          const response = await call({
+            type: 'createPersona',
+            payload: { prompt: lastUserContent(messages) },
+          });
+          return { text: '', structured: response.persona };
+        }
+
+        const response = await call({
+          type: 'sendMessage',
+          payload: {
+            text: lastUserContent(messages),
+            context: { messages: [] },
+          },
+        });
+        const text = typeof response.text === 'string' ? response.text : '';
+        if (text.length > 0) {
+          onChunk?.(text);
+        }
+        return { text };
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      }
+    },
+  };
+};
+
+/** Options for the deterministic service stub. */
+export type ServiceStubTextAdapterOptions = {
+  /** Chunks emitted in order via onChunk. */
+  chunks?: string[];
+  /** Structured object returned when a schema is requested. */
+  structured?: unknown;
+  /** When set, every call fails with this normalized code. */
+  failWith?: 'provider_unreachable' | 'rate_limited' | 'timeout' | 'invalid_response';
+};
+
+/**
+ * Deterministic `service`-mode stub adapter. Emits fixed chunks in order,
+ * honors AbortSignal, and fails with typed gateway errors on demand — used
+ * by the shared adapter-contract test suite.
+ */
+export const createServiceStubTextAdapter = (
+  options?: ServiceStubTextAdapterOptions,
+): AiTextAdapter => {
+  const { chunks = ['Hello', ' from', ' the', ' stub'], structured, failWith } = options ?? {};
+
+  return {
+    provider: 'aikami_service_stub',
+    async generateText(request): Promise<AiTextGenerationResult> {
+      const { resolution, signal, schema, onChunk } = request;
+
+      if (signal.aborted) {
+        throw createAiGatewayError({
+          code: 'cancelled',
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+          message: 'Aborted',
+        });
+      }
+
+      if (failWith) {
+        throw createAiGatewayError({
+          code: failWith,
+          capability: 'text',
+          mode: resolution.mode,
+          provider: resolution.provider,
+          message: `Stub failure: ${failWith}`,
+        });
+      }
+
+      let accumulated = '';
+      for (const chunk of chunks) {
+        // Yield between chunks so cancellation can interleave deterministically.
+        await Promise.resolve();
+        if (signal.aborted) {
+          throw createAiGatewayError({
+            code: 'cancelled',
+            capability: 'text',
+            mode: resolution.mode,
+            provider: resolution.provider,
+            message: 'Aborted',
+          });
+        }
+        accumulated += chunk;
+        onChunk?.(chunk);
+      }
+
+      if (schema) {
+        return { text: accumulated, structured: structured ?? {} };
+      }
+      return { text: accumulated };
+    },
+  };
+};

--- a/packages/frontend/ai-gateway/src/lib/voice_adapter.ts
+++ b/packages/frontend/ai-gateway/src/lib/voice_adapter.ts
@@ -1,0 +1,63 @@
+// packages/frontend/ai-gateway/src/lib/voice_adapter.ts
+//
+// Delegating voice adapter — wraps the existing Kokoro TTS path
+// (tts_service) unchanged, including its internal WebGPU-worker vs REST
+// engine selection. The gateway never re-implements engine choice.
+// Contract: C-320 AC-3
+
+import { createAiGatewayError, toAiGatewayError } from './errors.ts';
+import type { AiVoiceAdapter, AiVoiceGenerationResult } from './gateway_types.ts';
+import { raceWithAbort } from './image_adapter.ts';
+
+/**
+ * Creates a voice adapter that delegates to an existing synthesizer.
+ * The current Kokoro delegation plays audio through the client's audio
+ * pipeline and returns no raw buffer — `audio` is therefore optional.
+ */
+export const createDelegatingVoiceAdapter = (options: {
+  /** Existing synthesis entry point (e.g. ttsService.speak). */
+  synthesize: (options: {
+    text: string;
+    voiceId?: string;
+  }) => Promise<{ audio?: ArrayBuffer | ReadableStream<Uint8Array> } | undefined>;
+  /** Provider label for resolutions/errors. Defaults to 'kokoro'. */
+  provider?: string;
+}): AiVoiceAdapter => {
+  const { synthesize, provider = 'kokoro' } = options;
+
+  return {
+    provider,
+    async generateVoice(request): Promise<AiVoiceGenerationResult> {
+      const { resolution, signal, text, voiceId } = request;
+
+      const cancelledError = (): Error =>
+        createAiGatewayError({
+          code: 'cancelled',
+          capability: 'voice',
+          mode: resolution.mode,
+          provider: resolution.provider,
+          message: 'Aborted',
+        });
+
+      if (signal.aborted) {
+        throw cancelledError();
+      }
+
+      try {
+        const result = await raceWithAbort({
+          promise: Promise.resolve(synthesize({ text, voiceId })),
+          signal,
+          onAbort: cancelledError,
+        });
+        return { audio: result?.audio };
+      } catch (error) {
+        throw toAiGatewayError({
+          error,
+          capability: 'voice',
+          mode: resolution.mode,
+          provider: resolution.provider,
+        });
+      }
+    },
+  };
+};

--- a/packages/frontend/ai-gateway/tests/adapter_contract.test.ts
+++ b/packages/frontend/ai-gateway/tests/adapter_contract.test.ts
@@ -1,0 +1,339 @@
+// packages/frontend/ai-gateway/tests/adapter_contract.test.ts
+//
+// AC-4 (C-320): shared adapter-contract suite. Every registered adapter —
+// offline text, byok text, service stub text, image, voice — must surface
+// failures exclusively as AiGatewayException, honor AbortSignal with
+// 'cancelled', and never crash with raw errors. Also covers the service
+// mode_unavailable guard at resolution and dispatch.
+
+import { describe, expect, test } from 'bun:test';
+import type { AiModeResolution } from '@aikami/types';
+import {
+  createAdapterRegistry,
+  createAiProviderGateway,
+  createDelegatingImageAdapter,
+  createDelegatingVoiceAdapter,
+  createModeResolver,
+  createOpenAiCompatibleTextAdapter,
+  createServiceStubTextAdapter,
+  isAiGatewayError,
+} from '../src/index.ts';
+import { createSseFetchMock, mixedModeConfig } from './helpers.ts';
+
+const textResolution: AiModeResolution = {
+  capability: 'text',
+  mode: 'offline',
+  provider: 'ollama',
+  endpoint: 'http://localhost:11434/v1',
+  model: 'llama3',
+};
+
+const abortedSignal = (): AbortSignal => {
+  const controller = new AbortController();
+  controller.abort();
+  return controller.signal;
+};
+
+// ---------------------------------------------------------------------------
+// Shared contract: every adapter normalizes failures to AiGatewayException
+// ---------------------------------------------------------------------------
+
+describe('Adapter contract — uniform AiGatewayError surface', () => {
+  const failingFetch = (() =>
+    Promise.reject(new TypeError('fetch failed'))) as unknown as typeof fetch;
+
+  type ContractCase = {
+    name: string;
+    run: (signal: AbortSignal) => Promise<unknown>;
+  };
+
+  const cases: ContractCase[] = [
+    {
+      name: 'openai-compatible text adapter (offline)',
+      run: (signal) =>
+        createOpenAiCompatibleTextAdapter({ fetchFn: failingFetch }).generateText({
+          resolution: textResolution,
+          signal,
+          messages: [{ role: 'user', content: 'Hi' }],
+        }),
+    },
+    {
+      name: 'openai-compatible text adapter (byok)',
+      run: (signal) =>
+        createOpenAiCompatibleTextAdapter({ fetchFn: failingFetch }).generateText({
+          resolution: { ...textResolution, mode: 'byok', provider: 'openrouter' },
+          signal,
+          messages: [{ role: 'user', content: 'Hi' }],
+        }),
+    },
+    {
+      name: 'service stub text adapter',
+      run: (signal) =>
+        createServiceStubTextAdapter({ failWith: 'provider_unreachable' }).generateText({
+          resolution: { ...textResolution, mode: 'service', provider: 'aikami_service_stub' },
+          signal,
+          messages: [{ role: 'user', content: 'Hi' }],
+        }),
+    },
+    {
+      name: 'image adapter',
+      run: (signal) =>
+        createDelegatingImageAdapter({
+          generate: () => Promise.reject(new Error('ComfyUI API error (500): boom')),
+        }).generateImage({
+          resolution: { capability: 'image', mode: 'offline', provider: 'comfyui' },
+          signal,
+          prompt: 'a castle',
+        }),
+    },
+    {
+      name: 'voice adapter',
+      run: (signal) =>
+        createDelegatingVoiceAdapter({
+          synthesize: () => Promise.reject(new Error('Kokoro server unreachable')),
+        }).generateVoice({
+          resolution: { capability: 'voice', mode: 'offline', provider: 'kokoro' },
+          signal,
+          text: 'Hello',
+        }),
+    },
+  ];
+
+  for (const contractCase of cases) {
+    test(`${contractCase.name} — failure surfaces as AiGatewayException`, async () => {
+      const controller = new AbortController();
+      try {
+        await contractCase.run(controller.signal);
+        throw new Error('expected rejection');
+      } catch (error) {
+        expect(isAiGatewayError(error)).toBe(true);
+        if (isAiGatewayError(error)) {
+          expect(error.capability).toBeDefined();
+          expect(error.mode).toBeDefined();
+          expect(typeof error.retryable).toBe('boolean');
+          expect(error.message.length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    test(`${contractCase.name} — pre-aborted signal yields 'cancelled'`, async () => {
+      try {
+        await contractCase.run(abortedSignal());
+        throw new Error('expected rejection');
+      } catch (error) {
+        expect(isAiGatewayError(error)).toBe(true);
+        if (isAiGatewayError(error)) {
+          expect(error.code).toBe('cancelled');
+          expect(error.retryable).toBe(false);
+        }
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Stub adapter passes the same happy-path contract as real adapters
+// ---------------------------------------------------------------------------
+
+describe('Service stub adapter — deterministic behavior', () => {
+  test('emits chunks in order and returns accumulated text', async () => {
+    const adapter = createServiceStubTextAdapter({ chunks: ['A', 'B', 'C'] });
+    const received: string[] = [];
+    const controller = new AbortController();
+
+    const result = await adapter.generateText({
+      resolution: { capability: 'text', mode: 'service', provider: 'aikami_service_stub' },
+      signal: controller.signal,
+      messages: [{ role: 'user', content: 'Hi' }],
+      onChunk: (text) => received.push(text),
+    });
+
+    expect(received).toEqual(['A', 'B', 'C']);
+    expect(result.text).toBe('ABC');
+  });
+
+  test('returns structured payload when a schema is requested', async () => {
+    const adapter = createServiceStubTextAdapter({ structured: { name: 'Stub' } });
+    const controller = new AbortController();
+
+    const result = await adapter.generateText({
+      resolution: { capability: 'text', mode: 'service', provider: 'aikami_service_stub' },
+      signal: controller.signal,
+      messages: [{ role: 'user', content: 'Hi' }],
+      schema: { type: 'object', properties: { name: { type: 'string' } } },
+      schemaName: 'StubSchema',
+    });
+
+    expect(result.structured).toEqual({ name: 'Stub' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service mode guard (mode_unavailable) at resolution and dispatch
+// ---------------------------------------------------------------------------
+
+describe('Service mode guard — mode_unavailable', () => {
+  test('resolveMode throws mode_unavailable when service is not activated', () => {
+    const resolver = createModeResolver({
+      getConfig: () => ({
+        text: { mode: 'service', provider: 'aikami_service' },
+        serviceActivated: false,
+      }),
+    });
+
+    try {
+      resolver({ capability: 'text' });
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('mode_unavailable');
+        expect(error.mode).toBe('service');
+      }
+    }
+  });
+
+  test('resolveMode succeeds when service is activated', () => {
+    const resolver = createModeResolver({
+      getConfig: () => ({
+        text: { mode: 'service', provider: 'aikami_service' },
+        serviceActivated: true,
+      }),
+    });
+
+    const resolution = resolver({ capability: 'text' });
+    expect(resolution.mode).toBe('service');
+    expect(resolution.provider).toBe('aikami_service');
+  });
+
+  test('explicit service-mode dispatch with no registered adapter throws mode_unavailable', async () => {
+    const registry = createAdapterRegistry();
+    const gateway = createAiProviderGateway({
+      registry,
+      resolveMode: createModeResolver({ getConfig: mixedModeConfig }),
+    });
+
+    try {
+      await gateway.generateText({
+        messages: [{ role: 'user', content: 'Hi' }],
+        mode: 'service',
+      });
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('mode_unavailable');
+      }
+    }
+  });
+
+  test('unconfigured capability resolves to not_configured', () => {
+    const resolver = createModeResolver({ getConfig: () => ({}) });
+    try {
+      resolver({ capability: 'image' });
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('not_configured');
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gateway-level dispatch: mixed modes per capability + cancelAll
+// ---------------------------------------------------------------------------
+
+describe('Gateway dispatch — mixed-mode resolution and cancellation', () => {
+  test('mixed modes: text offline + image byok resolve independently', async () => {
+    const registry = createAdapterRegistry();
+    const { fetchFn } = createSseFetchMock();
+    registry.registerText({
+      mode: 'offline',
+      adapter: createOpenAiCompatibleTextAdapter({ fetchFn }),
+    });
+    registry.registerImage({
+      mode: 'byok',
+      adapter: createDelegatingImageAdapter({
+        generate: () => Promise.resolve({ url: 'blob:image' }),
+      }),
+    });
+
+    const dispatched: AiModeResolution[] = [];
+    const gateway = createAiProviderGateway({
+      registry,
+      resolveMode: createModeResolver({ getConfig: mixedModeConfig }),
+      onDispatch: (resolution) => dispatched.push(resolution),
+    });
+
+    const textResult = await gateway.generateText({
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+    const imageResult = await gateway.generateImage({ prompt: 'a castle' });
+
+    expect(textResult.text.length).toBeGreaterThan(0);
+    expect(imageResult.url).toBe('blob:image');
+    expect(dispatched[0].mode).toBe('offline');
+    expect(dispatched[0].capability).toBe('text');
+    expect(dispatched[1].mode).toBe('byok');
+    expect(dispatched[1].capability).toBe('image');
+  });
+
+  test('resolution is exposed exactly once per call via onResolve', async () => {
+    const registry = createAdapterRegistry();
+    const { fetchFn } = createSseFetchMock();
+    registry.registerText({
+      mode: 'offline',
+      adapter: createOpenAiCompatibleTextAdapter({ fetchFn }),
+    });
+
+    const gateway = createAiProviderGateway({
+      registry,
+      resolveMode: createModeResolver({ getConfig: mixedModeConfig }),
+    });
+
+    const resolutions: AiModeResolution[] = [];
+    await gateway.generateText({
+      messages: [{ role: 'user', content: 'Hi' }],
+      onResolve: (resolution) => resolutions.push(resolution),
+    });
+
+    expect(resolutions).toHaveLength(1);
+    expect(resolutions[0].provider).toBe('ollama');
+  });
+
+  test('cancelAll aborts in-flight calls with cancelled errors', async () => {
+    const registry = createAdapterRegistry();
+    // A fetch that never resolves until aborted.
+    const hangingFetch = ((_input: unknown, init?: RequestInit): Promise<Response> =>
+      new Promise((_, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError')),
+        );
+      })) as typeof fetch;
+    registry.registerText({
+      mode: 'offline',
+      adapter: createOpenAiCompatibleTextAdapter({ fetchFn: hangingFetch }),
+    });
+
+    const gateway = createAiProviderGateway({
+      registry,
+      resolveMode: createModeResolver({ getConfig: mixedModeConfig }),
+    });
+
+    const pending = gateway.generateText({ messages: [{ role: 'user', content: 'Hi' }] });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    gateway.cancelAll();
+
+    try {
+      await pending;
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('cancelled');
+      }
+    }
+  });
+});

--- a/packages/frontend/ai-gateway/tests/detection.test.ts
+++ b/packages/frontend/ai-gateway/tests/detection.test.ts
@@ -1,0 +1,233 @@
+// packages/frontend/ai-gateway/tests/detection.test.ts
+//
+// AC-5 (C-320): detection parity with capability_service — Ollama proxy
+// ping with native fallback under one shared deadline, cloud config check,
+// ComfyUI ping, Kokoro engine status — all within the 3s budget and
+// convertible to the existing DetectionStatus union.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  createAdapterRegistry,
+  createAiProviderGateway,
+  createModeResolver,
+  detectImageAvailability,
+  detectTextAvailability,
+  detectVoiceAvailability,
+  toDetectionStatus,
+} from '../src/index.ts';
+import { mixedModeConfig } from './helpers.ts';
+
+/** Builds a fetch mock keyed by URL substring → responder. */
+const routedFetch = (
+  routes: Array<{ match: string; respond: () => Promise<Response> }>,
+): typeof fetch =>
+  ((input: string | URL | Request): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    for (const route of routes) {
+      if (url.includes(route.match)) {
+        return route.respond();
+      }
+    }
+    return Promise.reject(new TypeError('fetch failed'));
+  }) as typeof fetch;
+
+describe('detectTextAvailability — parity with capability_service.detectText', () => {
+  test('cloud config present → available via byok → DetectionStatus configured', async () => {
+    const result = await detectTextAvailability({
+      hasCloudConfig: () => true,
+      fetchFn: routedFetch([]),
+    });
+
+    expect(result.available).toBe(true);
+    expect(result.mode).toBe('byok');
+    expect(toDetectionStatus(result)).toBe('configured');
+  });
+
+  test('Ollama proxy responds → detected', async () => {
+    const result = await detectTextAvailability({
+      fetchFn: routedFetch([
+        {
+          match: '/api/text/',
+          respond: () => Promise.resolve(new Response('ok', { status: 200 })),
+        },
+      ]),
+    });
+
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe('ollama');
+    expect(toDetectionStatus(result)).toBe('detected');
+  });
+
+  test('proxy fails, native tags responds → detected (fallback path)', async () => {
+    const result = await detectTextAvailability({
+      fetchFn: routedFetch([
+        {
+          match: '11434/api/tags',
+          respond: () =>
+            Promise.resolve(
+              new Response(JSON.stringify({ models: [{ name: 'llama3' }] }), { status: 200 }),
+            ),
+        },
+      ]),
+    });
+
+    expect(result.available).toBe(true);
+    expect(result.detail).toContain('natively');
+    expect(toDetectionStatus(result)).toBe('detected');
+  });
+
+  test('nothing reachable and no config → not_found within the 3s budget', async () => {
+    const start = Date.now();
+    const result = await detectTextAvailability({
+      hasCloudConfig: () => false,
+      fetchFn: routedFetch([]),
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.available).toBe(false);
+    expect(toDetectionStatus(result)).toBe('not_found');
+    expect(elapsed).toBeLessThan(3_000);
+  });
+
+  test('hanging pings respect the shared aggregate deadline', async () => {
+    const hangingFetch = (() => new Promise<Response>(() => {})) as unknown as typeof fetch;
+    const start = Date.now();
+    const result = await detectTextAvailability({ fetchFn: hangingFetch, timeoutMs: 300 });
+    const elapsed = Date.now() - start;
+
+    expect(result.available).toBe(false);
+    expect(elapsed).toBeLessThan(1_500);
+  });
+
+  test('vault read failure degrades to local pings, not a crash', async () => {
+    const result = await detectTextAvailability({
+      hasCloudConfig: () => {
+        throw new Error('vault fingerprint mismatch');
+      },
+      fetchFn: routedFetch([
+        {
+          match: '/api/text/',
+          respond: () => Promise.resolve(new Response('ok', { status: 200 })),
+        },
+      ]),
+    });
+
+    expect(result.available).toBe(true);
+    expect(toDetectionStatus(result)).toBe('detected');
+  });
+});
+
+describe('detectImageAvailability — parity with capability_service.detectImage', () => {
+  test('configured provider → configured', async () => {
+    const result = await detectImageAvailability({
+      hasConfiguredProvider: () => true,
+      fetchFn: routedFetch([]),
+    });
+
+    expect(result.available).toBe(true);
+    expect(toDetectionStatus(result)).toBe('configured');
+  });
+
+  test('ComfyUI object_info responds → detected', async () => {
+    const result = await detectImageAvailability({
+      fetchFn: routedFetch([
+        {
+          match: 'object_info',
+          respond: () => Promise.resolve(new Response('{}', { status: 200 })),
+        },
+      ]),
+    });
+
+    expect(result.available).toBe(true);
+    expect(result.provider).toBe('comfyui');
+    expect(toDetectionStatus(result)).toBe('detected');
+  });
+
+  test('ComfyUI unreachable → not_found', async () => {
+    const result = await detectImageAvailability({ fetchFn: routedFetch([]) });
+
+    expect(result.available).toBe(false);
+    expect(toDetectionStatus(result)).toBe('not_found');
+  });
+});
+
+describe('detectVoiceAvailability — real engine status, optimistic-convertible', () => {
+  test('uninitialized WebGPU engine remains available (legacy optimistic snapshot)', async () => {
+    const result = await detectVoiceAvailability({
+      getEngineStatus: () => ({ status: 'uninitialized', serverAvailable: false }),
+    });
+
+    expect(result.available).toBe(true);
+    expect(toDetectionStatus(result)).toBe('detected');
+  });
+
+  test('Kokoro REST server detected is reflected in detail', async () => {
+    const result = await detectVoiceAvailability({
+      getEngineStatus: () => ({ status: 'ready', serverAvailable: true }),
+    });
+
+    expect(result.available).toBe(true);
+    expect(result.detail).toContain('REST server');
+  });
+
+  test('engine error reports unavailable', async () => {
+    const result = await detectVoiceAvailability({
+      getEngineStatus: () => ({ status: 'error', serverAvailable: false }),
+    });
+
+    expect(result.available).toBe(false);
+    expect(toDetectionStatus(result)).toBe('not_found');
+  });
+});
+
+describe('gateway.detect — bounded, independent, never throws', () => {
+  test('capability checks run independently and a hanging detector times out', async () => {
+    const registry = createAdapterRegistry();
+    const gateway = createAiProviderGateway({
+      registry,
+      resolveMode: createModeResolver({ getConfig: mixedModeConfig }),
+      detectionTimeoutMs: 200,
+      detectors: {
+        text: () => new Promise(() => {}),
+        image: () =>
+          Promise.resolve({
+            capability: 'image',
+            available: true,
+            mode: 'offline',
+            provider: 'comfyui',
+            checkedAt: new Date().toISOString(),
+          }),
+      },
+    });
+
+    const start = Date.now();
+    const [textResult, imageResult, voiceResult] = await Promise.all([
+      gateway.detect('text'),
+      gateway.detect('image'),
+      gateway.detect('voice'),
+    ]);
+    const elapsed = Date.now() - start;
+
+    expect(textResult.available).toBe(false);
+    expect(textResult.detail).toBe('Detection timed out');
+    expect(imageResult.available).toBe(true);
+    expect(voiceResult.available).toBe(false);
+    expect(voiceResult.detail).toBe('No detector registered');
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test('a throwing detector yields an unavailable result, not a crash', async () => {
+    const registry = createAdapterRegistry();
+    const gateway = createAiProviderGateway({
+      registry,
+      resolveMode: createModeResolver({ getConfig: mixedModeConfig }),
+      detectors: {
+        text: () => Promise.reject(new Error('boom')),
+      },
+    });
+
+    const result = await gateway.detect('text');
+    expect(result.available).toBe(false);
+    expect(result.detail).toContain('boom');
+  });
+});

--- a/packages/frontend/ai-gateway/tests/helpers.ts
+++ b/packages/frontend/ai-gateway/tests/helpers.ts
@@ -1,0 +1,87 @@
+// packages/frontend/ai-gateway/tests/helpers.ts
+//
+// Test helpers — synthetic SSE streams and fetch mocks for deterministic
+// adapter tests (mirrors the SyntheticSseMock approach from C-056).
+
+import type { AiGatewayModeConfig } from '@aikami/types';
+
+/** Builds an OpenAI-compatible SSE data line for a token. */
+export const sseChunk = (text: string): string =>
+  `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`;
+
+/** SSE end-of-stream signal. */
+export const SSE_DONE = 'data: [DONE]\n\n';
+
+/** Creates a ReadableStream that emits the given SSE lines then closes. */
+export const syntheticSseBody = (chunks: string[]): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller): void {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+};
+
+/** Record of a captured fetch call. */
+export type CapturedFetch = {
+  url: string;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+  signal: AbortSignal | undefined;
+};
+
+/**
+ * Creates a mock fetch that returns a synthetic SSE response and records
+ * every call.
+ */
+export const createSseFetchMock = (options?: {
+  chunks?: string[];
+  status?: number;
+  statusBody?: string;
+}): { fetchFn: typeof fetch; calls: CapturedFetch[] } => {
+  const { chunks = [sseChunk('Hello'), SSE_DONE], status = 200, statusBody = '' } = options ?? {};
+  const calls: CapturedFetch[] = [];
+
+  const fetchFn = ((input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    let body: Record<string, unknown> = {};
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        // ignore
+      }
+    }
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [key, value] of Object.entries(init.headers as Record<string, string>)) {
+        headers[key] = value;
+      }
+    }
+    calls.push({ url, body, headers, signal: init?.signal ?? undefined });
+
+    if (status !== 200) {
+      return Promise.resolve(new Response(statusBody, { status }));
+    }
+
+    return Promise.resolve(
+      new Response(syntheticSseBody(chunks), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+  }) as typeof fetch;
+
+  return { fetchFn, calls };
+};
+
+/** A mixed-mode gateway config fixture: text offline + image byok + voice offline. */
+export const mixedModeConfig = (): AiGatewayModeConfig => ({
+  text: { mode: 'offline', provider: 'ollama', model: 'llama3' },
+  image: { mode: 'byok', provider: 'comfyui', endpoint: 'https://images.example.com' },
+  voice: { mode: 'offline', provider: 'kokoro' },
+  serviceActivated: false,
+});

--- a/packages/frontend/ai-gateway/tests/image_voice_adapters.test.ts
+++ b/packages/frontend/ai-gateway/tests/image_voice_adapters.test.ts
@@ -1,0 +1,165 @@
+// packages/frontend/ai-gateway/tests/image_voice_adapters.test.ts
+//
+// AC-3 (C-320): image and voice adapters delegate to existing client
+// implementations unchanged — same request payloads, same outputs —
+// and honor AbortSignal + normalize failures.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  createDelegatingImageAdapter,
+  createDelegatingVoiceAdapter,
+  isAiGatewayError,
+} from '../src/index.ts';
+
+const imageResolution = { capability: 'image', mode: 'offline', provider: 'comfyui' } as const;
+const voiceResolution = { capability: 'voice', mode: 'offline', provider: 'kokoro' } as const;
+
+describe('Delegating image adapter', () => {
+  test('passes the same request payload to the delegate and returns its output', async () => {
+    const captured: Array<{ prompt: string; checkpoint?: string }> = [];
+    const adapter = createDelegatingImageAdapter({
+      generate: (options) => {
+        captured.push(options);
+        return Promise.resolve({ url: 'blob:generated' });
+      },
+    });
+
+    const result = await adapter.generateImage({
+      resolution: imageResolution,
+      signal: new AbortController().signal,
+      prompt: 'a castle at dusk',
+      checkpoint: 'sd_xl_base_1.0',
+    });
+
+    expect(captured).toEqual([{ prompt: 'a castle at dusk', checkpoint: 'sd_xl_base_1.0' }]);
+    expect(result.url).toBe('blob:generated');
+  });
+
+  test('rejects with cancelled when aborted mid-generation', async () => {
+    const controller = new AbortController();
+    const adapter = createDelegatingImageAdapter({
+      generate: () => new Promise(() => {}),
+    });
+
+    const pending = adapter.generateImage({
+      resolution: imageResolution,
+      signal: controller.signal,
+      prompt: 'never finishes',
+    });
+    controller.abort();
+
+    try {
+      await pending;
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('cancelled');
+      }
+    }
+  });
+
+  test('normalizes delegate failures to AiGatewayException', async () => {
+    const adapter = createDelegatingImageAdapter({
+      generate: () => Promise.reject(new Error('Image generation timed out — ComfyUI')),
+    });
+
+    try {
+      await adapter.generateImage({
+        resolution: imageResolution,
+        signal: new AbortController().signal,
+        prompt: 'x',
+      });
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('timeout');
+        expect(error.capability).toBe('image');
+      }
+    }
+  });
+});
+
+describe('Delegating voice adapter', () => {
+  test('passes the same request payload to the delegate', async () => {
+    const captured: Array<{ text: string; voiceId?: string }> = [];
+    const adapter = createDelegatingVoiceAdapter({
+      synthesize: (options) => {
+        captured.push(options);
+        return Promise.resolve(undefined);
+      },
+    });
+
+    const result = await adapter.generateVoice({
+      resolution: voiceResolution,
+      signal: new AbortController().signal,
+      text: 'Hello there',
+      voiceId: 'af_bella',
+    });
+
+    expect(captured).toEqual([{ text: 'Hello there', voiceId: 'af_bella' }]);
+    // Kokoro path plays through the audio pipeline — no raw buffer.
+    expect(result.audio).toBeUndefined();
+  });
+
+  test('returns raw audio when the delegate produces one', async () => {
+    const buffer = new ArrayBuffer(8);
+    const adapter = createDelegatingVoiceAdapter({
+      synthesize: () => Promise.resolve({ audio: buffer }),
+    });
+
+    const result = await adapter.generateVoice({
+      resolution: voiceResolution,
+      signal: new AbortController().signal,
+      text: 'Hello',
+    });
+
+    expect(result.audio).toBe(buffer);
+  });
+
+  test('rejects with cancelled when aborted mid-synthesis', async () => {
+    const controller = new AbortController();
+    const adapter = createDelegatingVoiceAdapter({
+      synthesize: () => new Promise(() => {}),
+    });
+
+    const pending = adapter.generateVoice({
+      resolution: voiceResolution,
+      signal: controller.signal,
+      text: 'never finishes',
+    });
+    controller.abort();
+
+    try {
+      await pending;
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('cancelled');
+      }
+    }
+  });
+
+  test('normalizes delegate failures to AiGatewayException', async () => {
+    const adapter = createDelegatingVoiceAdapter({
+      synthesize: () => Promise.reject(new Error('WebGPU init failed: network error')),
+    });
+
+    try {
+      await adapter.generateVoice({
+        resolution: voiceResolution,
+        signal: new AbortController().signal,
+        text: 'x',
+      });
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.capability).toBe('voice');
+        expect(error.mode).toBe('offline');
+      }
+    }
+  });
+});

--- a/packages/frontend/ai-gateway/tests/text_adapters.test.ts
+++ b/packages/frontend/ai-gateway/tests/text_adapters.test.ts
@@ -1,0 +1,379 @@
+// packages/frontend/ai-gateway/tests/text_adapters.test.ts
+//
+// AC-2 (C-320): OpenAI-compatible text adapter — streaming order, headers,
+// endpoint resolution, Ollama VRAM eviction params, structured extraction
+// (native response_format + system-prompt fallback), abort propagation.
+
+import { describe, expect, test } from 'bun:test';
+import type { AiModeResolution } from '@aikami/types';
+import {
+  createOpenAiCompatibleTextAdapter,
+  isAiGatewayError,
+  OLLAMA_VRAM_EVICTION_PARAMS,
+} from '../src/index.ts';
+import { createSseFetchMock, SSE_DONE, sseChunk } from './helpers.ts';
+
+const resolution = (overrides?: Partial<AiModeResolution>): AiModeResolution => ({
+  capability: 'text',
+  mode: 'byok',
+  provider: 'openrouter',
+  endpoint: 'https://openrouter.ai/api/v1',
+  model: 'llama-3-70b',
+  ...overrides,
+});
+
+const signal = (): AbortSignal => new AbortController().signal;
+
+describe('OpenAI-compatible text adapter — streaming', () => {
+  test('delivers chunks in provider order and accumulates text', async () => {
+    const { fetchFn } = createSseFetchMock({
+      chunks: [sseChunk('Hel'), sseChunk('lo '), sseChunk('World'), SSE_DONE],
+    });
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    const received: string[] = [];
+    const result = await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+      onChunk: (text) => received.push(text),
+    });
+
+    expect(received).toEqual(['Hel', 'lo ', 'World']);
+    expect(result.text).toBe('Hello World');
+  });
+
+  test('posts to <endpoint>/chat/completions with OpenAI-compatible body', async () => {
+    const { fetchFn, calls } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'Hello' },
+      ],
+    });
+
+    expect(calls[0].url).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(calls[0].body.model).toBe('llama-3-70b');
+    expect(calls[0].body.stream).toBe(true);
+    expect(calls[0].body.messages).toEqual([
+      { role: 'system', content: 'You are helpful' },
+      { role: 'user', content: 'Hello' },
+    ]);
+  });
+
+  test('sends Authorization header from injected key resolver', async () => {
+    const { fetchFn, calls } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({
+      fetchFn,
+      getApiKey: (provider) => (provider === 'openrouter' ? 'or-key' : undefined),
+    });
+
+    await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(calls[0].headers.Authorization).toBe('Bearer or-key');
+  });
+
+  test('includes OpenRouter attribution headers for openrouter provider', async () => {
+    const { fetchFn, calls } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(calls[0].headers['HTTP-Referer']).toBe('https://aikami.app');
+    expect(calls[0].headers['X-Title']).toBe('Aikami');
+  });
+
+  test('falls back to well-known local endpoint for ollama', async () => {
+    const { fetchFn, calls } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    await adapter.generateText({
+      resolution: resolution({ mode: 'offline', provider: 'ollama', endpoint: '' }),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(calls[0].url).toBe('http://localhost:11434/v1/chat/completions');
+  });
+
+  test('uses injected default endpoint for cloud providers without one', async () => {
+    const { fetchFn, calls } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({
+      fetchFn,
+      getDefaultEndpoint: (provider) =>
+        provider === 'openai' ? 'https://api.openai.com/v1' : undefined,
+    });
+
+    await adapter.generateText({
+      resolution: resolution({ provider: 'openai', endpoint: '' }),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(calls[0].url).toBe('https://api.openai.com/v1/chat/completions');
+  });
+
+  test('throws not_configured when no endpoint can be resolved', async () => {
+    const { fetchFn } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    try {
+      await adapter.generateText({
+        resolution: resolution({ provider: 'unknown', endpoint: '' }),
+        signal: signal(),
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('not_configured');
+        expect(error.message).toContain('No endpoint configured for provider "unknown"');
+      }
+    }
+  });
+
+  test('includes Ollama VRAM eviction params for ollama provider only', async () => {
+    const { fetchFn, calls } = createSseFetchMock();
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    await adapter.generateText({
+      resolution: resolution({ mode: 'offline', provider: 'ollama', endpoint: '' }),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+    await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    expect(calls[0].body.keep_alive).toBe(OLLAMA_VRAM_EVICTION_PARAMS.keep_alive);
+    expect(calls[0].body.options).toEqual(OLLAMA_VRAM_EVICTION_PARAMS.options);
+    expect(calls[1].body.keep_alive).toBeUndefined();
+    expect(calls[1].body.options).toBeUndefined();
+  });
+
+  test('propagates AbortSignal to the upstream fetch mid-stream', async () => {
+    // SSE stream that emits one chunk and stays open — only an abort ends it.
+    const calls: Array<{ signal: AbortSignal | undefined }> = [];
+    const encoder = new TextEncoder();
+    const fetchFn = ((_input: unknown, init?: RequestInit): Promise<Response> => {
+      calls.push({ signal: init?.signal ?? undefined });
+      const body = new ReadableStream<Uint8Array>({
+        start(controller): void {
+          controller.enqueue(encoder.encode(sseChunk('partial')));
+          // never closed — simulates a hung provider stream
+        },
+      });
+      return Promise.resolve(new Response(body, { status: 200 }));
+    }) as typeof fetch;
+
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+    const controller = new AbortController();
+
+    const pending = adapter.generateText({
+      resolution: resolution(),
+      signal: controller.signal,
+      messages: [{ role: 'user', content: 'Hi' }],
+      onChunk: () => controller.abort(), // abort mid-stream on first chunk
+    });
+
+    await pending.catch(() => undefined);
+
+    // Client disconnect must abort the upstream fetch signal (C-056 VRAM lesson).
+    expect(calls[0].signal).toBeDefined();
+    expect(calls[0].signal?.aborted).toBe(true);
+  });
+
+  test('maps provider HTTP 401 to auth_failed', async () => {
+    const { fetchFn } = createSseFetchMock({ status: 401, statusBody: 'bad key' });
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    try {
+      await adapter.generateText({
+        resolution: resolution(),
+        signal: signal(),
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+      throw new Error('expected rejection');
+    } catch (error) {
+      expect(isAiGatewayError(error)).toBe(true);
+      if (isAiGatewayError(error)) {
+        expect(error.code).toBe('auth_failed');
+        expect(error.message).toContain('HTTP 401');
+      }
+    }
+  });
+});
+
+describe('OpenAI-compatible text adapter — structured extraction', () => {
+  const characterSchema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      level: { type: 'integer' },
+    },
+    required: ['name'],
+  };
+
+  test('extracts a structured object with native response_format', async () => {
+    const payload = JSON.stringify({ name: 'Aragorn', level: 5 });
+    const { fetchFn, calls } = createSseFetchMock({ chunks: [sseChunk(payload), SSE_DONE] });
+    const adapter = createOpenAiCompatibleTextAdapter({
+      fetchFn,
+      supportsStructuredOutput: () => true,
+    });
+
+    const result = await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Extract a character' }],
+      schema: characterSchema,
+      schemaName: 'TestCharacter',
+    });
+
+    expect(result.structured).toEqual({ name: 'Aragorn', level: 5 });
+    const responseFormat = calls[0].body.response_format as Record<string, unknown>;
+    expect(responseFormat).toBeDefined();
+    expect(responseFormat.type).toBe('json_schema');
+  });
+
+  test('omits response_format for providers without structured support', async () => {
+    const payload = JSON.stringify({ name: 'Gandalf' });
+    const { fetchFn, calls } = createSseFetchMock({ chunks: [sseChunk(payload), SSE_DONE] });
+    const adapter = createOpenAiCompatibleTextAdapter({
+      fetchFn,
+      supportsStructuredOutput: () => false,
+    });
+
+    const result = await adapter.generateText({
+      resolution: resolution({ mode: 'offline', provider: 'ollama', endpoint: '' }),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Extract a wizard' }],
+      schema: characterSchema,
+      schemaName: 'TestWizard',
+    });
+
+    expect(result.structured).toEqual({ name: 'Gandalf' });
+    expect(calls[0].body.response_format).toBeUndefined();
+  });
+
+  test('strips markdown fences and surrounding prose from the response', async () => {
+    const { fetchFn } = createSseFetchMock({
+      chunks: [
+        sseChunk('Here you go: ```json\n'),
+        sseChunk(JSON.stringify({ name: 'Gimli' })),
+        sseChunk('\n```'),
+        SSE_DONE,
+      ],
+    });
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    const result = await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Extract' }],
+      schema: characterSchema,
+      schemaName: 'TestDwarf',
+    });
+
+    expect(result.structured).toEqual({ name: 'Gimli' });
+  });
+
+  test('enforces additionalProperties: false and caches compiled schemas', async () => {
+    const sizes: number[] = [];
+    const payload = JSON.stringify({ name: 'Test' });
+    const { fetchFn, calls } = createSseFetchMock({ chunks: [sseChunk(payload), SSE_DONE] });
+    const adapter = createOpenAiCompatibleTextAdapter({
+      fetchFn,
+      supportsStructuredOutput: () => true,
+      onSchemaCacheSize: (size) => sizes.push(size),
+    });
+
+    for (const prompt of ['first', 'second'] as const) {
+      await adapter.generateText({
+        resolution: resolution(),
+        signal: signal(),
+        messages: [{ role: 'user', content: prompt }],
+        schema: characterSchema,
+        schemaName: 'CachedSchema',
+      });
+    }
+
+    const responseFormat = calls[0].body.response_format as {
+      // biome-ignore lint/style/useNamingConvention: OpenAI API contract field name
+      json_schema: { schema: Record<string, unknown> };
+    };
+    expect(responseFormat.json_schema.schema.additionalProperties).toBe(false);
+    expect(sizes).toEqual([1, 1]);
+  });
+
+  test('falls back to system-prompt extraction on HTTP 400', async () => {
+    const payload = JSON.stringify({ name: 'Legolas' });
+    let callCount = 0;
+    const { fetchFn: sseFetch } = createSseFetchMock({ chunks: [sseChunk(payload), SSE_DONE] });
+    const fetchFn = ((input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(new Response('response_format unsupported', { status: 400 }));
+      }
+      return sseFetch(input, init);
+    }) as typeof fetch;
+
+    const adapter = createOpenAiCompatibleTextAdapter({
+      fetchFn,
+      supportsStructuredOutput: () => true,
+    });
+
+    const result = await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Extract' }],
+      schema: characterSchema,
+      schemaName: 'FallbackSchema',
+    });
+
+    expect(callCount).toBe(2);
+    expect(result.structured).toEqual({ name: 'Legolas' });
+  });
+
+  test('falls back to system-prompt extraction when 200 response is not JSON', async () => {
+    let callCount = 0;
+    const { fetchFn: proseFetch } = createSseFetchMock({
+      chunks: [sseChunk('I cannot produce structured output, sorry.'), SSE_DONE],
+    });
+    const { fetchFn: jsonFetch } = createSseFetchMock({
+      chunks: [sseChunk(JSON.stringify({ name: 'Boromir' })), SSE_DONE],
+    });
+    const fetchFn = ((input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      callCount++;
+      return callCount === 1 ? proseFetch(input, init) : jsonFetch(input, init);
+    }) as typeof fetch;
+
+    const adapter = createOpenAiCompatibleTextAdapter({ fetchFn });
+
+    const result = await adapter.generateText({
+      resolution: resolution(),
+      signal: signal(),
+      messages: [{ role: 'user', content: 'Extract' }],
+      schema: characterSchema,
+      schemaName: 'ProseFallback',
+    });
+
+    expect(callCount).toBe(2);
+    expect(result.structured).toEqual({ name: 'Boromir' });
+  });
+});

--- a/packages/frontend/ai-gateway/tsconfig.json
+++ b/packages/frontend/ai-gateway/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Frontend AI Gateway",
+  "extends": "../../../config/tsconfig/tsconfig.frontend.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "outDir": "dist",
+    "paths": {
+      "@aikami/frontend/ai-gateway": ["./src/index.ts"],
+      "@aikami/frontend/ai-gateway/*": ["./src/lib/*"],
+      "@aikami/constants": ["../../shared/constants/src/index.ts"],
+      "@aikami/constants/*": ["../../shared/constants/src/lib/*"],
+      "@aikami/schemas": ["../../shared/schemas/src/index.ts"],
+      "@aikami/schemas/*": ["../../shared/schemas/src/lib/*"],
+      "@aikami/types": ["../../shared/types/src/index.ts"],
+      "@aikami/types/*": ["../../shared/types/src/lib/*"],
+      "$logger": ["../../shared/logger/src/lib/logger_browser.ts"],
+      "$logger/*": ["../../shared/logger/src/lib/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/schemas/src/index.ts
+++ b/packages/shared/schemas/src/index.ts
@@ -1,5 +1,6 @@
 import { Value } from 'typebox/value';
 export const schemaCheck = Value.Check;
+export * from './lib/ai_gateway.ts';
 export * from './lib/api/fcm.ts';
 export * from './lib/api/game.ts';
 export * from './lib/api/oauth.ts';

--- a/packages/shared/schemas/src/lib/ai_gateway.ts
+++ b/packages/shared/schemas/src/lib/ai_gateway.ts
@@ -1,0 +1,103 @@
+// packages/shared/schemas/src/lib/ai_gateway.ts
+//
+// AI Provider Gateway contract schemas — the shared shapes for the unified
+// AI dispatch layer (offline / byok / service) built by C-320.
+// Types are derived via Static<> in @aikami/types.
+// Contract: C-320 AC-1
+
+import Type from 'typebox';
+
+/** Which adapter family serves a capability. */
+export const AiModeSchema = Type.Union([
+  Type.Literal('offline'),
+  Type.Literal('byok'),
+  Type.Literal('service'),
+]);
+
+/** The three AI capabilities behind the gateway. */
+export const AiCapabilitySchema = Type.Union([
+  Type.Literal('text'),
+  Type.Literal('image'),
+  Type.Literal('voice'),
+]);
+
+/** Normalized gateway error codes across all modes/capabilities. */
+export const AiGatewayErrorCodeSchema = Type.Union([
+  Type.Literal('provider_unreachable'),
+  Type.Literal('not_configured'),
+  Type.Literal('auth_failed'),
+  Type.Literal('rate_limited'),
+  Type.Literal('cancelled'),
+  Type.Literal('timeout'),
+  Type.Literal('invalid_response'),
+  Type.Literal('mode_unavailable'),
+]);
+
+/** Typed error shape surfaced by every gateway call. */
+export const AiGatewayErrorSchema = Type.Object({
+  /** Machine-readable normalized error code. */
+  code: AiGatewayErrorCodeSchema,
+  /** Which capability the failing call targeted. */
+  capability: AiCapabilitySchema,
+  /** Which mode served (or failed to serve) the call. */
+  mode: AiModeSchema,
+  /** Provider id when known (e.g. 'ollama', 'openrouter'). */
+  provider: Type.Optional(Type.String()),
+  /** Human-readable message. Never contains secrets. */
+  message: Type.String(),
+  /** Whether retrying the call may succeed. */
+  retryable: Type.Boolean(),
+});
+
+/** Per-capability resolved routing, computed once at the gateway boundary. */
+export const AiModeResolutionSchema = Type.Object({
+  capability: AiCapabilitySchema,
+  mode: AiModeSchema,
+  /** Provider id, e.g. 'ollama' | 'openrouter' | 'comfyui' | 'kokoro' | 'aikami_service'. */
+  provider: Type.String(),
+  /** Base endpoint URL, when the provider needs one. */
+  endpoint: Type.Optional(Type.String()),
+  /** Model id, when the capability is model-addressable. */
+  model: Type.Optional(Type.String()),
+});
+
+/** Detection result per capability (convertible to existing DetectionStatus). */
+export const AiDetectionResultSchema = Type.Object({
+  capability: AiCapabilitySchema,
+  /** Whether the capability can serve calls right now. */
+  available: Type.Boolean(),
+  /** Mode that would serve the capability, when known. */
+  mode: Type.Optional(AiModeSchema),
+  /** Provider id that answered the detection, when known. */
+  provider: Type.Optional(Type.String()),
+  /** Human-readable diagnostic detail. Never contains secrets. */
+  detail: Type.Optional(Type.String()),
+  /** ISO timestamp of when the check completed. */
+  checkedAt: Type.String(),
+});
+
+/** A single chat message in a gateway text-generation request. */
+export const AiChatMessageSchema = Type.Object({
+  role: Type.Union([Type.Literal('user'), Type.Literal('assistant'), Type.Literal('system')]),
+  content: Type.String(),
+});
+
+/** Per-capability gateway routing configuration. */
+export const AiGatewayCapabilityConfigSchema = Type.Object({
+  mode: AiModeSchema,
+  provider: Type.String(),
+  endpoint: Type.Optional(Type.String()),
+  model: Type.Optional(Type.String()),
+});
+
+/**
+ * Full gateway mode configuration — one optional entry per capability.
+ * `serviceActivated` gates the hosted `service` mode (Phase 5); resolving
+ * `service` while it is false yields a `mode_unavailable` gateway error.
+ */
+export const AiGatewayModeConfigSchema = Type.Object({
+  text: Type.Optional(AiGatewayCapabilityConfigSchema),
+  image: Type.Optional(AiGatewayCapabilityConfigSchema),
+  voice: Type.Optional(AiGatewayCapabilityConfigSchema),
+  serviceActivated: Type.Optional(Type.Boolean()),
+});

--- a/packages/shared/schemas/tests/ai_gateway.test.ts
+++ b/packages/shared/schemas/tests/ai_gateway.test.ts
@@ -1,0 +1,199 @@
+// packages/shared/schemas/tests/ai_gateway.test.ts
+//
+// AC-1 (C-320): AI Gateway contract schemas accept valid payloads and
+// reject invalid ones via schemaCheck.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  AiCapabilitySchema,
+  AiChatMessageSchema,
+  AiDetectionResultSchema,
+  AiGatewayCapabilityConfigSchema,
+  AiGatewayErrorCodeSchema,
+  AiGatewayErrorSchema,
+  AiGatewayModeConfigSchema,
+  AiModeResolutionSchema,
+  AiModeSchema,
+  schemaCheck,
+} from '../src/index.ts';
+
+describe('AiModeSchema', () => {
+  test('accepts the three modes', () => {
+    for (const mode of ['offline', 'byok', 'service']) {
+      expect(schemaCheck(AiModeSchema, mode)).toBe(true);
+    }
+  });
+
+  test('rejects unknown modes', () => {
+    expect(schemaCheck(AiModeSchema, 'cloud')).toBe(false);
+    expect(schemaCheck(AiModeSchema, '')).toBe(false);
+    expect(schemaCheck(AiModeSchema, 42)).toBe(false);
+  });
+});
+
+describe('AiCapabilitySchema', () => {
+  test('accepts the three capabilities', () => {
+    for (const capability of ['text', 'image', 'voice']) {
+      expect(schemaCheck(AiCapabilitySchema, capability)).toBe(true);
+    }
+  });
+
+  test('rejects unknown capabilities', () => {
+    expect(schemaCheck(AiCapabilitySchema, 'video')).toBe(false);
+    expect(schemaCheck(AiCapabilitySchema, undefined)).toBe(false);
+  });
+});
+
+describe('AiGatewayErrorCodeSchema', () => {
+  test('accepts every normalized error code', () => {
+    const codes = [
+      'provider_unreachable',
+      'not_configured',
+      'auth_failed',
+      'rate_limited',
+      'cancelled',
+      'timeout',
+      'invalid_response',
+      'mode_unavailable',
+    ];
+    for (const code of codes) {
+      expect(schemaCheck(AiGatewayErrorCodeSchema, code)).toBe(true);
+    }
+  });
+
+  test('rejects unknown codes', () => {
+    expect(schemaCheck(AiGatewayErrorCodeSchema, 'unknown_error')).toBe(false);
+  });
+});
+
+describe('AiGatewayErrorSchema', () => {
+  test('accepts a fully-populated error', () => {
+    const error = {
+      code: 'provider_unreachable',
+      capability: 'text',
+      mode: 'offline',
+      provider: 'ollama',
+      message: 'Connection refused',
+      retryable: true,
+    };
+    expect(schemaCheck(AiGatewayErrorSchema, error)).toBe(true);
+  });
+
+  test('accepts an error without optional provider', () => {
+    const error = {
+      code: 'mode_unavailable',
+      capability: 'voice',
+      mode: 'service',
+      message: 'Service mode is not activated',
+      retryable: false,
+    };
+    expect(schemaCheck(AiGatewayErrorSchema, error)).toBe(true);
+  });
+
+  test('rejects an error missing required fields', () => {
+    expect(schemaCheck(AiGatewayErrorSchema, { code: 'timeout' })).toBe(false);
+    expect(
+      schemaCheck(AiGatewayErrorSchema, {
+        code: 'bogus',
+        capability: 'text',
+        mode: 'offline',
+        message: 'x',
+        retryable: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('AiModeResolutionSchema', () => {
+  test('accepts a full resolution', () => {
+    const resolution = {
+      capability: 'text',
+      mode: 'byok',
+      provider: 'openrouter',
+      endpoint: 'https://openrouter.ai/api/v1',
+      model: 'llama-3-70b',
+    };
+    expect(schemaCheck(AiModeResolutionSchema, resolution)).toBe(true);
+  });
+
+  test('accepts a resolution without optional endpoint/model', () => {
+    const resolution = { capability: 'image', mode: 'offline', provider: 'comfyui' };
+    expect(schemaCheck(AiModeResolutionSchema, resolution)).toBe(true);
+  });
+
+  test('rejects a resolution with invalid mode', () => {
+    const resolution = { capability: 'text', mode: 'remote', provider: 'ollama' };
+    expect(schemaCheck(AiModeResolutionSchema, resolution)).toBe(false);
+  });
+});
+
+describe('AiDetectionResultSchema', () => {
+  test('accepts an available detection result', () => {
+    const result = {
+      capability: 'text',
+      available: true,
+      mode: 'offline',
+      provider: 'ollama',
+      detail: 'proxy ping ok',
+      checkedAt: new Date().toISOString(),
+    };
+    expect(schemaCheck(AiDetectionResultSchema, result)).toBe(true);
+  });
+
+  test('accepts an unavailable result with only required fields', () => {
+    const result = {
+      capability: 'image',
+      available: false,
+      checkedAt: new Date().toISOString(),
+    };
+    expect(schemaCheck(AiDetectionResultSchema, result)).toBe(true);
+  });
+
+  test('rejects a result missing checkedAt', () => {
+    expect(schemaCheck(AiDetectionResultSchema, { capability: 'text', available: true })).toBe(
+      false,
+    );
+  });
+});
+
+describe('AiChatMessageSchema', () => {
+  test('accepts valid chat messages', () => {
+    expect(schemaCheck(AiChatMessageSchema, { role: 'user', content: 'Hi' })).toBe(true);
+    expect(schemaCheck(AiChatMessageSchema, { role: 'system', content: '' })).toBe(true);
+    expect(schemaCheck(AiChatMessageSchema, { role: 'assistant', content: 'Hello' })).toBe(true);
+  });
+
+  test('rejects invalid roles', () => {
+    expect(schemaCheck(AiChatMessageSchema, { role: 'bot', content: 'Hi' })).toBe(false);
+  });
+});
+
+describe('AiGatewayCapabilityConfigSchema / AiGatewayModeConfigSchema', () => {
+  test('accepts a per-capability config', () => {
+    const config = {
+      mode: 'offline',
+      provider: 'ollama',
+      endpoint: 'http://localhost:11434/v1',
+      model: 'llama3',
+    };
+    expect(schemaCheck(AiGatewayCapabilityConfigSchema, config)).toBe(true);
+  });
+
+  test('accepts a mixed-mode gateway config (text offline + image byok)', () => {
+    const config = {
+      text: { mode: 'offline', provider: 'ollama' },
+      image: { mode: 'byok', provider: 'comfyui', endpoint: 'https://example.com' },
+      serviceActivated: false,
+    };
+    expect(schemaCheck(AiGatewayModeConfigSchema, config)).toBe(true);
+  });
+
+  test('accepts an empty gateway config', () => {
+    expect(schemaCheck(AiGatewayModeConfigSchema, {})).toBe(true);
+  });
+
+  test('rejects config with invalid capability entry', () => {
+    const config = { text: { mode: 'nope', provider: 'x' } };
+    expect(schemaCheck(AiGatewayModeConfigSchema, config)).toBe(false);
+  });
+});

--- a/packages/shared/types/src/index.ts
+++ b/packages/shared/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/ai/index.js';
+export * from './lib/ai_gateway.ts';
 export * from './lib/api/auth.ts';
 export * from './lib/api/fcm.ts';
 export * from './lib/api/firestore.ts';

--- a/packages/shared/types/src/lib/ai_gateway.ts
+++ b/packages/shared/types/src/lib/ai_gateway.ts
@@ -1,0 +1,44 @@
+// packages/shared/types/src/lib/ai_gateway.ts
+//
+// AI Provider Gateway types — derived from @aikami/schemas.
+// Contract: C-320 AC-1
+
+import type {
+  AiCapabilitySchema,
+  AiChatMessageSchema,
+  AiDetectionResultSchema,
+  AiGatewayCapabilityConfigSchema,
+  AiGatewayErrorCodeSchema,
+  AiGatewayErrorSchema,
+  AiGatewayModeConfigSchema,
+  AiModeResolutionSchema,
+  AiModeSchema,
+} from '@aikami/schemas';
+import type { Static } from 'typebox';
+
+/** Which adapter family serves a capability: 'offline' | 'byok' | 'service'. */
+export type AiMode = Static<typeof AiModeSchema>;
+
+/** The three AI capabilities behind the gateway: 'text' | 'image' | 'voice'. */
+export type AiCapability = Static<typeof AiCapabilitySchema>;
+
+/** Normalized gateway error codes across all modes/capabilities. */
+export type AiGatewayErrorCode = Static<typeof AiGatewayErrorCodeSchema>;
+
+/** Typed error shape surfaced by every gateway call. */
+export type AiGatewayError = Static<typeof AiGatewayErrorSchema>;
+
+/** Per-capability resolved routing, computed once at the gateway boundary. */
+export type AiModeResolution = Static<typeof AiModeResolutionSchema>;
+
+/** Detection result per capability (convertible to existing DetectionStatus). */
+export type AiDetectionResult = Static<typeof AiDetectionResultSchema>;
+
+/** A single chat message in a gateway text-generation request. */
+export type AiChatMessage = Static<typeof AiChatMessageSchema>;
+
+/** Per-capability gateway routing configuration. */
+export type AiGatewayCapabilityConfig = Static<typeof AiGatewayCapabilityConfigSchema>;
+
+/** Full gateway mode configuration — one optional entry per capability. */
+export type AiGatewayModeConfig = Static<typeof AiGatewayModeConfigSchema>;


### PR DESCRIPTION
## What was built

New `@aikami/frontend/ai-gateway` (moon ID `frontend-ai-gateway`) — a **single, typed dispatch layer** for text, image, and voice AI calls across three provider modes: `offline` (Ollama/ComfyUI/Kokoro), `byok` (OpenRouter/OpenAI/Gemini with user keys from vault), and `service` (Aikami-hosted — stub in this contract, backend migration deferred to C-324).

Before: AI calls were scattered across **four unrelated surfaces** (SSE streaming, Firebase callable, C-056 backend gateway, detection pings) — each with its own routing, error shapes, and resolution logic. After: one `AiProviderGateway`.

### What changed

| Area | Description |
|------|-------------|
| **`packages/frontend/ai-gateway/`** *(new)* | Adapter registry, mode resolver, text adapters (offline/BYOK/service stub), image adapter, voice adapter, detection API, uniform `AiGatewayError`, SSE parsing + structured extraction, AbortSignal propagation + `cancelAll()` |
| **`packages/shared/schemas/src/lib/ai_gateway.ts`** *(new)* | TypeBox schemas: `AiMode`, `AiCapability`, `AiModeResolution`, `AiDetectionResult`, `AiGatewayErrorShape` |
| **`packages/shared/types/src/lib/ai_gateway.ts`** *(new)* | `Static<>`-derived types from schemas |
| **`client: ai_gateway_service.svelte.ts`** *(new)* | `AiGatewayService` singleton — `create()` pattern, injectable config |
| **`client: text_generation_service.svelte.ts`** *(refactored)* | Streams through gateway; restored lost cloud chat-endpoint defaults (fixes 16 previously-failing text tests) |
| **`client: ai_service.svelte.ts`** *(refactored)* | Routes through gateway `service` adapter; unchanged public interface |
| **`.moon/workspace.yml`, `svelte.config.js`, `tsconfig.test.json`** | Moon project registration + `@aikami/frontend/ai-gateway` alias |

### What was NOT changed

- Image/voice services wrapped unchanged (AC-3 watch point)
- `FrontendAiInterface` (game-loop layer) untouched — gateway is a **service layer**
- No new storage — BYOK keys stay on existing `crypto_vault` path
- Backend functions unchanged (C-324 handles migration)

## Verification

| Stage | Status | Key results |
|-------|--------|-------------|
| Writer | ✅ | Contract from `docs/TODO.md` § C-320 |
| Critic | ✅ | 3 issues fixed inline |
| Implementer | ✅ | All 5 ACs; 56 gateway + 20 client text tests |
| Verifier | ✅ | All 5 ACs independently verified; zero regressions |

## Test Results

| Suite | Pass | Fail |
|-------|------|------|
| `schemas:test` | 21 | 0 |
| `frontend-ai-gateway:test` (4 suites) | 56 | 0 |
| `client:text_generation_service` | 20 | 0 |
| `client:image_generation_service` | 20 | 0 |
| `client:tts_service` | 5 | 0 |
| `client:config_service` | 30 | 0 |
| `client:capability_service` | 14 | 1 (pre-existing) |
| Typecheck (all projects) | 0 errors | — |
| Lint/format | 32/32 clean | — |

## Pipeline

- **Run:** `run-mro5tmsu-C-320`
- **Deps:** C-056 ✅ · C-133 ✅ · C-134 ✅ · C-230 ✅
- **Follow-ups:** C-322 (settings wiring) · C-323 (product gate) · C-324 (backend retirement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified AI gateway for text, image, and voice generation.
  * Added support for offline, cloud, and service-based text generation modes.
  * Added streaming responses, structured output extraction, provider availability checks, and routing diagnostics.
  * Integrated offline image generation and voice synthesis.

* **Refactor**
  * Updated AI services to use the unified gateway for persona creation, messaging, and text generation.
  * Improved cancellation handling for active generation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->