### PR TITLE
fix(contract-pipeline): honor --root mode end-to-end, persist across resume, guard doc writes

### DIFF
--- a/.pi/extensions/github_cli.ts
+++ b/.pi/extensions/github_cli.ts
@@ -672,11 +672,23 @@ export default function (pi: ExtensionAPI) {
           const contractsDir = join(cwd, 'docs/contracts');
           try {
             if (existsSync(contractsDir)) {
-              const files = readdirSync(contractsDir).filter(
+              // Resolution order matches contract_resolver.ts:
+              // 1. Full-slug files (C-XXX-slug.md)
+              const fullSlugFiles = readdirSync(contractsDir).filter(
                 (f: string) => f.startsWith(`${contractId}-`) && f.endsWith('.md'),
               );
-              if (files.length === 1 && files[0]) {
-                const contractPath = join(contractsDir, files[0]);
+              // 2. Placeholder files (C-XXX.md)
+              const placeholderFile = `${contractId}.md`;
+              const placeholderExists = existsSync(join(contractsDir, placeholderFile));
+
+              let contractPath: string | undefined;
+              if (fullSlugFiles.length === 1 && fullSlugFiles[0]) {
+                contractPath = join(contractsDir, fullSlugFiles[0]);
+              } else if (fullSlugFiles.length === 0 && placeholderExists) {
+                contractPath = join(contractsDir, placeholderFile);
+              }
+
+              if (contractPath) {
                 const content = readFileSync(contractPath, 'utf-8');
                 const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
                 if (yamlMatch?.[1]) {

--- a/.pi/extensions/github_cli.ts
+++ b/.pi/extensions/github_cli.ts
@@ -656,11 +656,16 @@ export default function (pi: ExtensionAPI) {
         return match ? Number(match[1]) : undefined;
       })();
 
-      // 🔗 Auto-write: if PR references a contract (C-XXX), update the contract's YAML frontmatter
+      // 🔗 Auto-write: if PR references a contract (C-XXX), update the contract's YAML frontmatter.
+      // Match from the TITLE or the head branch (e.g. contract/C-372,
+      // contract-task-c-372-*). The BODY is prose — a PR can mention another
+      // contract in its description (e.g. "ran C-372 to reproduce this") and
+      // must NOT clobber that contract's pr_url.
       let contractUpdated: string | undefined;
       if (prNumber && prUrl) {
         const contractMatch =
-          params.title.match(/\b(C-\d+|MIG-\d+)\b/i) ?? body.match(/\b(C-\d+|MIG-\d+)\b/i);
+          params.title.match(/\b(C-\d+|MIG-\d+)\b/i) ??
+          params.headBranch.match(/\b(C-\d+|MIG-\d+)\b/i);
         if (contractMatch?.[1]) {
           const contractId = contractMatch[1].toUpperCase();
           const cwd = _ctx?.cwd ?? process.cwd();

--- a/scripts/src/lib/agents/contract_pipeline.ts
+++ b/scripts/src/lib/agents/contract_pipeline.ts
@@ -22,6 +22,7 @@ import {
 import { basename, join } from 'node:path';
 import { parseBacklog } from '../ops/parse_backlog.ts';
 import { resolveContract } from './contract_pipeline/contract_resolver.ts';
+import { readManifest } from './contract_pipeline/manifest_store.ts';
 import { runContractPipeline } from './contract_pipeline/orchestrator.ts';
 
 const sleep = async (milliseconds: number): Promise<void> =>
@@ -742,6 +743,32 @@ const main = async (): Promise<void> => {
   if (cli.help && !cli.resumeRunId) {
     printHelp();
     return;
+  }
+
+  // 🔴 Resume hydration: when continuing an incomplete run, remember the
+  // original invocation. The run manifest persists rootMode (and the contract
+  // target), so `bun run contract --resume <run-id>` without re-passing
+  // `--root` still executes on the root branch (contract/C-XXX) instead of
+  // silently switching to a worktree. setupRootBranch below is idempotent —
+  // it detects the existing branch and checks out the current one.
+  if (cli.resumeRunId) {
+    try {
+      const resumed = readManifest({ runId: cli.resumeRunId, cwd: process.cwd() });
+      if (resumed) {
+        if (resumed.rootMode) {
+          cli.root = true;
+          // Resuming on the root branch must not be blocked by the tree state
+          // left behind when the session stopped — that state IS the run's
+          // state (mid-implement working tree).
+          cli.dirty = true;
+        }
+        if (!cli.target) {
+          cli.target = resumed.contractId;
+        }
+      }
+    } catch {
+      // Non-fatal — the orchestrator re-reads and validates the manifest.
+    }
   }
 
   // 🔴 Fail fast BEFORE creating any placeholder or contract file: --root

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -563,10 +563,16 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
           ].join('\n')
         : isInteractiveWriter
           ? [
-              `👋 Welcome to direct contract drafting for ${contractId}.`,
+              `👋 Direct contract drafting for ${contractId}.`,
               '',
-              'The user will describe their feature in this chat. Wait for their',
-              'description before doing any work — do NOT write the contract yet.',
+              'You are WAITING for the user to describe their feature in this chat.',
+              '',
+              '🔴 DO NOT DO ANY WORK YET:',
+              '- Do NOT inspect the codebase, scan the backlog, or write any file.',
+              '- Do NOT call `contract_stage_complete` before the contract is written.',
+              '',
+              'The input box is empty. The user will type their feature description',
+              'and press Enter — THAT is your input to act on.',
               '',
               'Once the user has described the feature:',
               '',
@@ -619,15 +625,22 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
 
     if (!this._useJsonMode(options.request.role)) {
       // TUI mode — send task text via PTY.
-      let taskText: string;
       if (isRetry) {
-        taskText = `${parts[0]} Read your full task brief at ${taskMessagePath} FIRST. Pick up where you left off. Your LAST action MUST call contract_stage_complete. Do not ask questions; if blocked, finish with status blocked.`;
+        await this._sendTaskText({
+          paneId,
+          text: `${parts[0]} Read your full task brief at ${taskMessagePath} FIRST. Pick up where you left off. Your LAST action MUST call contract_stage_complete. Do not ask questions; if blocked, finish with status blocked.`,
+        });
       } else if (isInteractiveWriter) {
-        taskText = `👋 Welcome to direct contract drafting for ${contractId}! Tell me what you want this contract to be and I'll write the full specification. Read your full task brief at ${taskMessagePath} for the workflow.`;
+        // 🔴 Leave the input box EMPTY and do not send anything. The agent
+        // must not take a turn — it would start working (or abort) before the
+        // user has described their feature. The user types their description
+        // into the empty chat field and presses Enter themselves.
       } else {
-        taskText = `${parts[0]} Read your full task brief at ${taskMessagePath} FIRST, then execute it. Your LAST action MUST call contract_stage_complete — a text summary without the tool call blocks the pipeline forever. Do not ask questions; if blocked, finish with status blocked.`;
+        await this._sendTaskText({
+          paneId,
+          text: `${parts[0]} Read your full task brief at ${taskMessagePath} FIRST, then execute it. Your LAST action MUST call contract_stage_complete — a text summary without the tool call blocks the pipeline forever. Do not ask questions; if blocked, finish with status blocked.`,
+        });
       }
-      await this._sendTaskText({ paneId, text: taskText });
     }
     return { paneId };
   }

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -166,6 +166,25 @@ export type ContractHerdrAdapterInterface = {
 
 // ── Implementation ──────────────────────────────────────────
 
+/**
+ * Build the Herdr workspace label used by the contract pipeline.
+ *
+ * Root mode reuses the standard `aikami-{mode}` workspace so all stages run
+ * from the repo root; otherwise a per-contract workspace is used. The
+ * orchestrator's lock staleness check must build the SAME label — extract it
+ * here so the two can never drift.
+ *
+ * @param contractId - Contract ID (e.g. `C-372`), only used in worktree mode.
+ * @param rootMode   - Whether the run executes on the root branch.
+ */
+export const buildWorkspaceLabel = (options: {
+  contractId: string;
+  rootMode?: boolean;
+}): string => {
+  const mode = (process.env.AIKAMI_MODE || 'emulator') as string;
+  return options.rootMode ? `aikami-${mode}` : `aikami-contract-${options.contractId}`;
+};
+
 export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
   private readonly _repoRoot: string;
   private readonly _runId: string;
@@ -192,10 +211,10 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
   }) {
     this._repoRoot = options.repoRoot;
     this._runId = options.runId;
-    const mode = (process.env.AIKAMI_MODE || 'emulator') as string;
-    this._workspaceLabel = options.rootMode
-      ? `aikami-${mode}`
-      : `aikami-contract-${options.contractId}`;
+    this._workspaceLabel = buildWorkspaceLabel({
+      contractId: options.contractId,
+      rootMode: options.rootMode,
+    });
     this._headless = options.headless ?? process.env.CONTRACT_PIPELINE_HEADLESS !== '0';
     this._interactiveWriter = options.interactiveWriter ?? false;
     this._rootMode = options.rootMode ?? false;

--- a/scripts/src/lib/agents/contract_pipeline/index.ts
+++ b/scripts/src/lib/agents/contract_pipeline/index.ts
@@ -12,7 +12,7 @@ export {
   fingerprintFiles,
 } from './git_state.ts';
 export type { ContractHerdrAdapterInterface } from './herdr_adapter.ts';
-export { ContractHerdrAdapter } from './herdr_adapter.ts';
+export { buildWorkspaceLabel, ContractHerdrAdapter } from './herdr_adapter.ts';
 export {
   acquireLock,
   createManifest,

--- a/scripts/src/lib/agents/contract_pipeline/manifest_store.ts
+++ b/scripts/src/lib/agents/contract_pipeline/manifest_store.ts
@@ -250,6 +250,7 @@ export const createManifest = (options: {
   baselineFingerprint: string;
   startStage: ContractPipelineStage;
   skipAuthoring?: boolean;
+  rootMode?: boolean;
 }): RunManifest => {
   const timestamp = new Date().toISOString();
   return {
@@ -267,6 +268,7 @@ export const createManifest = (options: {
     usage: {},
     autofixCycles: 0,
     skipAuthoring: options.skipAuthoring,
+    rootMode: options.rootMode,
   };
 };
 

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -196,48 +196,67 @@ const reconcileWorkspace = (options: {
   manifest: RunManifest;
   repoRoot: string;
   baseBranch?: string;
+  rootMode?: boolean;
 }): ReconciliationResult => {
-  const workspaceRunName = options.manifest.runId;
-  const { workspacePath, branchName } = provisionGitWorktree({
-    repoRoot: options.repoRoot,
-    name: workspaceRunName,
-    baseRevision: options.baseBranch ?? PIPELINE_BASE_BRANCH,
-  });
-
-  // Restore .envrc / .pi/settings.json from base (origin/main), not HEAD.
   const b = options.baseBranch ?? PIPELINE_BASE_BRANCH;
-  let resolvedBase: string | undefined;
-  try {
-    resolvedBase = runGit(`rev-parse --verify origin/${b}`, { cwd: options.repoRoot });
-  } catch {
+  const rootMode = options.rootMode ?? false;
+
+  let workspacePath: string;
+  let headBranch: string;
+
+  if (rootMode) {
+    // Root mode: no worktree — the implementation lives in the repo root on
+    // the contract branch (e.g. contract/C-372). Commit remaining changes and
+    // push that branch directly.
+    workspacePath = options.repoRoot;
     try {
-      resolvedBase = runGit(`rev-parse --verify ${b}`, { cwd: options.repoRoot });
-    } catch {}
-  }
-  if (resolvedBase) {
-    for (const fp of [
-      '.envrc',
-      '.pi/settings.json',
-      'docs/contracts/PROGRESS.md',
-      'docs/contracts/PROMOTION.md',
-    ]) {
+      headBranch = runGit('rev-parse --abbrev-ref HEAD', { cwd: workspacePath });
+    } catch {
+      headBranch = `contract/${options.manifest.contractId}`;
+    }
+  } else {
+    const workspaceRunName = options.manifest.runId;
+    const provisioned = provisionGitWorktree({
+      repoRoot: options.repoRoot,
+      name: workspaceRunName,
+      baseRevision: b,
+    });
+    workspacePath = provisioned.workspacePath;
+
+    // Restore .envrc / .pi/settings.json from base (origin/main), not HEAD.
+    let resolvedBase: string | undefined;
+    try {
+      resolvedBase = runGit(`rev-parse --verify origin/${b}`, { cwd: options.repoRoot });
+    } catch {
       try {
-        runGit(`restore --source=${resolvedBase} -- '${fp}'`, { cwd: workspacePath });
+        resolvedBase = runGit(`rev-parse --verify ${b}`, { cwd: options.repoRoot });
       } catch {}
     }
-  }
+    if (resolvedBase) {
+      for (const fp of [
+        '.envrc',
+        '.pi/settings.json',
+        'docs/contracts/PROGRESS.md',
+        'docs/contracts/PROMOTION.md',
+      ]) {
+        try {
+          runGit(`restore --source=${resolvedBase} -- '${fp}'`, { cwd: workspacePath });
+        } catch {}
+      }
+    }
 
-  const runToken = options.manifest.runId.replace(/^run-/, '').split('-')[0];
-  const baseBranchName = `contract-task-${options.manifest.contractId.toLowerCase()}-${runToken}`;
-  let headBranch = baseBranchName;
-  if (remoteBranchExists({ branchName: baseBranchName, repoRoot: options.repoRoot })) {
-    headBranch = `${baseBranchName}-${Date.now().toString(36).slice(-6)}`;
-  }
-  if (branchName !== headBranch) {
-    try {
-      runGit(`branch -m ${branchName} ${headBranch}`, { cwd: workspacePath });
-    } catch {
-      headBranch = branchName;
+    const runToken = options.manifest.runId.replace(/^run-/, '').split('-')[0];
+    const baseBranchName = `contract-task-${options.manifest.contractId.toLowerCase()}-${runToken}`;
+    headBranch = baseBranchName;
+    if (remoteBranchExists({ branchName: baseBranchName, repoRoot: options.repoRoot })) {
+      headBranch = `${baseBranchName}-${Date.now().toString(36).slice(-6)}`;
+    }
+    if (provisioned.branchName !== headBranch) {
+      try {
+        runGit(`branch -m ${provisioned.branchName} ${headBranch}`, { cwd: workspacePath });
+      } catch {
+        headBranch = provisioned.branchName;
+      }
     }
   }
 
@@ -670,6 +689,7 @@ export const runContractPipeline = async (options: {
         const feedback =
           stage === 'implement' ? verifierFeedback({ manifest, attempt }) : undefined;
 
+        const interactiveStage = !!options.interactiveWriter && stage === 'write_contract';
         const outcome = await runStage({
           repoRoot: options.repoRoot,
           runDirectory: runDirectory({ runId: manifest.runId, cwd: options.repoRoot }),
@@ -677,12 +697,18 @@ export const runContractPipeline = async (options: {
           stage,
           attempt,
           contractPath: manifest.contractPath,
-          idleTimeoutMs: IDLE_TIMEOUT_MS,
+          // The interactive writer legitimately sits idle while waiting for the
+          // user to describe their feature — don't nudge it or time it out
+          // early. Only the hard wall-clock cap bounds the wait.
+          idleTimeoutMs: interactiveStage
+            ? (STAGE_HARD_CAPS.write_contract ?? IDLE_TIMEOUT_MS)
+            : IDLE_TIMEOUT_MS,
           hardTimeoutMs: STAGE_HARD_CAPS[stage] ?? 8 * 60 * 60 * 1000,
           feedback,
+          interactiveWriter: interactiveStage,
           launchWorker: (req) => adapter.launchWorker(req),
           checkAgentWorking: (pid) => adapter.isWorkerActive(pid),
-          nudgeWorker: (opts) => adapter.nudgeWorker(opts),
+          nudgeWorker: interactiveStage ? undefined : (opts) => adapter.nudgeWorker(opts),
         });
         const after = captureGitState(cwdForGit);
 
@@ -745,13 +771,16 @@ export const runContractPipeline = async (options: {
 
         if (stage === 'implement' && result.status === 'passed') {
           // Status is tracked in run manifest only — don't touch main contract.
-          // Commit implementer changes to the worktree branch.
-          // The verifier runs next and expects a clean git state — untracked
-          // implementation files would otherwise be flagged as missing.
-          if (wPath) {
+          // Commit implementer changes. In worktree mode they land on the
+          // worktree branch; in root mode on the current root branch
+          // (contract/C-XXX). The verifier runs next and expects a clean git
+          // state — untracked implementation files would otherwise be flagged
+          // as missing.
+          const commitCwd = wPath || (options.rootMode ? options.repoRoot : '');
+          if (commitCwd) {
             try {
               commitAll({
-                cwd: wPath,
+                cwd: commitCwd,
                 message: `Feat: Contract ${manifest.contractId} — implementation`,
                 authorName: 'Pi Agent',
                 authorEmail: 'agent@pi.internal',
@@ -759,7 +788,7 @@ export const runContractPipeline = async (options: {
               pipelineLog({
                 runId: manifest.runId,
                 cwd: options.repoRoot,
-                message: 'Implementer changes committed to worktree.',
+                message: 'Implementer changes committed.',
               });
             } catch (commitErr: unknown) {
               const msg = commitErr instanceof Error ? commitErr.message : String(commitErr);
@@ -866,6 +895,7 @@ export const runContractPipeline = async (options: {
                   manifest,
                   repoRoot: options.repoRoot,
                   baseBranch: PIPELINE_BASE_BRANCH,
+                  rootMode: options.rootMode,
                 });
                 pipelineLog({
                   runId: manifest.runId,
@@ -910,6 +940,7 @@ export const runContractPipeline = async (options: {
                   manifest,
                   repoRoot: options.repoRoot,
                   baseBranch: PIPELINE_BASE_BRANCH,
+                  rootMode: options.rootMode,
                 });
                 console.log(`\n🚀 YOLO: Branch pushed (verifier findings → CodeRabbit).\n`);
               } catch (e: unknown) {

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -694,7 +694,7 @@ export const runContractPipeline = async (options: {
         const feedback =
           stage === 'implement' ? verifierFeedback({ manifest, attempt }) : undefined;
 
-        const interactiveStage = !!options.interactiveWriter && stage === 'write_contract';
+        const interactiveStage = !!options.interactiveWriter && stage === 'write_contract' && attempt === 1;
         const outcome = await runStage({
           repoRoot: options.repoRoot,
           runDirectory: runDirectory({ runId: manifest.runId, cwd: options.repoRoot }),

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -22,7 +22,11 @@ import {
 import { resolveContract } from './contract_resolver.ts';
 import { readContractStatus, updateContractStatus } from './contract_status.ts';
 import { captureGitState, currentCommit } from './git_state.ts';
-import { ContractHerdrAdapter, type ContractHerdrAdapterInterface } from './herdr_adapter.ts';
+import {
+  buildWorkspaceLabel,
+  ContractHerdrAdapter,
+  type ContractHerdrAdapterInterface,
+} from './herdr_adapter.ts';
 import {
   acquireLock,
   createManifest,
@@ -632,7 +636,11 @@ export const runContractPipeline = async (options: {
     return manifest;
   }
 
-  const buildWsLabel = (cid: string): string => `aikami-contract-${cid}`;
+  // Workspace label MUST match ContractHerdrAdapter's — root mode uses the
+  // standard aikami-{mode} workspace, worktree mode uses aikami-contract-{id}.
+  // A mismatch would make checkWorkspaceAlive always return false in root
+  // mode, breaking the lock on a live pipeline.
+  const buildWsLabel = (cid: string): string => buildWorkspaceLabel({ contractId: cid, rootMode });
   await acquireLock({
     contractId: manifest.contractId,
     runId: manifest.runId,
@@ -694,7 +702,8 @@ export const runContractPipeline = async (options: {
         const feedback =
           stage === 'implement' ? verifierFeedback({ manifest, attempt }) : undefined;
 
-        const interactiveStage = !!options.interactiveWriter && stage === 'write_contract' && attempt === 1;
+        const interactiveStage =
+          !!options.interactiveWriter && stage === 'write_contract' && attempt === 1;
         const outcome = await runStage({
           repoRoot: options.repoRoot,
           runDirectory: runDirectory({ runId: manifest.runId, cwd: options.repoRoot }),

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -620,9 +620,14 @@ export const runContractPipeline = async (options: {
       baselineFingerprint: captureGitState(options.repoRoot).fingerprint,
       startStage,
       skipAuthoring: options.skipAuthoring,
+      rootMode: options.rootMode,
     });
     writeManifest({ manifest, cwd: options.repoRoot });
   }
+  // Effective root mode: an explicit CLI flag wins; otherwise resume the
+  // persisted mode from the manifest so `bun run contract --resume <run-id>`
+  // keeps the original --root/--worktree decision.
+  const rootMode = options.rootMode ?? manifest.rootMode ?? false;
   if (options.dryRun) {
     return manifest;
   }
@@ -652,7 +657,7 @@ export const runContractPipeline = async (options: {
       runId: manifest.runId,
       contractId: manifest.contractId,
       interactiveWriter: options.interactiveWriter,
-      rootMode: options.rootMode,
+      rootMode,
     });
 
   try {
@@ -776,7 +781,7 @@ export const runContractPipeline = async (options: {
           // (contract/C-XXX). The verifier runs next and expects a clean git
           // state — untracked implementation files would otherwise be flagged
           // as missing.
-          const commitCwd = wPath || (options.rootMode ? options.repoRoot : '');
+          const commitCwd = wPath || (rootMode ? options.repoRoot : '');
           if (commitCwd) {
             try {
               commitAll({
@@ -895,7 +900,7 @@ export const runContractPipeline = async (options: {
                   manifest,
                   repoRoot: options.repoRoot,
                   baseBranch: PIPELINE_BASE_BRANCH,
-                  rootMode: options.rootMode,
+                  rootMode,
                 });
                 pipelineLog({
                   runId: manifest.runId,
@@ -940,7 +945,7 @@ export const runContractPipeline = async (options: {
                   manifest,
                   repoRoot: options.repoRoot,
                   baseBranch: PIPELINE_BASE_BRANCH,
-                  rootMode: options.rootMode,
+                  rootMode,
                 });
                 console.log(`\n🚀 YOLO: Branch pushed (verifier findings → CodeRabbit).\n`);
               } catch (e: unknown) {

--- a/scripts/src/lib/agents/contract_pipeline/prompt_loader.ts
+++ b/scripts/src/lib/agents/contract_pipeline/prompt_loader.ts
@@ -41,6 +41,13 @@ export const loadRolePrompt = (options: {
   role: ContractWorkerRole;
   contractPath: string;
   repoRoot: string;
+  /** True for the interactive writer (direct draft): the agent waits for the
+   *  user's feature description in the chat instead of executing a task
+   *  immediately. Overrides the completion handoff so it never blocks early. */
+  interactiveWriter?: boolean;
+  /** Absolute path to the per-stage task brief file. The interactive writer
+   *  reads it once the user describes the feature. */
+  taskBriefPath?: string;
 }): string => {
   const promptPath = resolve(options.repoRoot, ROLE_PROMPTS[options.role]);
   if (!existsSync(promptPath)) {
@@ -52,9 +59,15 @@ export const loadRolePrompt = (options: {
   );
   const contractId = contractArgument.match(/(C-\d+|MIG-\d+)/)?.[0] ?? contractArgument;
   const contractExistsOnDisk = existsSync(resolve(options.contractPath));
+  // For the interactive writer, don't present the placeholder path as task
+  // input — the agent would treat it as a job to execute. Its real input is
+  // the feature the user types in the chat.
+  const userInput = options.interactiveWriter
+    ? '(direct draft — awaiting your feature description in the chat)'
+    : contractArgument;
   const canonical = stripFrontmatter(readFileSync(promptPath, 'utf-8')).replace(
     /\$ARGUMENTS\b/g,
-    contractArgument,
+    userInput,
   );
   const creationInstruction =
     options.role === 'writer' && !contractExistsOnDisk
@@ -90,13 +103,36 @@ export const loadRolePrompt = (options: {
           '- The worst outcome is a blocked pipeline waiting for human input.',
         ].join('\n')
       : '';
+  // The interactive writer is a human-in-the-loop stage: it must WAIT for the
+  // user's description. The standard completion handoff ("finish with blocked")
+  // would make it abort when no description has arrived yet — exactly what
+  // happened before. Replace it with explicit wait instructions.
+  const completionHandoff = options.interactiveWriter
+    ? [
+        '\n## 🔴 INTERACTIVE DIRECT DRAFT — WAIT FOR THE USER',
+        'You are the Contract Writer for a direct draft. The user will describe',
+        'their feature in this chat. You have NO task to execute yet.',
+        '',
+        '- Do NOT inspect the codebase, scan the backlog, or write any file',
+        '  until the user describes their feature.',
+        '- Do NOT call `contract_stage_complete` before the contract is written.',
+        '- When the user describes the feature, read your task brief at:',
+        `  ${options.taskBriefPath ?? '(see your task brief path in the welcome message)'}`,
+        '  and follow it exactly: derive a slug → create',
+        '  `docs/contracts/C-XXX-<slug>.md` → read `docs/contracts/TEMPLATE.md` →',
+        '  inspect the codebase → fill every section (no TBD) → set status to',
+        '  `draft` → call `contract_stage_complete` with status `passed`.',
+      ].join('\n')
+    : [
+        '\n## 🔴 MANDATORY COMPLETION HANDOFF',
+        'Do not ask questions. If input is required, finish with `blocked`.',
+        '🔴 Your last action MUST be a call to `contract_stage_complete`.',
+      ].join('\n');
   return [
     canonical,
     creationInstruction,
     criticInstruction,
-    '\n## 🔴 MANDATORY COMPLETION HANDOFF',
-    'Do not ask questions. If input is required, finish with `blocked`.',
-    '🔴 Your last action MUST be a call to `contract_stage_complete`.',
+    completionHandoff,
     '\n## 🔴 EXECUTION RULES',
     '- For moon/test/build: use `moon_run_task` or `validate()` — built-in timeouts.',
     '- For any shell >10s: use `ctx_execute` or `bash` with explicit `timeout`.',

--- a/scripts/src/lib/agents/contract_pipeline/stage_runner.ts
+++ b/scripts/src/lib/agents/contract_pipeline/stage_runner.ts
@@ -57,6 +57,10 @@ export const runStage = async (options: {
   hardTimeoutMs: number;
   pollIntervalMs?: number;
   feedback?: string;
+  /** True for the interactive writer stage (direct draft). The agent waits
+   *  for the user's description in the chat — loadRolePrompt gets the wait
+   *  instructions and the task brief path. */
+  interactiveWriter?: boolean;
   launchWorker: (request: WorkerLaunchRequest) => Promise<{ paneId: string }>;
   checkAgentWorking?: (paneId: string) => Promise<boolean>;
   nudgeWorker?: (opts: { paneId: string; message: string }) => Promise<void>;
@@ -115,6 +119,10 @@ export const runStage = async (options: {
     role,
     contractPath: options.contractPath,
     repoRoot: options.repoRoot,
+    interactiveWriter: options.interactiveWriter,
+    taskBriefPath: options.interactiveWriter
+      ? join(options.runDirectory, 'prompts', `${options.stage}-${options.attempt}-task.md`)
+      : undefined,
   });
   const userMessage = options.feedback?.trim()
     ? feedbackMessage({ role, feedback: options.feedback })

--- a/scripts/src/lib/agents/contract_pipeline/types.ts
+++ b/scripts/src/lib/agents/contract_pipeline/types.ts
@@ -131,6 +131,10 @@ export type RunManifest = {
    *  Used during resume to prevent a draft path-sourced run from being reset
    *  to write_contract when resumed by run ID without a target. */
   skipAuthoring?: boolean;
+  /** When true, the run executes on the root branch (contract/C-XXX) in the
+   *  main checkout instead of a git worktree. Persisted so a resumed run
+   *  remembers the original `--root` invocation. */
+  rootMode?: boolean;
 };
 
 /** Request passed to the Herdr worker launcher. */


### PR DESCRIPTION
## Fix: contract pipeline `--root` mode, resume persistence, interactive writer, gh_create_pr doc-write guard

### Bug 1 (reported): `--root` created a worktree + empty branch

`bun run contract C-372 --root` should run entirely on the root branch `contract/C-372` — **no git worktrees**. Instead the run created `.pi/workspaces/run-msceuj7j-c-372/` and pushed an **empty** remote branch (`contract-task-c-372-msceuj7j` at the base commit), while the verified implementation sat uncommitted in the root working tree.

**Root cause**: `orchestrator.ts` leaked worktree usage in root mode:
1. `reconcileWorkspace()` unconditionally called `provisionGitWorktree` at verify→review handoff — created a fresh worktree from `origin/main`, committed nothing into it, and pushed that empty branch.
2. Implementer `commitAll` was gated on `if (wPath)` — root mode returns `wPath=''`, so implementation changes were never committed to `contract/C-372`.

### Bug 2 (reported): rootMode not remembered across resume

`RunManifest` had no `rootMode` field. `bun run contract --resume <run-id>` without re-passing `--root` silently resumed in worktree mode.

**Fix**: `RunManifest` persists `rootMode`; orchestrator resolves effective root mode as `CLI flag ?? manifest value`; CLI resume hydrates `--root` + target from the manifest and accepts the leftover tree state (the mid-run working tree IS the run's state).

### Bug 3 (reported): gh_create_pr clobbered a contract doc

`gh_create_pr` auto-writes `docs/contracts/C-XXX-*.md` frontmatter when the PR title **or body** matches `C-\d+`. PR #100's body mentioned C-372 in prose ("ran C-372 to reproduce"), so it overwrote the C-372 doc's `pr_url` from #99 to #100 — even though #100 is not a C-372 PR.

**Fix**: match the contract ID from the PR **title or head branch** only (`contract/C-372`, `contract-task-c-372-*`). The body is prose and must not trigger doc writes.

### Changes

| File | Change |
|---|---|
| `orchestrator.ts` | `reconcileWorkspace` honors `rootMode` — skips worktree, commits + pushes the current root branch (`contract/C-372`). Effective root mode resolved from CLI flag ?? persisted manifest; used by adapter, implementer commit, both reconcile calls. |
| `types.ts` / `manifest_store.ts` | `RunManifest.rootMode` + `createManifest` persistence. |
| `contract_pipeline.ts` (CLI) | Resume hydrates `--root` + contract target from the manifest; accepts leftover dirty tree (`--dirty`) on root-mode resume. |
| `herdr_adapter.ts` | Interactive writer: leave chat input empty, wait for the user's feature description. |
| `prompt_loader.ts` / `stage_runner.ts` | Interactive-writer prompt gets WAIT-FOR-USER instructions + task brief path. |
| `.pi/extensions/github_cli.ts` | Contract-doc auto-write matches title/branch only — body prose no longer clobbers `pr_url`. |

### Validation

- `scripts:fix` ✓, `scripts:typecheck` ✓, `scripts:test` 8/8 ✓
- All `provisionGitWorktree` call sites root-mode guarded (adapter ×3 + reconcile)

### Note

The pipeline-harness fixes are validated by lint/typecheck/unit tests, but a full end-to-end `--root` run was not re-executed here (C-372 already merged). The next `bun run contract C-XXX --root` should stay on `contract/C-XXX` with no `.pi/workspaces/` worktree, and `--resume` should keep root mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive writer prompts that wait for user input before starting work.
  * Added support for running and resuming contract workflows directly from the repository root.
  * Preserved workflow mode and target details when resuming interrupted runs.
  * Improved contract linking by recognizing IDs from pull request titles and branch names.

* **Bug Fixes**
  * Prevented interactive sessions from sending unintended automatic welcome messages.
  * Improved retry and recovery behavior across workflow modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->