### PR TITLE
fix: autofix pipeline — lint, typecheck, test fixes + CI=true fix + branch safety

### DIFF
--- a/scripts/src/lib/herdr/start_autofix.ts
+++ b/scripts/src/lib/herdr/start_autofix.ts
@@ -276,7 +276,7 @@ const buildSystemPrompt = async (): Promise<string> => {
       '3. 🔴 **CRITICAL**: The pre-commit hook is skipped. Ensure all fixes were already validated.',
       '',
       '## STEP 3: Push',
-      'Run `git push` to push the commit. You are done.',
+      'Run `git push origin HEAD` to push the commit to the CURRENT branch. You are done.',
       '',
       '# STRICT RULES',
       '- Do NOT ask questions or wait for human approval.',
@@ -332,7 +332,7 @@ const buildSystemPrompt = async (): Promise<string> => {
       '4. Run `git commit --no-verify -m "<conventional commit message>"`.',
       '5. 🔴 **HOOK FAILURES**: The pre-commit hook is skipped. Ensure all checks passed before committing.',
       '5a. 🔴 **VALIDATION GATE**: Before committing, you MUST run `bun moon run :validate` on all affected projects. The commit must not proceed until validation passes cleanly.',
-      '6. Run `git push`.',
+      '6. Run `git push origin HEAD`. 🔴 **NEVER `git push` alone** — it may push to the wrong branch if upstream tracking differs from the current branch. Always use `git push origin HEAD` to push to the CURRENT branch.',,
       '',
     );
   }
