### PR TITLE
feat(contract): rework CLI source modes — prompt/issue/path + early dirty check

### DIFF
--- a/docs/guides/contract-pipeline.md
+++ b/docs/guides/contract-pipeline.md
@@ -10,81 +10,75 @@ Source → Write → Critique → Implement → Verify → Review → Merge
   │        │         │           │          │         │
   │    draft    approved    in_progress  implemented  verified
   │                                                     │
-  └── todo / roadmap / direct ──────────────────────────┘
+  └── prompt / issue / todo / existing contract ────────┘
 ```
 
 ## Quick Start
 
 ```bash
-# Chat-draft a new feature (auto-generates contract ID, no worktree):
-bun run contract --source direct --root
+# Chat-draft a new feature (auto-generates contract ID, opens the writer):
+bun run contract --source prompt --root
 
-# From the backlog (requires the item in docs/TODO.md):
+# Run an existing contract (skips writer + critique, starts implementation):
 bun run contract C-370 --root
 
 # From a GitHub Issue:
-bun run contract #102 --source roadmap
+bun run contract --source issue #102
 
 # Resume a previous run:
 bun run contract --resume <run-id>
 ```
 
-## Source Modes — Four Ways to Start
+## Source Modes — How to Start a Contract
 
-### 1. Direct (`--source direct`) — Chat Drafting
+The `--source` flag picks the source of the contract. If omitted, the mode is
+inferred from the target: **no target → `prompt`**, a bare `C-XXX` or path →
+**existing contract**.
+
+### 1. Prompt (`--source prompt`, default with no target) — Chat Drafting
 
 Best for **new ideas and exploratory features**. Pi auto-generates the next
 `C-XXX` ID, creates a placeholder contract, and opens an interactive writer pi
-session. You describe the feature in natural language and the writer fills out
-every section of the contract template.
+session. You describe the feature in natural language and the writer renames
+the placeholder to `C-XXX-<slug>.md` and fills out every section of the
+contract template.
 
 ```bash
-bun run contract --source direct --root
+bun run contract --source prompt --root
+# or simply:
+bun run contract
 ```
 
 **What happens:**
-1. Auto-generates `C-NNN` (next available number)
-2. Creates a minimal placeholder at `docs/contracts/C-NNN.md`
-3. Switches to branch `contract/C-NNN` (with `--root`)
-4. Opens a writer pi session in **interactive TUI mode**
-5. You type your feature description — the writer generates the full contract
-6. Pipeline continues: critique → implement → verify → review
+1. Auto-generates `C-NNN` (next available number) and creates a placeholder at `docs/contracts/C-NNN.md`
+2. Switches to branch `contract/C-NNN` (with `--root`)
+3. Opens a writer pi session in **interactive TUI mode**
+4. You type your feature description — the writer creates `docs/contracts/C-NNN-<slug>.md`
+   (the placeholder is removed automatically) and completes the full contract
+5. Pipeline continues: critique → implement → verify → review
 
 **No `--root`?** The pipeline creates a Git worktree at `.pi/workspaces/` instead
 of switching your current branch. Worktrees isolate file changes from your
 working tree — useful for background/CI runs.
 
-### 2. TODO Backlog (`--source todo`, default)
-
-Start from an item in `docs/TODO.md`. Every TODO item has a stable `C-XXX` ID.
-
-```bash
-bun run contract C-370            # implicitly --source todo
-bun run contract "Fix LPC Paperdoll" --source todo
-```
-
-The writer inspects the TODO item, reads the codebase, and fills in:
-- Problem & baseline evidence (what's broken today)
-- Architecture directives (which files/packages to change)
-- Acceptance criteria with concrete Given/When/Then
-- Implementation sequence with moon task references
-
-### 3. Roadmap — From GitHub Issues (`--source roadmap`)
+### 2. Issue (`--source issue`) — From GitHub Issues / Roadmap
 
 Freeze a GitHub Issue into a contract. The issue body becomes the problem
-baseline; the writer expands it into a full specification.
+baseline; the writer expands it into a full specification. `--issue` is an
+alias for `--source issue`.
 
 ```bash
-bun run contract #102 --source roadmap
-bun run contract C-370 --source roadmap    # lookup from backlog reference
-bun run contract "Fix auth" --source roadmap  # search Project v2 by title
+bun run contract --source issue #102
+bun run contract --source issue https://github.com/BearlySleeping/aikami/issues/102
+bun run contract --source issue C-370    # lookup from backlog reference
+bun run contract --issue 54              # alias
 ```
 
 **What it does:**
 - Fetches the GitHub Issue via `gh issue view`
 - Generates a contract from `TEMPLATE.md` populated with issue metadata
 - Links `issue_number` and `issue_url` in YAML frontmatter
-- Sets `source: roadmap`
+- Sets `source: issue`
 
 The contract file is created immediately (no writer stage). To run it through
 the full pipeline:
@@ -93,14 +87,44 @@ the full pipeline:
 bun run contract C-XXX --root
 ```
 
-### 4. GitHub Issues (No CLI) — Manual Entry
+### 3. Existing Contract (`--source <path|C-XXX>`, default with a target)
 
-If an issue already exists on GitHub and you want to keep it as the source of
-truth, you can:
+Use a contract that already exists on disk. The **writer and critique stages are
+skipped** — the pipeline starts at implementation (or later, depending on the
+contract's status). This is the default when you pass a bare ID or a path:
 
-1. Create the contract manually from `docs/contracts/TEMPLATE.md`
-2. Fill in the YAML frontmatter with `source: roadmap` and the `issue_number`
-3. Run through the pipeline: `bun run contract C-XXX --root`
+```bash
+bun run contract C-370 --root           # look up docs/contracts/C-370*.md
+bun run contract docs/contracts/C-370-fix-lpc-paperdoll-base-layering-and-neck-alignment.md
+bun run contract --source path C-370    # explicit
+```
+
+**Stage start depends on the contract status:**
+
+| Contract status | Pipeline starts at |
+|---|---|
+| `draft` / `approved` / `in_progress` / `verification_failed` | `implement` |
+| `implemented` | `verify` |
+| `verified` / `completed` | `review` |
+
+If the ID cannot be found on disk (and is not in `docs/TODO.md`), the command
+errors out with a clear message.
+
+### 4. TODO Backlog (`--source todo`, legacy)
+
+Start from an item in `docs/TODO.md`. Every TODO item has a stable `C-XXX` ID.
+Unlike path mode, the writer stage runs to author the contract from the backlog
+item.
+
+```bash
+bun run contract --source todo C-370
+```
+
+The writer inspects the TODO item, reads the codebase, and fills in:
+- Problem & baseline evidence (what's broken today)
+- Architecture directives (which files/packages to change)
+- Acceptance criteria with concrete Given/When/Then
+- Implementation sequence with moon task references
 
 ## Pipeline Stages
 
@@ -109,7 +133,7 @@ automatically — a stage calls `contract_stage_complete` to hand off to the nex
 
 | # | Stage | Role | What It Does |
 |---|-------|------|-------------|
-| 1 | **Write** | `writer` | Reads the source (TODO/Issue/direct chat), inspects the codebase, fills every section of `TEMPLATE.md`. Ends at status `draft`. |
+| 1 | **Write** | `writer` | Reads the source (prompt/Issue/backlog), inspects the codebase, fills every section of `TEMPLATE.md`. Ends at status `draft`. |
 | 2 | **Critique** | `critic` | Adversarial review. Fixes typos and underspecified ACs directly. Blocks only for fundamentally wrong scope or missing critical details. Advances status to `approved`. |
 | 3 | **Implement** | `implementer` | Writes the actual code. Runs moon tasks, creates views/viewmodels, adds tests. Ends at `implemented`. |
 | 4 | **Verify** | `verifier` | Independent verification against every AC. Runs `validate({ test: true })`, blackbox tests, visual validation. If ACs fail → back to implementer. If all pass → `verified`. |
@@ -140,13 +164,29 @@ isolation — all file changes are visible in your working tree.
 
 ```bash
 bun run contract C-370 --root
-bun run contract --source direct --root
+bun run contract --source prompt --root
 ```
 
 **Behavior:**
 - Creates or switches to branch `contract/C-XXX`
 - Refuses to switch if the working directory is dirty (uncommitted changes)
 - Use `--dirty` to carry changes over: `bun run contract C-370 --root --dirty`
+
+### Starting With Uncommitted Changes (`--dirty`)
+
+`--root` refuses to switch branches when your working tree has uncommitted
+changes (staged or modified files). `--dirty` tells the pipeline to switch
+anyway and carry your changes onto the `contract/C-XXX` branch:
+
+```bash
+# You have edits in progress but want to start a contract run anyway:
+bun run contract C-370 --root --dirty
+bun run contract --source prompt --root --dirty
+```
+
+This is useful mid-feature when you want to spin up a related contract without
+stashing. Your uncommitted changes ride along on the new branch and are visible
+to the pipeline agents.
 
 ### Worktree Mode (default)
 
@@ -177,14 +217,15 @@ bun workspace:list
 ## CLI Options — Full Reference
 
 ```
-bun run contract [ID-or-Title] [--source <mode>] [options]
+bun run contract [target] [--source <mode>] [options]
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--source todo` | Parse `docs/TODO.md` for the backlog item (default) |
-| `--source roadmap` | Fetch from GitHub Issue or Project v2 |
-| `--source direct` | Auto-generate C-XXX, launch interactive writer session |
+| `--source prompt` | Open the interactive writer — you describe the feature in the chat (default with no target) |
+| `--source issue` | Freeze a contract from a GitHub Issue/Roadmap item (alias: `--issue <#\|url>`) |
+| `--source <path\|C-XXX>` | Use an existing contract — skip writer + critique, start at implementation |
+| `--source todo` | Legacy: parse `docs/TODO.md` for the backlog item |
 | `--root, -r` | Work on branch `contract/C-XXX` in the repo root |
 | `--dirty` | Allow branch switch with uncommitted changes (only with `--root`) |
 | `--resume <run-id>` | Resume an incomplete pipeline run |
@@ -241,7 +282,7 @@ implementer + verifier quality.
 
 ```bash
 # 1. Chat-draft the contract
-bun run contract --source direct --root
+bun run contract --source prompt --root
 
 # 2. Describe your feature in the writer pi session
 #    "I want a crafting system where players combine items..."
@@ -255,13 +296,13 @@ bun run contract --source direct --root
 # 5. The orchestrator merges and cleans up.
 ```
 
-### Workflow 2: Backlog Item
+### Workflow 2: Existing Contract
 
 ```bash
-# 1. Pick from TODO.md
+# 1. You already have a contract (e.g. from a previous writer session)
 bun run contract C-370 --root
 
-# 2. Pipeline runs: write → critique → implement → verify → review
+# 2. Pipeline skips writer + critique and runs: implement → verify → review
 
 # 3. At review, if you want changes:
 #    "needs changes" → back to implementer for fixes
@@ -273,7 +314,7 @@ bun run contract C-370 --root
 
 ```bash
 # 1. Freeze the issue as a contract
-bun run contract #102 --source roadmap
+bun run contract --source issue #102
 
 # 2. Run through the pipeline
 bun run contract C-XXX --root
@@ -288,7 +329,7 @@ bun run contract C-XXX --root
 
 ```bash
 # Small bug fix, well-understood scope
-bun run contract --source direct --root --yolo
+bun run contract --source prompt --root --yolo
 
 # Describe the bug → pipeline auto-runs through merge
 # No human review needed — CodeRabbit handles it.
@@ -331,7 +372,7 @@ docs/
 
 Contracts live in `docs/contracts/` (a separate repo, gitignored inside main).
 
-- **Creating**: Use `bun run contract --source direct` or write manually from `TEMPLATE.md`
+- **Creating**: Use `bun run contract` (interactive writer), `bun run contract --source issue <#|url>`, or write manually from `TEMPLATE.md`
 - **Reading**: `INDEX.md` for priority order, `PROGRESS.md` for status dashboard
 - **Syncing**: `bun run sync:roadmap` syncs contract statuses to GitHub Project #1
 
@@ -343,6 +384,9 @@ C-370-lpc-paperdoll-rendering.md
 │     └─ Slug derived from title (lowercase, hyphenated, ≤60 chars)
 └─ Stable ID (never reused even if the contract is superseded)
 ```
+
+Direct-draft placeholders are named `C-XXX.md` (no slug) until the writer
+renames them to `C-XXX-<slug>.md`.
 
 ## GitHub Integration
 
@@ -362,7 +406,7 @@ Sync with: `bun run sync:contracts`
 ### PR → Issue Linkage
 
 When the review captain creates a PR:
-- PR body includes `Closes #<issue_number>` for roadmap-sourced contracts
+- PR body includes `Closes #<issue_number>` for issue-sourced contracts
 - The contract's `github.pr_url` is set in YAML frontmatter
 - The roadmap item transitions to **In Review**
 
@@ -416,9 +460,10 @@ bun workspace:cleanup     # Remove all
 
 ### Contract not found error
 
-The contract ID must match a file in `docs/contracts/` or an item in
-`docs/TODO.md`. For direct mode, the ID is auto-generated — you should never
-hit this.
+`bun run contract C-999` errors when the ID has no file in `docs/contracts/` and
+no entry in `docs/TODO.md`. Create the contract first with `bun run contract`
+(interactive writer) or `bun run contract --source issue <#|url>` (freeze from
+GitHub).
 
 ## Reference
 

--- a/docs/guides/dev-workflow.md
+++ b/docs/guides/dev-workflow.md
@@ -59,13 +59,13 @@ Quick start:
 
 ```bash
 # Chat-draft a new feature (auto-generates contract, no worktree):
-bun run contract --source direct --root
+bun run contract --source prompt --root
 
-# From the TODO backlog:
+# Run an existing contract (skips writer + critique, starts implementation):
 bun run contract C-370 --root
 
 # From a GitHub Issue:
-bun run contract #102 --source roadmap
+bun run contract --source issue #102
 ```
 
 The pipeline orchestrates: **Write → Critique → Implement → Verify → Review → Merge**,

--- a/scripts/src/lib/agents/contract_pipeline.ts
+++ b/scripts/src/lib/agents/contract_pipeline.ts
@@ -2,11 +2,10 @@
 // scripts/src/lib/agents/contract_pipeline.ts
 //
 // Contract Pipeline CLI — entry point for `bun run contract`.
-// Default: interactive direct drafting. Use --issue to freeze from a GitHub Issue.
-//   bun run contract                    → interactive direct draft (default)
-//   bun run contract --issue #54        → freeze contract from GitHub Issue
-//   bun run contract --issue https://... → freeze from issue URL
-//   bun run contract --source todo C-370 → parse docs/TODO.md
+//   bun run contract                       → prompt source (interactive writer draft)
+//   bun run contract C-370                 → existing contract (path source, default)
+//   bun run contract --source issue #54    → freeze contract from a GitHub Issue
+//   bun run contract --source todo C-370   → parse docs/TODO.md (legacy)
 
 import { execFileSync, execSync, spawn } from 'node:child_process';
 import {
@@ -17,17 +16,19 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { parseBacklog } from '../ops/parse_backlog.ts';
+import { resolveContract } from './contract_pipeline/contract_resolver.ts';
 import { runContractPipeline } from './contract_pipeline/orchestrator.ts';
 
 const sleep = async (milliseconds: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
 
-/** Valid source modes for contract generation */
-type ContractSource = 'todo' | 'roadmap' | 'direct';
+/** Valid source modes for contract generation. */
+type ContractSource = 'prompt' | 'issue' | 'todo' | 'path';
 
 type CliArguments = {
   target?: string;
@@ -44,6 +45,9 @@ type CliArguments = {
   help: boolean;
   root: boolean;
   dirty: boolean;
+  /** Internal — forwarded by the launcher to the background child so the
+   *  writer stage stays interactive (user describes the feature in the TUI). */
+  interactiveWriter: boolean;
 };
 
 const parseArguments = (): CliArguments => {
@@ -60,12 +64,40 @@ const parseArguments = (): CliArguments => {
     }
   }
 
-  const sourceRaw = valueAfter('--source')?.toLowerCase();
-  const source: ContractSource =
-    sourceRaw === 'todo' || sourceRaw === 'roadmap' ? sourceRaw : 'direct';
+  const positionalTarget = args.find((value) => !value.startsWith('-') && !consumed.has(value));
+
+  // Resolve the source mode. The --source value is either a keyword
+  // (prompt|issue|todo|path) or a contract path/ID (e.g. docs/contracts/C-372.md).
+  const sourceRaw = valueAfter('--source')?.trim();
+  const sourceKey = sourceRaw?.toLowerCase();
+
+  let source: ContractSource;
+  let target = positionalTarget;
+  if (sourceKey === 'issue' || sourceKey === 'roadmap') {
+    // roadmap → issue (renamed). Both freeze a contract from GitHub.
+    source = 'issue';
+  } else if (sourceKey === 'todo') {
+    source = 'todo';
+  } else if (sourceKey === 'path') {
+    source = 'path';
+  } else if (sourceKey === 'prompt' || sourceKey === 'direct') {
+    // direct → prompt (renamed). Both open the interactive writer.
+    source = 'prompt';
+  } else if (sourceRaw) {
+    // --source <path-or-ID>: the value IS the contract → path mode.
+    source = 'path';
+    target = sourceRaw;
+  } else if (target) {
+    // No --source flag but a target was passed (C-XXX or a contract path) →
+    // default to using the existing contract.
+    source = 'path';
+  } else {
+    // No --source flag and no target → interactive direct draft.
+    source = 'prompt';
+  }
 
   return {
-    target: args.find((value) => !value.startsWith('-') && !consumed.has(value)),
+    target,
     source,
     issueTarget: valueAfter('--issue'),
     resumeRunId: valueAfter('--resume'),
@@ -78,6 +110,7 @@ const parseArguments = (): CliArguments => {
     yolo: args.includes('--yolo'),
     root: args.includes('--root') || args.includes('-r'),
     dirty: args.includes('--dirty'),
+    interactiveWriter: args.includes('--interactive-writer'),
     help: args.includes('--help') || args.includes('-h'),
   };
 };
@@ -85,35 +118,52 @@ const parseArguments = (): CliArguments => {
 const printHelp = (): void => {
   console.log(`
 Usage:
-  bun run contract [--issue <url|#>] [options]
+  bun run contract [target] [--source <mode>] [options]
 
-Default: interactive direct drafting (describe your feature in the chat).
-Use --issue to freeze a contract from an existing GitHub Issue.
-Legacy --source modes are still supported.
+Modes (--source):
+  prompt   Open the interactive writer — you describe the feature in the chat
+           and the writer drafts the contract (default when no target is given).
+  issue    Freeze a contract from a GitHub Issue/Roadmap item. Requires a
+           target: issue number (#54), URL, or C-XXX with a linked issue.
+  <path>   Use an existing contract: a file path (docs/contracts/C-372.md) or
+           a bare ID (C-372, looked up in docs/contracts/). Skips the writer
+           and critique stages — starts at implementation/verification.
+  todo     Legacy: parse docs/TODO.md for the backlog item.
+
+Targets:
+  C-XXX                  Look up an existing contract in docs/contracts/ (default).
+  docs/contracts/C-XXX-slug.md   Path to an existing contract file.
+  #54 | issue URL        With --source issue: the GitHub Issue to freeze.
+
+Defaults:
+  bun run contract                     → prompt source (new contract, interactive writer)
+  bun run contract C-370               → path source (existing contract)
+  bun run contract --source direct ... → prompt (legacy alias)
+  bun run contract --source roadmap .. → issue (legacy alias)
 
 Examples:
-  bun run contract                          # Interactive direct draft (default)
-  bun run contract --issue 54               # Freeze from Issue #54
-  bun run contract --issue https://github.com/BearlySleeping/aikami/issues/54
-  bun run contract --source todo C-370       # Legacy: parse docs/TODO.md
-  bun run contract --source direct           # Explicit direct draft
-  bun run contract --issue 54 --root         # Issue source + root branch
-  bun run contract --root                    # Direct draft + root branch
-  bun run contract --root --dirty            # Allow uncommitted changes
-  bun run contract docs/contracts/C-xxx-....md
+  bun run contract                          # Interactive direct draft
+  bun run contract --source prompt --root   # Same, but on a root branch
+  bun run contract --source issue 54        # Freeze from Issue #54
+  bun run contract --source issue https://github.com/BearlySleeping/aikami/issues/54
+  bun run contract C-370 --root             # Run an existing contract on a root branch
+  bun run contract docs/contracts/C-370-fix-lpc-paperdoll-....md
+  bun run contract --source todo C-370      # Legacy: parse docs/TODO.md
   bun run contract --resume <run-id>
 
 Options:
-  --source <mode>   Source for contract generation: todo, roadmap, direct (default: direct)
-  --root, -r        Start work on branch contract/C-XXX in the root repo before launching pipeline
-  --dirty           Allow branch switch with uncommitted changes (only with --root)
-  --resume <run-id> Resume an incomplete v3 run
-  --dry-run          Resolve and create the manifest without starting Herdr/Pi
-  --background       Internal/background mode; do not attach Herdr
-  --fresh            Start a brand-new run (skip auto-resume)
-  --no-attach        Run pipeline in background without attaching to herdr
-  --ready            Create PR as ready-for-review (skip draft); triggers CodeRabbit immediately
-  -h, --help         Show this help
+  --issue <url|#>      Alias for --source issue.
+  --source <mode>      prompt (default), issue, todo, or a contract path/ID.
+  --root, -r           Start work on branch contract/C-XXX in the root repo.
+  --dirty              Allow branch switch with uncommitted changes (only with --root).
+  --resume <run-id>    Resume an incomplete run.
+  --fresh              Start a brand-new run (skip auto-resume).
+  --dry-run            Resolve and create the manifest without starting Herdr/Pi.
+  --background         Internal/background mode; do not attach Herdr.
+  --no-attach          Run pipeline in background without attaching to herdr.
+  --ready              Create PR as ready-for-review (skip draft); triggers CodeRabbit immediately.
+  --yolo               Fully automated pipeline — no human in the review loop.
+  -h, --help           Show this help.
 `);
 };
 
@@ -130,10 +180,10 @@ const gh = (args: string[], options?: { timeout?: number }): string => {
 };
 
 /**
- * Handle --source roadmap: fetch a GitHub Issue or Project v2 item
+ * Handle --source issue: fetch a GitHub Issue or Project v2 item
  * and freeze it into a contract file.
  */
-const handleRoadmapSource = (target: string): string => {
+const handleIssueSource = (target: string): string => {
   const repoRoot = process.cwd();
   const contractsDir = join(repoRoot, 'docs/contracts');
   const templatePath = join(contractsDir, 'TEMPLATE.md');
@@ -274,7 +324,7 @@ const handleRoadmapSource = (target: string): string => {
     const contractContent = template
       .replace(/{FEATURE_CODE}/g, contractId)
       .replace(/{TITLE}/g, issueData.title)
-      .replace(/{source}/g, 'roadmap')
+      .replace(/{source}/g, 'issue')
       .replace(/{created_at}/g, now)
       .replace(/{reference_description}/g, `GitHub Issue [#${issueNum}](${issueUrl})`)
       .replace(/{path}/g, 'TBD — determined during implementation')
@@ -310,7 +360,7 @@ const handleRoadmapSource = (target: string): string => {
       .replace(/issue_url:\s*null/, `issue_url: "${issueUrl}"`);
 
     writeFileSync(contractPath, finalContent);
-    console.log(`✅ Contract frozen from roadmap: ${contractFileName}`);
+    console.log(`✅ Contract frozen from issue: ${contractFileName}`);
     console.log(`   Path: ${contractPath}`);
     console.log(`   Issue: ${issueUrl}`);
   }
@@ -354,7 +404,7 @@ const resolveIssueFromProject = (searchTitle: string): number | undefined => {
 };
 
 /**
- * Prepare a --source direct contract pipeline run.
+ * Prepare a --source prompt (direct draft) contract pipeline run.
  *
  * Generates the next available contract ID, creates a minimal placeholder
  * contract on disk, and returns the ID. The pipeline writer stage then opens
@@ -364,21 +414,38 @@ const prepareDirectSource = (repoRoot: string): string => {
   const contractsDir = join(repoRoot, 'docs/contracts');
 
   // Determine next contract ID from existing files on disk.
-  // Check for existing direct-draft placeholders first (idempotent
-  // across foreground+background process launches).
+  // 🔴 This runs in the FOREGROUND only. The background child receives the
+  // resolved ID from the launcher (forwarded as a positional arg) and never
+  // re-derives it — re-deriving here picks the first C-XXX.md placeholder
+  // alphabetically (e.g. a stale C-371.md), not the one just created.
   const existingContracts = existsSync(contractsDir)
     ? readdirSync(contractsDir).filter((f) => /^C-\d+/.test(f) && f.endsWith('.md'))
     : [];
 
-  // Reuse an existing placeholder if running in background mode
-  // (foreground already created it). In foreground, always create fresh.
-  const isBackground = process.argv.includes('--background');
-  if (isBackground) {
-    const existingPlaceholder = existingContracts.find((f) => /^C-\d+\.md$/.test(f));
-    if (existingPlaceholder) {
-      const id = existingPlaceholder.replace('.md', '');
-      return id;
-    }
+  // Reuse an orphaned placeholder from an interrupted direct-draft run — but
+  // ONLY when it is still a genuine placeholder (heading "Direct Draft" +
+  // the source marker). Real contracts (e.g. C-371.md with a real title)
+  // are never reused. Newest first, so a fresh orphan wins over an old one.
+  const stalePlaceholders = existingContracts
+    .filter((f) => /^C-\d+\.md$/.test(f))
+    .map((f) => join(contractsDir, f))
+    .filter((p) => {
+      try {
+        const content = readFileSync(p, 'utf-8');
+        return (
+          /^#\s+Contract\s+C-\d+:\s*Direct Draft/m.test(content) &&
+          (content.includes('Placeholder created by `--source prompt`') ||
+            content.includes('Placeholder created by `--source direct`'))
+        );
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+  if (stalePlaceholders[0]) {
+    const reusedId = basename(stalePlaceholders[0], '.md');
+    console.log(`♻️  Reusing orphaned placeholder: ${reusedId}.md`);
+    return reusedId;
   }
 
   const maxId = existingContracts.reduce((max: number, f: string) => {
@@ -388,15 +455,15 @@ const prepareDirectSource = (repoRoot: string): string => {
   const contractId = `C-${maxId + 1}`;
 
   // Create a minimal placeholder so resolveContract() can find it.
-  // The writer pi session will call contract_generate to create the
-  // full v2 contract shell and fill it in based on user input.
+  // The interactive writer pi session waits for the user's feature
+  // description, then renames this to C-XXX-<slug>.md and fills it in.
   const placeholderPath = join(contractsDir, `${contractId}.md`);
   const placeholder = [
     `# Contract ${contractId}: Direct Draft`,
     '',
-    '> ⚠️ Placeholder created by `--source direct`. The writer will call',
-    '> `contract_generate` to create the full contract shell, then complete',
-    '> every section based on the feature you describe in the chat.',
+    '> ⚠️ Placeholder created by `--source prompt`. The writer will rename',
+    `> this file to \`${contractId}-<slug>.md\` and complete every section`,
+    '> based on the feature you describe in the chat.',
     '',
     '| **Status** | draft |',
     '',
@@ -414,7 +481,7 @@ const prepareDirectSource = (repoRoot: string): string => {
       '',
       'A writer pi session will open in a moment.',
       'Describe your feature in the chat and the writer',
-      'will create the full contract specification.',
+      `will write the contract to docs/contracts/${contractId}-<slug>.md.`,
       '',
       '═══════════════════════════════════════════',
       '',
@@ -425,6 +492,57 @@ const prepareDirectSource = (repoRoot: string): string => {
 };
 
 // ── Root Branch Checkout ────────────────────────────────────
+
+/**
+ * Detect uncommitted changes in the working tree.
+ * Only modifications, staged changes, and conflicts count — untracked
+ * files (??) don't block branch switches.
+ */
+const detectDirty = (): boolean => {
+  try {
+    const status = execSync('git status --porcelain', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return status.split('\n').some((line) => line.length > 2 && !line.startsWith('??'));
+  } catch {
+    throw new Error('Not a git repository. --root requires a git working tree.');
+  }
+};
+
+/** Reconstruct the current command with --dirty appended (retry hint). */
+const retryWithDirtyHint = (): string => {
+  const args = process.argv.slice(2).filter((value) => value !== '--dry-run');
+  return `bun run contract ${args.join(' ')} --dirty`.replace(/\s+/g, ' ').trim();
+};
+
+/**
+ * Fail fast when --root would switch a dirty tree. Run BEFORE any file is
+ * created (placeholder, frozen contract) so the user isn't left with a
+ * half-created contract when the branch switch would have been blocked.
+ */
+const assertRootTreeClean = (options: { allowDirty: boolean }): void => {
+  if (options.allowDirty) {
+    return;
+  }
+  if (!detectDirty()) {
+    return;
+  }
+  console.error(
+    [
+      '❌ Error: Working directory is dirty.',
+      '',
+      'Uncommitted changes: run `git status` to review.',
+      '',
+      'Options:',
+      '  1. Commit or stash your changes: `git stash`',
+      '  2. Re-run with --dirty to continue with uncommitted changes:',
+      `     ${retryWithDirtyHint()}`,
+      '',
+    ].join('\n'),
+  );
+  process.exit(1);
+};
 
 /**
  * Set up a root-directory branch for contract work instead of a worktree.
@@ -450,17 +568,10 @@ const setupRootBranch = (options: {
   // and conflicts count. Untracked files (??) don't block branch switches.
   let wasDirty = false;
   try {
-    const status = execSync('git status --porcelain', {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-    // Filter out untracked files — only staged/modified/conflict lines matter
-    const dirtyLines = status
-      .split('\n')
-      .filter((line) => line.length > 2 && !line.startsWith('??'));
-    wasDirty = dirtyLines.length > 0;
-  } catch {
-    throw new Error('Not a git repository. --root requires a git working tree.');
+    wasDirty = detectDirty();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(msg);
   }
 
   if (wasDirty && !options.allowDirty) {
@@ -472,8 +583,8 @@ const setupRootBranch = (options: {
         '',
         'Options:',
         '  1. Commit or stash your changes: `git stash`',
-        '  2. Re-run with --dirty to switch branches with uncommitted changes:',
-        `     bun run contract ${options.target} --root --dirty`,
+        '  2. Re-run with --dirty to continue with uncommitted changes:',
+        `     ${retryWithDirtyHint()}`,
         '',
       ].join('\n'),
     );
@@ -539,26 +650,43 @@ const atomicWrite = (options: { path: string; value: unknown }): void => {
   renameSync(temporaryPath, options.path);
 };
 
-const launchBackground = async (options: { noAttach: boolean }): Promise<void> => {
+const launchBackground = async (options: {
+  noAttach: boolean;
+  /** Resolved direct-draft contract ID (e.g. C-372) to forward to the child. */
+  target?: string;
+  /** Forward so the child keeps the writer stage interactive. */
+  interactiveWriter?: boolean;
+}): Promise<void> => {
   const token = `launch-${Date.now().toString(36)}-${process.pid}`;
   const runsDirectory = join(process.cwd(), '.pi/contract-runs');
   mkdirSync(runsDirectory, { recursive: true });
   const readyPath = join(runsDirectory, `${token}.json`);
   const launcherLogPath = join(runsDirectory, `${token}.log`);
   const descriptor = openSync(launcherLogPath, 'a');
+  // Forward ALL user args (including --root/--dirty) so the background child
+  // runs with the same configuration. setupRootBranch is idempotent — the
+  // child detects it is already on the branch and proceeds. Only the
+  // launcher-only flags are stripped.
   const forwarded = process.argv
     .slice(2)
-    .filter(
-      (value) =>
-        value !== '--background' &&
-        value !== '--no-attach' &&
-        value !== '--root' &&
-        value !== '-r' &&
-        value !== '--dirty',
-    );
+    .filter((value) => value !== '--background' && value !== '--no-attach');
+  // 🔴 Forward the resolved direct-draft target so the child uses the EXACT
+  // same contract ID instead of re-deriving a placeholder (which could pick
+  // a stale file and start the pipeline at the wrong stage).
+  const targetArgs = options.target && !forwarded.includes(options.target) ? [options.target] : [];
+  const writerArgs = options.interactiveWriter ? ['--interactive-writer'] : [];
   const child = spawn(
     'bun',
-    ['run', import.meta.path, ...forwarded, '--background', '--launcher-token', token],
+    [
+      'run',
+      import.meta.path,
+      ...forwarded,
+      ...targetArgs,
+      ...writerArgs,
+      '--background',
+      '--launcher-token',
+      token,
+    ],
     {
       cwd: process.cwd(),
       detached: true,
@@ -609,9 +737,18 @@ const main = async (): Promise<void> => {
     return;
   }
 
+  // 🔴 Fail fast BEFORE creating any placeholder or contract file: --root
+  // switches branches, so a dirty working tree blocks unless --dirty is
+  // passed. Checking up front means a failed run leaves no C-XXX.md behind.
+  // setupRootBranch re-checks later (idempotent), and the background child
+  // inherits the same flags from the launcher.
+  if (cli.root) {
+    assertRootTreeClean({ allowDirty: cli.dirty });
+  }
+
   // --issue: freeze contract from GitHub Issue (no pipeline)
   if (cli.issueTarget) {
-    const contractId = handleRoadmapSource(cli.issueTarget);
+    const contractId = handleIssueSource(cli.issueTarget);
     if (cli.root) {
       setupRootBranch({
         target: contractId,
@@ -622,19 +759,63 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Handle --source modes that don't use the full pipeline
-  if (cli.source === 'roadmap' && cli.target) {
-    handleRoadmapSource(cli.target);
+  // Handle --source modes that don't use the full pipeline: --source issue
+  // freezes a contract from GitHub (same as --issue).
+  if (cli.source === 'issue') {
+    if (!cli.target) {
+      console.error(
+        '❌ --source issue requires a target: an issue number (#54), a URL, or a C-XXX with a linked issue.',
+      );
+      process.exit(1);
+    }
+    handleIssueSource(cli.target);
     return;
   }
 
-  // Default (direct): generate contract ID + placeholder, then fall through
-  // to the pipeline. The writer stage opens in interactive TUI mode.
+  // ── Prompt source: fresh direct draft → interactive writer ──
+  // The default when no target is given. Creates a placeholder contract and
+  // opens the writer pi session in interactive TUI mode so the user can
+  // describe the feature in the chat.
+  //
+  // 🔴 Only the foreground derives a fresh ID. The background child receives
+  // the resolved target + --interactive-writer from the launcher and never
+  // re-runs prepareDirectSource (that would pick the wrong placeholder).
   let interactiveWriter = false;
-  if (cli.source === 'direct') {
-    cli.target = prepareDirectSource(process.cwd());
+  let skipAuthoring = false;
+  if (cli.source === 'prompt' && !cli.resumeRunId) {
+    if (!cli.target) {
+      cli.target = prepareDirectSource(process.cwd());
+    }
     interactiveWriter = true;
+  } else if (cli.source === 'path') {
+    // Existing contract passed by path or bare C-XXX. Skip the contract-
+    // authoring stages (writer + critique) and start at implementation
+    // (or later, per the contract's status). The contract must already
+    // exist on disk — path mode does not fall back to the backlog.
+    skipAuthoring = true;
+    if (!cli.target) {
+      console.error(
+        '❌ --source path requires a contract path or ID (e.g. docs/contracts/C-370.md).',
+      );
+      process.exit(1);
+    }
+    try {
+      const resolved = resolveContract({ target: cli.target, repoRoot: process.cwd() });
+      if (!existsSync(resolved.path)) {
+        console.error(`❌ Contract not found on disk: ${resolved.path}`);
+        console.error('   Create it first with `bun run contract` (interactive writer)');
+        console.error('   or `bun run contract --source issue <#|url>` (freeze from GitHub).');
+        process.exit(1);
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`❌ ${msg}`);
+      process.exit(1);
+    }
   }
+  // The background child inherits the interactive flag from the launcher
+  // (target was forwarded, so the branch above does not re-derive).
+  interactiveWriter = interactiveWriter || (cli.interactiveWriter && cli.source === 'prompt');
 
   // --root mode: switch branch directly in root repo instead of using worktrees
   if (cli.root) {
@@ -653,7 +834,11 @@ const main = async (): Promise<void> => {
   }
 
   if (!cli.background && !cli.dryRun) {
-    await launchBackground({ noAttach: cli.noAttach });
+    await launchBackground({
+      noAttach: cli.noAttach,
+      target: cli.target,
+      interactiveWriter,
+    });
     return;
   }
 
@@ -666,6 +851,7 @@ const main = async (): Promise<void> => {
     ready: cli.ready,
     yolo: cli.yolo,
     interactiveWriter,
+    skipAuthoring,
     rootMode: cli.root,
     onReady: cli.launcherToken
       ? (readyManifest) => {

--- a/scripts/src/lib/agents/contract_pipeline.ts
+++ b/scripts/src/lib/agents/contract_pipeline.ts
@@ -656,6 +656,8 @@ const launchBackground = async (options: {
   target?: string;
   /** Forward so the child keeps the writer stage interactive. */
   interactiveWriter?: boolean;
+  /** Resolved CLI source mode (prompt/issue/path) to forward to the child. */
+  source?: ContractSource;
 }): Promise<void> => {
   const token = `launch-${Date.now().toString(36)}-${process.pid}`;
   const runsDirectory = join(process.cwd(), '.pi/contract-runs');
@@ -675,6 +677,10 @@ const launchBackground = async (options: {
   // a stale file and start the pipeline at the wrong stage).
   const targetArgs = options.target && !forwarded.includes(options.target) ? [options.target] : [];
   const writerArgs = options.interactiveWriter ? ['--interactive-writer'] : [];
+  // 🔴 Forward the resolved source mode so the child re-parses as source='prompt'
+  // for default prompt runs, preserving interactiveWriter and preventing
+  // skipAuthoring from advancing directly to implementation.
+  const sourceArgs = options.source ? ['--source', options.source] : [];
   const child = spawn(
     'bun',
     [
@@ -683,6 +689,7 @@ const launchBackground = async (options: {
       ...forwarded,
       ...targetArgs,
       ...writerArgs,
+      ...sourceArgs,
       '--background',
       '--launcher-token',
       token,
@@ -838,6 +845,7 @@ const main = async (): Promise<void> => {
       noAttach: cli.noAttach,
       target: cli.target,
       interactiveWriter,
+      source: cli.source,
     });
     return;
   }

--- a/scripts/src/lib/agents/contract_pipeline/contract_resolver.ts
+++ b/scripts/src/lib/agents/contract_pipeline/contract_resolver.ts
@@ -56,7 +56,7 @@ export const resolveContract = (options: { target: string; repoRoot: string }): 
     if (existingFile) {
       return parseContract(join(contractsDirectory, existingFile));
     }
-    // Second: look for a placeholder (C-XXX.md, no slug — from --source direct)
+    // Second: look for a placeholder (C-XXX.md, no slug — from --source prompt)
     const placeholderFile = readdirSync(contractsDirectory).find(
       (file) => file === `${identifier}.md`,
     );
@@ -68,7 +68,7 @@ export const resolveContract = (options: { target: string; repoRoot: string }): 
   const backlog = parseBacklog(options.repoRoot);
   const item = backlog.items.find((candidate) => candidate.id === identifier);
   if (!item) {
-    throw new Error(`${identifier} not found in docs/TODO.md.`);
+    throw new Error(`${identifier} not found in docs/contracts/ or docs/TODO.md.`);
   }
 
   // Contract does not exist on disk yet — the writer Pi session will create it

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -566,15 +566,24 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
               `👋 Welcome to direct contract drafting for ${contractId}.`,
               '',
               'The user will describe their feature in this chat. Wait for their',
-              'description, then create a complete contract specification:',
+              'description before doing any work — do NOT write the contract yet.',
               '',
-              '1. Call `contract_generate` with the feature code to create the v2 shell',
-              '2. Read `docs/contracts/TEMPLATE.md` for the required sections',
-              '3. Inspect the codebase to fill in architecture directives, data models,',
-              '   and baseline evidence',
-              '4. Write concrete Given/When/Then acceptance criteria',
-              '5. Fill every section — no TBD or placeholders',
-              '6. Set status to `draft` and call `contract_stage_complete`',
+              'Once the user has described the feature:',
+              '',
+              '1. Derive a short slug from the described feature (lowercase, hyphens,',
+              '   max ~60 chars, e.g. "npc-free-text-dialogue").',
+              `2. Create the real contract at \`docs/contracts/${contractId}-<slug>.md\`.`,
+              `   This renames the placeholder \`docs/contracts/${contractId}.md\``,
+              '   (the pipeline removes the placeholder file automatically).',
+              '3. Read `docs/contracts/TEMPLATE.md` — the canonical v2.0.0 template.',
+              '   Direct drafts have NO docs/TODO.md entry, so do NOT call',
+              '   `contract_generate` (it only works for backlog IDs).',
+              '4. Inspect the codebase to fill in architecture directives, data models,',
+              '   and baseline evidence.',
+              '5. Write concrete Given/When/Then acceptance criteria. Fill every',
+              '   section — no TBD or placeholders.',
+              '6. Set status to `draft` and call `contract_stage_complete` with',
+              '   status `passed`.',
               '',
               '🔴 Your LAST action MUST call contract_stage_complete.',
             ].join('\n')
@@ -614,7 +623,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       if (isRetry) {
         taskText = `${parts[0]} Read your full task brief at ${taskMessagePath} FIRST. Pick up where you left off. Your LAST action MUST call contract_stage_complete. Do not ask questions; if blocked, finish with status blocked.`;
       } else if (isInteractiveWriter) {
-        taskText = `👋 Welcome to direct contract drafting for ${contractId}! Describe your feature and I'll create the full contract specification.`;
+        taskText = `👋 Welcome to direct contract drafting for ${contractId}! Tell me what you want this contract to be and I'll write the full specification. Read your full task brief at ${taskMessagePath} for the workflow.`;
       } else {
         taskText = `${parts[0]} Read your full task brief at ${taskMessagePath} FIRST, then execute it. Your LAST action MUST call contract_stage_complete — a text summary without the tool call blocks the pipeline forever. Do not ask questions; if blocked, finish with status blocked.`;
       }

--- a/scripts/src/lib/agents/contract_pipeline/manifest_store.ts
+++ b/scripts/src/lib/agents/contract_pipeline/manifest_store.ts
@@ -249,6 +249,7 @@ export const createManifest = (options: {
   baseCommit: string;
   baselineFingerprint: string;
   startStage: ContractPipelineStage;
+  skipAuthoring?: boolean;
 }): RunManifest => {
   const timestamp = new Date().toISOString();
   return {
@@ -265,6 +266,7 @@ export const createManifest = (options: {
     attempts: [],
     usage: {},
     autofixCycles: 0,
+    skipAuthoring: options.skipAuthoring,
   };
 };
 

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -544,8 +544,11 @@ export const runContractPipeline = async (options: {
     const cs = readContractStatus(manifest.contractPath);
     let contractStage = STATUS_TO_START_STAGE[cs] ?? 'write_contract';
     // Path-sourced contracts skip authoring — a draft contract resumes at
-    // implementation, not back to the writer.
-    if (options.skipAuthoring && contractStage === 'write_contract') {
+    // implementation, not back to the writer. Use the persisted skipAuthoring
+    // decision from the manifest so a draft path-sourced run resumed by run ID
+    // without a target remains at implement instead of being reset to write_contract.
+    const skipAuthoring = options.skipAuthoring ?? manifest.skipAuthoring;
+    if (skipAuthoring && contractStage === 'write_contract') {
       contractStage = 'implement';
     }
     const stageOrder: ContractPipelineStage[] = [
@@ -597,6 +600,7 @@ export const runContractPipeline = async (options: {
       baseCommit: currentCommit(options.repoRoot),
       baselineFingerprint: captureGitState(options.repoRoot).fingerprint,
       startStage,
+      skipAuthoring: options.skipAuthoring,
     });
     writeManifest({ manifest, cwd: options.repoRoot });
   }

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -507,6 +507,10 @@ export const runContractPipeline = async (options: {
   /** When true, the writer stage runs in interactive TUI mode so the user
    *  can chat directly with the writer pi session. */
   interactiveWriter?: boolean;
+  /** When true, skip the contract-authoring stages (writer + critique) and
+   *  start at implementation (or later, per the contract's status). Used
+   *  when the contract already exists and is passed by path or bare C-XXX. */
+  skipAuthoring?: boolean;
   /** When true, use the standard aikami-{mode} herdr workspace and
    *  skip git worktree provisioning. All stages run from the repo root. */
   rootMode?: boolean;
@@ -538,7 +542,12 @@ export const runContractPipeline = async (options: {
     manifest.blockedReason = undefined;
 
     const cs = readContractStatus(manifest.contractPath);
-    const contractStage = STATUS_TO_START_STAGE[cs] ?? 'write_contract';
+    let contractStage = STATUS_TO_START_STAGE[cs] ?? 'write_contract';
+    // Path-sourced contracts skip authoring — a draft contract resumes at
+    // implementation, not back to the writer.
+    if (options.skipAuthoring && contractStage === 'write_contract') {
+      contractStage = 'implement';
+    }
     const stageOrder: ContractPipelineStage[] = [
       'write_contract',
       'critique',
@@ -577,12 +586,17 @@ export const runContractPipeline = async (options: {
       throw new Error('A contract ID or path is required for a new run.');
     }
     const contract = resolveContract({ target: options.target, repoRoot: options.repoRoot });
+    const baseStart = STATUS_TO_START_STAGE[contract.status] ?? 'write_contract';
+    // Path-sourced contracts (existing contract by path or bare C-XXX) skip
+    // the authoring stages — draft contracts start at implementation.
+    const startStage =
+      options.skipAuthoring && baseStart === 'write_contract' ? 'implement' : baseStart;
     manifest = createManifest({
       contractId: contract.id,
       contractPath: contract.path,
       baseCommit: currentCommit(options.repoRoot),
       baselineFingerprint: captureGitState(options.repoRoot).fingerprint,
-      startStage: STATUS_TO_START_STAGE[contract.status] ?? 'write_contract',
+      startStage,
     });
     writeManifest({ manifest, cwd: options.repoRoot });
   }
@@ -668,17 +682,10 @@ export const runContractPipeline = async (options: {
         });
         const after = captureGitState(cwdForGit);
 
-        if (
-          wPath &&
-          (stage === 'write_contract' || stage === 'critique') &&
-          existsSync(manifest.contractPath)
-        ) {
-          const wcp = join(wPath, relative(options.repoRoot, manifest.contractPath));
-          try {
-            mkdirSync(dirname(wcp), { recursive: true });
-            copyFileSync(manifest.contractPath, wcp);
-          } catch {}
-        }
+        // Direct-draft placeholder rename: the writer creates the real contract
+        // at docs/contracts/C-XXX-<slug>.md. Discover it, drop the stale
+        // placeholder, and point the manifest at the real file BEFORE syncing
+        // to the worktree (so implementers read the real contract).
         if (stage === 'write_contract' && outcome.result.status === 'passed') {
           const cd = resolve(options.repoRoot, 'docs/contracts');
           if (existsSync(cd)) {
@@ -690,8 +697,25 @@ export const runContractPipeline = async (options: {
             );
             if (discovered) {
               manifest.contractPath = join(cd, discovered);
+              const placeholderPath = join(cd, `${manifest.contractId}.md`);
+              if (placeholderPath !== manifest.contractPath && existsSync(placeholderPath)) {
+                try {
+                  unlinkSync(placeholderPath);
+                } catch {}
+              }
             }
           }
+        }
+        if (
+          wPath &&
+          (stage === 'write_contract' || stage === 'critique') &&
+          existsSync(manifest.contractPath)
+        ) {
+          const wcp = join(wPath, relative(options.repoRoot, manifest.contractPath));
+          try {
+            mkdirSync(dirname(wcp), { recursive: true });
+            copyFileSync(manifest.contractPath, wcp);
+          } catch {}
         }
 
         // Postcondition validation — catches agents crossing role boundaries.

--- a/scripts/src/lib/agents/contract_pipeline/types.ts
+++ b/scripts/src/lib/agents/contract_pipeline/types.ts
@@ -127,6 +127,10 @@ export type RunManifest = {
   blockedReason?: string;
   /** Number of autofix cycles attempted during YOLO review. Used for circuit breaker. */
   autofixCycles: number;
+  /** When true, contract-authoring stages (writer + critique) were skipped.
+   *  Used during resume to prevent a draft path-sourced run from being reset
+   *  to write_contract when resumed by run ID without a target. */
+  skipAuthoring?: boolean;
 };
 
 /** Request passed to the Herdr worker launcher. */


### PR DESCRIPTION
## Summary

Reworks the `bun run contract` CLI source modes and fixes two pipeline bugs found while drafting C-372.

## CLI changes

| Command | Behavior |
|---|---|
| `bun run contract` | **prompt** (default with no target) — auto-generates `C-NNN` placeholder, opens the interactive writer |
| `bun run contract C-370` / `--source docs/contracts/C-370-….md` | **existing contract** (default with a target) — skips writer + critique, starts at implement/verify/review per contract status |
| `bun run contract --source issue #54` | Freeze a contract from a GitHub Issue/Roadmap (renamed from `roadmap`; `--issue` remains an alias) |
| `bun run contract --source prompt` | Explicit interactive writer draft (renamed from `direct`) |
| `bun run contract --source todo C-370` | Legacy backlog mode (unchanged) |

Legacy aliases (`--source direct`, `--source roadmap`) still work.

## Bug fixes

- **Wrong-placeholder target mixup**: the background child re-derived the contract ID and picked the *first* `C-XXX.md` alphabetically (a stale approved C-371) instead of the freshly created placeholder, silently starting the pipeline at `implement` for the wrong contract. The resolved target + `--root`/`--dirty`/`--interactive-writer` are now forwarded to the child.
- **Dirty check ordering**: with `--root`, the dirty-tree check now runs **before** any placeholder/contract file is created, and the retry hint reconstructs the full command with `--dirty` appended.
- **Placeholder rename flow**: the interactive writer renames `docs/contracts/C-XXX.md` → `C-XXX-<slug>.md`; the orchestrator discovers the renamed file, removes the stale placeholder, and syncs the real contract to the worktree before implementation. Writer no longer told to call `contract_generate` (which only works for `docs/TODO.md` backlog IDs).
- **`skipAuthoring`**: path-sourced draft contracts start at `implement` instead of `write_contract` (new runs and resumes).

## Docs

- `docs/guides/contract-pipeline.md` rewritten for the new source modes, defaults, stage-start table, and `--dirty`.
- `docs/guides/dev-workflow.md` quick-start updated.

## Verification

- `scripts:fix` / `scripts:typecheck` / `scripts:lint` green
- Dry-run tested all source modes: default→prompt, `--source prompt`, bare `C-372`→implement (authoring skipped), `--source path`, `--source <path-as-value>`, `--source direct` (legacy), `--source issue` (error without target + real fetch), and the background-child arg forwarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI contract sources for prompts, issues, TODO items, and existing contract paths.
  - Added legacy aliases for direct and roadmap sources.
  - Prompt-based workflows can create or reuse validated placeholders before authoring.
  - Existing contract paths can be validated and sent directly to implementation.
  - Improved interactive guidance for describing features and completing contract acceptance criteria.

- **Bug Fixes**
  - Improved contract lookup and missing-contract guidance.
  - Added early dirty-tree checks with retry instructions while ignoring untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->