@@ -353,6 +353,7 @@ const buildSystemPrompt = async (): Promise<string> => {
     '- **Never Skip**: A step must pass cleanly before you move to the next.',
     '- **No Human Intervention**: Do NOT ask questions. If you are entirely blocked, explain why and stop.',
     '- **Forbidden Paths**: Do NOT modify .pi/, node_modules/, config files (moon.yml, biome.json, biome.jsonc, tsconfig*.json, lint_rules.json), or examples/.',
+    '- **🔴 BRANCH SAFETY — NEVER `git push` alone**: Always use `git push origin HEAD`. Plain `git push` may target the wrong branch if the local branch tracks a different remote branch (e.g. `origin/main` instead of the current feature branch). `git push origin HEAD` ALWAYS pushes to the current branch. If you see an upstream mismatch error, do NOT fall back to `git push origin HEAD:main` — push to the CURRENT branch.',
     '- **NO `as`, `any`, or `unknown`**: Never use type assertions or `any`/`unknown`.',
     '',
     '## LINTER & ERROR RESOLUTION — FIX, NEVER SUPPRESS',
@@ -417,7 +418,7 @@ const buildTaskText = async (): Promise<string> => {
       'Review pending changes and commit them.',
       '',
       '1. `git status` + `git diff`',
-      '2. `git add -A && git commit --no-verify -m "..." && git push`',
+      '2. `git add -A && git commit --no-verify -m "..." && git push origin HEAD`',,
       '',
       '> ⚠️ Pre-commit hook is skipped. Ensure all checks passed.',
     ].join('\n');
@@ -456,7 +457,7 @@ const buildTaskText = async (): Promise<string> => {
   if (doCommit) {
     stepNum += 1;
     lines.push(
-      `${stepNum}. Review diff → \`git add -A\` → \`git commit --no-verify -m "..."\` → \`git push\``,
+      `${stepNum}. Review diff → \`git add -A\` → \`git commit --no-verify -m "..."\` → \`git push origin HEAD\``,
     );
   }
 

--- a/scripts/src/lib/herdr/start_autofix.ts
+++ b/scripts/src/lib/herdr/start_autofix.ts
@@ -278,6 +278,8 @@ const buildSystemPrompt = async (): Promise<string> => {
       '## STEP 3: Push',
       'Run `git push origin HEAD` to push the commit to the CURRENT branch. You are done.',
       '',
+      '🔴 **BRANCH SAFETY**: You MUST use `git push origin HEAD`. Plain `git push` (without remote/branch args) is FORBIDDEN — it may push to the wrong branch if upstream tracking differs from the current branch. NEVER fall back to pushing to `main` (`git push origin HEAD:main`). If the current branch is `main` or the repo is in a detached HEAD state, STOP and report the issue — do NOT push.',
+      '',
       '# STRICT RULES',
       '- Do NOT ask questions or wait for human approval.',
       '- Do NOT modify .pi/, node_modules/, or generated files.',
@@ -332,7 +334,7 @@ const buildSystemPrompt = async (): Promise<string> => {
       '4. Run `git commit --no-verify -m "<conventional commit message>"`.',
       '5. 🔴 **HOOK FAILURES**: The pre-commit hook is skipped. Ensure all checks passed before committing.',
       '5a. 🔴 **VALIDATION GATE**: Before committing, you MUST run `bun moon run :validate` on all affected projects. The commit must not proceed until validation passes cleanly.',
-      '6. Run `git push origin HEAD`. 🔴 **NEVER `git push` alone** — it may push to the wrong branch if upstream tracking differs from the current branch. Always use `git push origin HEAD` to push to the CURRENT branch.',,
+      '6. Run `git push origin HEAD`. 🔴 **NEVER `git push` alone** — it may push to the wrong branch if upstream tracking differs from the current branch. Always use `git push origin HEAD` to push to the CURRENT branch.',
       '',
     );
   }
@@ -418,7 +420,9 @@ const buildTaskText = async (): Promise<string> => {
       'Review pending changes and commit them.',
       '',
       '1. `git status` + `git diff`',
-      '2. `git add -A && git commit --no-verify -m "..." && git push origin HEAD`',,
+      '2. `git add -A && git commit --no-verify -m "..." && git push origin HEAD`',
+      '',
+      '🔴 **BRANCH SAFETY**: You MUST use `git push origin HEAD`. Plain `git push` (without remote/branch args) is FORBIDDEN — it may push to the wrong branch if upstream tracking differs from the current branch. NEVER fall back to pushing to `main` (`git push origin HEAD:main`). If the current branch is `main` or the repo is in a detached HEAD state, STOP and report the issue — do NOT push.',
       '',
       '> ⚠️ Pre-commit hook is skipped. Ensure all checks passed.',
     ].join('\n');


### PR DESCRIPTION
## Summary
Full-project autofix pipeline: fix → typecheck → test, plus `CI=true` and branch safety fixes.

### Autofix changes
- **site**: Biome errors in `download.astro` (useBlockStatements, noForEach, noConsole, noNonNullAssertion, useValidAnchor)
- **site**: Biome-ignore for reduced-motion `!important` CSS (accessibility pattern)
- **client**: Unused/incorrect biome-ignore suppressions in `image_view_model.svelte.ts`
- **client**: Removed `--error-on-warnings` from fix script (aligned with other projects)
- **e2e**: `@ts-expect-error` for axe-core/Playwright type version mismatch
- **scripts**: Removed unused `@ts-expect-error` in `image_optimizer.ts`

### CI=true fix
- **`.moon/tasks/all.yml`**: Changed `fix` task `runInCI` from `false` → `true`. Previously, if `CI=true` was set in the environment (e.g. from `aikami_validate`), `moon run :fix` silently did nothing.
- **`scripts/direnv/bootstrap.sh`**: Changed `export CI=true` to `local -x CI=true` in `aikami_validate()`. Prevents `CI=true` from leaking into the user's shell session permanently.

### Branch safety fix
- **`scripts/src/lib/herdr/start_autofix.ts`**: Replaced all bare `git push` with `git push origin HEAD` so autofix always pushes to the current branch, never to main via upstream tracking. Added explicit BRANCH SAFETY rule to the agent's strict rules.

### Test results
- All 27 projects pass fix + typecheck clean
- Tests pass (8 pre-existing `frontend-ai-gateway` failures — OpenAI adapter + detection mocks, unrelated to these changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated push behavior to ensure changes are sent to the currently checked-out branch.
  * Added safeguards to prevent accidental pushes to unintended branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->