### PR TITLE
feat(herdr): herdr-native git worktrees for parallel pi task sessions

### DIFF
--- a/.pi/extensions/contract_factory.ts
+++ b/.pi/extensions/contract_factory.ts
@@ -17,11 +17,14 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import {
   getGitHeadCommit,
-  provisionGitWorktree,
   runGit,
   sanitizeBranchName,
-  WORKSPACES_DIR,
 } from '../../scripts/src/lib/agents/git_worktree';
+import {
+  bootstrapWorktree,
+  createWorktree,
+  listWorktrees,
+} from '../../scripts/src/lib/herdr/worktree';
 
 // ── Inline parser ───────────────────────────────────────────────
 //
@@ -507,17 +510,20 @@ export default function (pi: ExtensionAPI) {
     name: 'contract_workspace_create',
     label: 'Contract: Create Workspace',
     description:
-      'Provision an isolated Git Worktree for a contract task. ' +
-      'Creates a worktree at .pi/workspaces/<id> on a new branch and returns ' +
-      'the absolute path and branch name. Use BEFORE writing files or ' +
-      'running compilation tools in a contract task. ' +
+      'Provision an isolated herdr-native Git Worktree for a contract task. ' +
+      'Creates a worktree under ~/.herdr/worktrees/<repo>/ (outside the repo) ' +
+      'on branch task/<id>, opens it as a herdr workspace grouped with the repo, ' +
+      'and bootstraps it (direnv, seeds, bun install). Returns the checkout path, ' +
+      'branch name, and herdr workspace id. Use BEFORE writing files or running ' +
+      'compilation tools in a contract task. ' +
       'For interactive development, use `bun run contract C-XXX --root` instead — ' +
       'it works directly in the repo root without a worktree.',
     promptSnippet: 'Use contract_workspace_create to isolate a task in a dedicated Git Worktree.',
     promptGuidelines: [
       'Call this before any file mutations or build steps in a contract pipeline.',
       'Use the returned branch_name for reference.',
-      'Workspace directories live under .pi/workspaces/ and are .gitignored.',
+      'Checkouts live in ~/.herdr/worktrees/<repo>/ and are opened as herdr workspaces (aikami-task-<id>).',
+      'Clean up with `bun herdr:task rm <id>` or `bun run workspace:cleanup`.',
       'For local interactive development, prefer `bun run contract C-XXX --root` which switches the branch directly in the repo root instead of creating a worktree.',
     ],
     parameters: Type.Object({
@@ -530,18 +536,15 @@ export default function (pi: ExtensionAPI) {
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const cwd = ctx.cwd;
       const sanitized = sanitizeBranchName(params.taskId);
-      const wsDir = join(cwd, WORKSPACES_DIR, sanitized);
 
-      // Ensure parent directory exists
-      if (!existsSync(join(cwd, WORKSPACES_DIR))) {
-        mkdirSync(join(cwd, WORKSPACES_DIR), { recursive: true });
-      }
-
-      // Check for existing workspace
-      if (existsSync(wsDir)) {
+      // Check for an existing herdr-native worktree for this task.
+      const existing = (await listWorktrees(cwd)).find(
+        (w) => w.branch === `task/${sanitized}` || w.branch.endsWith(`/${sanitized}`),
+      );
+      if (existing) {
         const existingId = (() => {
           try {
-            return getGitHeadCommit(wsDir);
+            return getGitHeadCommit(existing.path);
           } catch {
             return 'unknown';
           }
@@ -551,46 +554,53 @@ export default function (pi: ExtensionAPI) {
             {
               type: 'text',
               text: [
-                `⚠️ Workspace already exists: \`${wsDir}\``,
+                `⚠️ Worktree already exists: \`${existing.path}\``,
+                `Branch: \`${existing.branch}\``,
                 `HEAD: \`${existingId}\``,
                 '',
-                'Use this existing workspace or run `bun workspace:cleanup` if you need a fresh one.',
+                'Use this existing worktree or run `bun herdr:task rm <id>` if you need a fresh one.',
               ].join('\n'),
             },
           ],
           details: {
-            path: wsDir,
+            path: existing.path,
+            branchName: existing.branch,
             headCommit: existingId,
             alreadyExists: true,
           },
         };
       }
 
-      // Create the Git Worktree
-      const { branchName, headCommit } = provisionGitWorktree({
+      // Create the herdr-native worktree (checkout + workspace in one call).
+      const w = await createWorktree({
+        slug: params.taskId,
         repoRoot: cwd,
-        name: params.taskId,
       });
+      await bootstrapWorktree({ checkoutPath: w.checkoutPath, repoRoot: cwd });
+      const headCommit = getGitHeadCommit(w.checkoutPath);
 
       return {
         content: [
           {
             type: 'text',
             text: [
-              `✅ Git Worktree created: \`${wsDir}\``,
-              `Branch: \`${branchName}\``,
+              `✅ herdr worktree created: \`${w.checkoutPath}\``,
+              `Branch: \`${w.branch}\``,
+              `Workspace: \`${w.workspaceId}\` (label aikami-task-${sanitized})`,
               `HEAD: \`${headCommit}\``,
               '',
               'This worktree is now the active working directory for the task.',
               'Use `contract_workspace_checkpoint` to save progress snapshots.',
               'Use `contract_workspace_complete` when the task is done.',
+              'Ship a PR with `bun herdr:task pr <id>` (or the task_pr tool).',
             ].join('\n'),
           },
         ],
         details: {
-          path: wsDir,
-          branchName,
+          path: w.checkoutPath,
+          branchName: w.branch,
           headCommit,
+          workspaceId: w.workspaceId,
           alreadyExists: false,
         },
       };
@@ -732,7 +742,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: 'contract_workspace_list',
     label: 'Contract: List Workspaces',
-    description: 'List all active Git Worktrees managed under .pi/workspaces/.',
+    description:
+      'List all active herdr-native + legacy Git Worktrees (git worktree list --porcelain).',
     promptSnippet: 'Use contract_workspace_list to inspect active agent workspaces.',
     promptGuidelines: [
       'Use for diagnostics — find orphaned or incomplete workspaces.',
@@ -741,23 +752,16 @@ export default function (pi: ExtensionAPI) {
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const cwd = ctx.cwd;
-      const wsParent = join(cwd, WORKSPACES_DIR);
+      const out = runGit('worktree list --porcelain', { cwd });
+      const entries = out
+        .split('\n')
+        .filter((l) => l.startsWith('worktree '))
+        .map((l) => l.slice('worktree '.length).trim())
+        .filter((p) => p !== cwd);
       const items: { path: string; headCommit: string; branchName: string; description: string }[] =
         [];
 
-      if (!existsSync(wsParent)) {
-        return {
-          content: [{ type: 'text', text: 'No workspaces directory found.' }],
-          details: { workspaces: [] },
-        };
-      }
-
-      const entries = readdirSync(wsParent, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
-        const wsPath = join(wsParent, entry.name);
+      for (const wsPath of entries) {
         try {
           const headCommit = getGitHeadCommit(wsPath);
           const branchName = runGit('rev-parse --abbrev-ref HEAD', { cwd: wsPath });

--- a/.pi/extensions/contract_factory.ts
+++ b/.pi/extensions/contract_factory.ts
@@ -24,6 +24,7 @@ import {
   bootstrapWorktree,
   createWorktree,
   listWorktrees,
+  removeWorktree,
 } from '../../scripts/src/lib/herdr/worktree';
 
 // ── Inline parser ───────────────────────────────────────────────
@@ -523,6 +524,7 @@ export default function (pi: ExtensionAPI) {
       'Call this before any file mutations or build steps in a contract pipeline.',
       'Use the returned branch_name for reference.',
       'Checkouts live in ~/.herdr/worktrees/<repo>/ and are opened as herdr workspaces (aikami-task-<id>).',
+      'The checkout is NOT your active working directory (created with --no-focus) — use the returned path (w.checkoutPath) for every file and command operation.',
       'Clean up with `bun herdr:task rm <id>` or `bun run workspace:cleanup`.',
       'For local interactive development, prefer `bun run contract C-XXX --root` which switches the branch directly in the repo root instead of creating a worktree.',
     ],
@@ -538,10 +540,17 @@ export default function (pi: ExtensionAPI) {
       const sanitized = sanitizeBranchName(params.taskId);
 
       // Check for an existing herdr-native worktree for this task.
-      const existing = (await listWorktrees(cwd)).find(
-        (w) => w.branch === `task/${sanitized}` || w.branch.endsWith(`/${sanitized}`),
-      );
+      const existing = (await listWorktrees(cwd)).find((w) => w.branch === `task/${sanitized}`);
       if (existing) {
+        // Existing (possibly incomplete) worktree — retry bootstrap so a
+        // previous failure is not silently reported as ready.
+        let installed = false;
+        try {
+          const r = await bootstrapWorktree({ checkoutPath: existing.path, repoRoot: cwd });
+          installed = r.installed;
+        } catch {
+          installed = false;
+        }
         const existingId = (() => {
           try {
             return getGitHeadCommit(existing.path);
@@ -557,6 +566,7 @@ export default function (pi: ExtensionAPI) {
                 `⚠️ Worktree already exists: \`${existing.path}\``,
                 `Branch: \`${existing.branch}\``,
                 `HEAD: \`${existingId}\``,
+                installed ? '' : '⚠️  bootstrap incomplete — dependencies may be missing.',
                 '',
                 'Use this existing worktree or run `bun herdr:task rm <id>` if you need a fresh one.',
               ].join('\n'),
@@ -567,6 +577,7 @@ export default function (pi: ExtensionAPI) {
             branchName: existing.branch,
             headCommit: existingId,
             alreadyExists: true,
+            bootstrapped: installed,
           },
         };
       }
@@ -576,7 +587,22 @@ export default function (pi: ExtensionAPI) {
         slug: params.taskId,
         repoRoot: cwd,
       });
-      await bootstrapWorktree({ checkoutPath: w.checkoutPath, repoRoot: cwd });
+      // If bootstrap fails, remove the newly created worktree so a retry
+      // starts clean instead of finding a half-provisioned checkout.
+      let installed = false;
+      try {
+        const r = await bootstrapWorktree({ checkoutPath: w.checkoutPath, repoRoot: cwd });
+        installed = r.installed;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        await removeWorktree({
+          workspaceId: w.workspaceId,
+          checkoutPath: w.checkoutPath,
+          branch: w.branch,
+          repoRoot: cwd,
+        }).catch(() => {});
+        throw new Error(`Worktree bootstrap failed (${message}) — created worktree removed.`);
+      }
       const headCommit = getGitHeadCommit(w.checkoutPath);
 
       return {
@@ -588,8 +614,11 @@ export default function (pi: ExtensionAPI) {
               `Branch: \`${w.branch}\``,
               `Workspace: \`${w.workspaceId}\` (label aikami-task-${sanitized})`,
               `HEAD: \`${headCommit}\``,
+              installed ? '' : '⚠️  bun install failed — run `bun install` manually.',
               '',
-              'This worktree is now the active working directory for the task.',
+              // --no-focus is used at creation: the checkout is NOT the
+              // agent's active cwd. Use it explicitly for all file/command ops.
+              'Use `w.checkoutPath` as the working directory for subsequent file and command operations.',
               'Use `contract_workspace_checkpoint` to save progress snapshots.',
               'Use `contract_workspace_complete` when the task is done.',
               'Ship a PR with `bun herdr:task pr <id>` (or the task_pr tool).',
@@ -602,6 +631,7 @@ export default function (pi: ExtensionAPI) {
           headCommit,
           workspaceId: w.workspaceId,
           alreadyExists: false,
+          bootstrapped: installed,
         },
       };
     },

--- a/.pi/extensions/contract_pipeline.ts
+++ b/.pi/extensions/contract_pipeline.ts
@@ -14,11 +14,8 @@ import type {
   ContractWorkerRole,
 } from '../../scripts/src/lib/agents/contract_pipeline/types';
 import { PIPELINE_BASE_BRANCH } from '../../scripts/src/lib/agents/contract_pipeline/types';
-import {
-  getGitHeadCommit,
-  runGit,
-  sanitizeBranchName,
-} from '../../scripts/src/lib/agents/git_worktree';
+import { getGitHeadCommit, runGit } from '../../scripts/src/lib/agents/git_worktree';
+import { publishWorktree } from '../../scripts/src/lib/herdr/worktree';
 import { runSyncOrThrow } from './lib/process_runner.ts';
 
 const MUTATING_GIT_RE =
@@ -396,87 +393,42 @@ export default function contractPipelineExtension(pi: ExtensionAPI): void {
         };
       }
 
-      // Phase C: Task Completion — GitHub PR Reconciliation
-      let headCommit: string;
-      let branchName: string;
-      try {
-        headCommit = getGitHeadCommit(wsPath);
-        branchName = runGit('rev-parse --abbrev-ref HEAD', { cwd: wsPath });
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `❌ Could not read git state from worktree: ${message}`,
-            },
-          ],
-          isError: true,
-          details: {},
-        };
-      }
-
-      // Derive a safe branch name from the contract ID, workspace name,
-      // or pipeline run ID. Idempotency guard: if a branch with this name
-      // already exists on the remote (from a prior partial run), append a
-      // timestamp token to avoid non-fast-forward push rejection.
+      // Phase C: Task Completion — GitHub PR Reconciliation.
+      // Delegates to the shared herdr-native publishWorktree (single source
+      // of truth): collision-guard + commit all + push. Branch renaming for
+      // native worktrees happens at creation time, so no rename here.
       const contractId =
         params.contractId ?? process.env.CONTRACT_PIPELINE_RUN_ID ?? basename(wsPath);
-      const baseBranchName = `contract-task-${sanitizeBranchName(contractId)}`;
       const baseBranch = params.baseBranch ?? PIPELINE_BASE_BRANCH;
 
-      let headBranch = baseBranchName;
-
-      // Check if the branch already exists on the remote.
+      // Resolve the main repo root from the worktree's .git file
+      // (<repo>/.git/worktrees/<name> → <repo>).
+      let repoRoot = cwd;
       try {
-        const remoteCheck = runSyncOrThrow(
-          'git',
-          ['ls-remote', '--heads', 'origin', `refs/heads/${baseBranchName}`],
-          { cwd, timeoutMs: 10000 },
-        );
-        if (remoteCheck) {
-          // Branch exists — append a short unique token to avoid collision
-          const token = Date.now().toString(36).slice(-6);
-          headBranch = `${baseBranchName}-${token}`;
-          console.log(
-            `  ⚠️  Branch \`${baseBranchName}\` already exists on remote. Using \`${headBranch}\`.`,
-          );
+        const gitFile = readFileSync(join(wsPath, '.git'), 'utf-8');
+        const m = gitFile.match(/^gitdir:\s*(.+)$/);
+        if (m?.[1]) {
+          const gitDir = resolve(m[1]);
+          const idx = gitDir.indexOf('/.git/worktrees/');
+          repoRoot = idx !== -1 ? gitDir.slice(0, idx) : gitDir;
         }
       } catch {
-        // If we can't check, assume the name is safe and proceed.
+        // Not a linked worktree — fall back to cwd.
       }
 
-      // Rename the worktree branch if needed.
-      if (branchName !== headBranch) {
-        try {
-          runGit(`branch -m ${branchName} ${headBranch}`, { cwd: wsPath });
-          branchName = headBranch;
-        } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `❌ Failed to rename branch \`${branchName}\` → \`${headBranch}\`: ${message}`,
-              },
-            ],
-            isError: true,
-            details: { headCommit, branchName },
-          };
-        }
-      }
-
-      // Finalize: commit all changes.
-      const finalMsg = `Feat: Completed contract pipeline task — PR as \`${headBranch}\` (commit: ${headCommit})`;
+      let headBranch: string;
+      let headCommit: string;
       try {
-        runGit(`commit -a --no-verify -m "${finalMsg}"`, { cwd: wsPath });
-      } catch {
-        // No changes to commit — proceed with push.
-      }
-
-      // Push the branch to origin.
-      try {
-        runGit(`push -u origin ${headBranch}`, { cwd: wsPath });
+        const result = await publishWorktree({
+          checkoutPath: wsPath,
+          repoRoot,
+          base: baseBranch,
+          message: `Feat: Contract ${contractId} — pipeline reconcile`,
+          authorName: 'Pi Agent',
+          authorEmail: 'agent@pi.internal',
+        });
+        headBranch = result.headBranch;
+        headCommit = result.headCommit;
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
         return {
@@ -484,17 +436,18 @@ export default function contractPipelineExtension(pi: ExtensionAPI): void {
             {
               type: 'text',
               text: [
-                `❌ Failed to push branch \`${headBranch}\` to remote: ${message}`,
+                `❌ Reconciliation failed: ${message}`,
                 '',
-                'The worktree has been preserved. Manual push:',
+                `The worktree has been preserved: ${wsPath}`,
+                'Manual push:',
                 `  1. cd ${wsPath}`,
-                `  2. git push -u origin ${headBranch}`,
-                `  3. gh pr create --head "${headBranch}" --base ${baseBranch}`,
+                `  2. git push -u origin HEAD`,
+                `  3. gh pr create --head <branch> --base ${baseBranch}`,
               ].join('\n'),
             },
           ],
           isError: true,
-          details: { headCommit, headBranch, workspacePath: wsPath },
+          details: { workspacePath: wsPath },
         };
       }
 

--- a/.pi/extensions/contract_pipeline.ts
+++ b/.pi/extensions/contract_pipeline.ts
@@ -405,10 +405,12 @@ export default function contractPipelineExtension(pi: ExtensionAPI): void {
       // (<repo>/.git/worktrees/<name> → <repo>).
       let repoRoot = cwd;
       try {
-        const gitFile = readFileSync(join(wsPath, '.git'), 'utf-8');
-        const m = gitFile.match(/^gitdir:\s*(.+)$/);
+        // Git writes linked-worktree .git files as `gitdir: <path>\n` —
+        // trim first so the regex is not defeated by the trailing newline.
+        const gitFile = readFileSync(join(wsPath, '.git'), 'utf-8').trim();
+        const m = gitFile.match(/^gitdir:\s*(.+)$/m);
         if (m?.[1]) {
-          const gitDir = resolve(m[1]);
+          const gitDir = resolve(m[1].trim());
           const idx = gitDir.indexOf('/.git/worktrees/');
           repoRoot = idx !== -1 ? gitDir.slice(0, idx) : gitDir;
         }

--- a/.pi/extensions/herdr_orchestrator.ts
+++ b/.pi/extensions/herdr_orchestrator.ts
@@ -17,8 +17,11 @@
 //                     read, list)
 
 // biome-ignore-all lint/style/useNamingConvention: HerDr API response field names (snake_case) — must match external API contract
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
+import { runGit, sanitizeBranchName } from '../../scripts/src/lib/agents/git_worktree';
 import {
   type AikamiMode,
   ALL_SERVICES,
@@ -32,6 +35,7 @@ import {
   startServices,
   stopServices,
 } from '../../scripts/src/lib/herdr/session';
+import { openPullRequest, publishWorktree } from '../../scripts/src/lib/herdr/worktree';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -694,6 +698,89 @@ export default function (pi: ExtensionAPI) {
       },
     });
   }
+
+  // ─────────────────────────────────────────────────────────────
+  // TOOL: task_pr — publish the current task worktree + open a PR
+  // ─────────────────────────────────────────────────────────────
+
+  pi.registerTool({
+    name: 'task_pr',
+    label: 'Task: Open PR from Worktree',
+    description:
+      'Publish the current herdr-native task worktree (commit all changes, push ' +
+      'the branch, with remote-collision guard) and open a GitHub PR to the ' +
+      'requested base branch (default: main). Run from inside a task worktree ' +
+      '(bun herdr:task new <slug>) or pass an explicit checkoutPath.',
+    promptSnippet: 'Use task_pr to ship the current task worktree as a PR to main',
+    promptGuidelines: [
+      'Call after the task work is complete and tests pass.',
+      'Default base is main — pass baseBranch to retarget.',
+      'Set draft=true for a work-in-progress PR.',
+      'The branch is pushed automatically; the worktree is preserved.',
+    ],
+    parameters: Type.Object({
+      checkoutPath: Type.Optional(
+        Type.String({ description: 'Absolute worktree checkout path. Defaults to cwd.' }),
+      ),
+      baseBranch: Type.Optional(Type.String({ default: 'main' })),
+      title: Type.Optional(Type.String()),
+      body: Type.Optional(Type.String()),
+      draft: Type.Optional(Type.Boolean({ default: false })),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const checkoutPath = (params.checkoutPath as string | undefined) ?? ctx.cwd;
+      const base = (params.baseBranch as string | undefined) ?? 'main';
+
+      // Resolve the main repo root from the worktree's .git file.
+      let repoRoot = ctx.cwd;
+      try {
+        const gitFile = readFileSync(join(checkoutPath, '.git'), 'utf-8');
+        const m = gitFile.match(/^gitdir:\s*(.+)$/);
+        if (m?.[1]) {
+          const gitDir = resolve(m[1]);
+          const idx = gitDir.indexOf('/.git/worktrees/');
+          repoRoot = idx !== -1 ? gitDir.slice(0, idx) : gitDir;
+        }
+      } catch {
+        // Not a linked worktree — fall back to cwd.
+      }
+
+      const branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: checkoutPath });
+      const slug = sanitizeBranchName(branch.replace(/^task\//, '').replace(/^worktree\//, ''));
+      const title = (params.title as string | undefined) ?? `Task: ${slug}`;
+
+      const { headBranch, headCommit } = await publishWorktree({
+        checkoutPath,
+        repoRoot,
+        base,
+        message: `Feat: ${slug}`,
+        authorName: 'Pi Agent',
+        authorEmail: 'agent@pi.internal',
+      });
+      const { prUrl, prNumber } = await openPullRequest({
+        headBranch,
+        base,
+        title,
+        body: params.body as string | undefined,
+        draft: (params.draft as boolean | undefined) ?? false,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: [
+              `✅ **PR #${prNumber} opened** (branch \`${headBranch}\` @ \`${headCommit.slice(0, 7)}\`)`,
+              `→ ${prUrl}`,
+              '',
+              'Merge it with gh_merge_pr when CI passes. The worktree is preserved.',
+            ].join('\n'),
+          },
+        ],
+        details: { headBranch, headCommit, prUrl, prNumber, base },
+      };
+    },
+  });
 
   // ─────────────────────────────────────────────────────────────
   // TOOL: herdr_session — aikami dev service lifecycle

--- a/.pi/extensions/herdr_orchestrator.ts
+++ b/.pi/extensions/herdr_orchestrator.ts
@@ -17,8 +17,6 @@
 //                     read, list)
 
 // biome-ignore-all lint/style/useNamingConvention: HerDr API response field names (snake_case) — must match external API contract
-import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { runGit, sanitizeBranchName } from '../../scripts/src/lib/agents/git_worktree';
@@ -35,7 +33,11 @@ import {
   startServices,
   stopServices,
 } from '../../scripts/src/lib/herdr/session';
-import { openPullRequest, publishWorktree } from '../../scripts/src/lib/herdr/worktree';
+import {
+  openPullRequest,
+  publishWorktree,
+  worktreeRepoRoot,
+} from '../../scripts/src/lib/herdr/worktree';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -731,39 +733,77 @@ export default function (pi: ExtensionAPI) {
       const checkoutPath = (params.checkoutPath as string | undefined) ?? ctx.cwd;
       const base = (params.baseBranch as string | undefined) ?? 'main';
 
-      // Resolve the main repo root from the worktree's .git file.
-      let repoRoot = ctx.cwd;
+      // Shared repo-root resolution (single implementation — worktree.ts).
+      let repoRoot: string;
+      let branch: string;
       try {
-        const gitFile = readFileSync(join(checkoutPath, '.git'), 'utf-8');
-        const m = gitFile.match(/^gitdir:\s*(.+)$/);
-        if (m?.[1]) {
-          const gitDir = resolve(m[1]);
-          const idx = gitDir.indexOf('/.git/worktrees/');
-          repoRoot = idx !== -1 ? gitDir.slice(0, idx) : gitDir;
-        }
-      } catch {
-        // Not a linked worktree — fall back to cwd.
+        repoRoot = worktreeRepoRoot(checkoutPath);
+        branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: checkoutPath });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `❌ Could not resolve the task checkout \`${checkoutPath}\`: ${message}`,
+            },
+          ],
+          details: { step: 'resolve_checkout', checkoutPath },
+        };
       }
 
-      const branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: checkoutPath });
       const slug = sanitizeBranchName(branch.replace(/^task\//, '').replace(/^worktree\//, ''));
       const title = (params.title as string | undefined) ?? `Task: ${slug}`;
 
-      const { headBranch, headCommit } = await publishWorktree({
-        checkoutPath,
-        repoRoot,
-        base,
-        message: `Feat: ${slug}`,
-        authorName: 'Pi Agent',
-        authorEmail: 'agent@pi.internal',
-      });
-      const { prUrl, prNumber } = await openPullRequest({
-        headBranch,
-        base,
-        title,
-        body: params.body as string | undefined,
-        draft: (params.draft as boolean | undefined) ?? false,
-      });
+      // Publish (commit + push). If this fails nothing was pushed.
+      let headBranch: string;
+      let headCommit: string;
+      try {
+        ({ headBranch, headCommit } = await publishWorktree({
+          checkoutPath,
+          repoRoot,
+          base,
+          message: `Feat: ${slug}`,
+          authorName: 'Pi Agent',
+          authorEmail: 'agent@pi.internal',
+        }));
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `❌ Publish failed (nothing was pushed): ${message}` }],
+          details: { step: 'publish_worktree', checkoutPath, base },
+        };
+      }
+
+      // Open the PR. The branch IS already pushed at this point — the caller
+      // must not re-publish, only retry the PR step.
+      let prUrl: string;
+      let prNumber: string;
+      try {
+        ({ prUrl, prNumber } = await openPullRequest({
+          headBranch,
+          base,
+          title,
+          body: params.body as string | undefined,
+          draft: (params.draft as boolean | undefined) ?? false,
+        }));
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text:
+                `❌ Branch \`${headBranch}\` was pushed, but \`gh pr create\` failed: ${message}\n` +
+                'Retry the PR step only; do not publish again.',
+            },
+          ],
+          details: { step: 'open_pull_request', headBranch, headCommit, base },
+        };
+      }
 
       return {
         content: [

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "herdr:start": "bun run scripts/src/lib/herdr/start.ts",
     "workspace:cleanup": "bun run scripts/src/lib/ops/workspace_cleanup.ts",
     "herdr:pi": "bun run scripts/src/lib/herdr/start_pi.ts",
+    "herdr:task": "bun run scripts/src/lib/herdr/task.ts",
     "scout": "bun run scripts/src/lib/agents/scout/run.ts",
     "guru": "bun run scripts/src/lib/agents/guru/run.ts",
     "worker": "bun run scripts/src/lib/agents/worker/run.ts",

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -11,7 +11,7 @@ import {
   listWorktrees,
   openWorktree,
 } from '../../herdr/worktree.ts';
-import { remoteBranchExists } from '../git_worktree.ts';
+import { remoteBranchExists, runGit } from '../git_worktree.ts';
 import { logPath } from './manifest_store.ts';
 import { getContractModelForRole, getContractThinkingForRole } from './models.ts';
 import type { ContractWorkerRole, WorkerLaunchRequest } from './types.ts';
@@ -107,6 +107,19 @@ const runHerdr = async (args: string[]): Promise<void> => {
     throw new Error(`Herdr command failed: herdr ${args.join(' ')}`);
   }
 };
+
+/** Expand base tab args with --env KEY=VALUE entries (shared by workers + review). */
+const withEnvArgs = (base: string[], env: string[]): string[] => {
+  const args = [...base];
+  for (const kv of env) {
+    args.push('--env', kv);
+  }
+  return args;
+};
+
+/** Path of the per-run GH_TOKEN file (mode 0600 — never passed as a CLI arg). */
+const ghTokenFilePath = (options: { repoRoot: string; runId: string }): string =>
+  join(options.repoRoot, '.pi/contract-runs', options.runId, 'gh-token');
 
 const atomicWrite = (options: { path: string; content: string }): void => {
   const temporaryPath = `${options.path}.${process.pid}.tmp`;
@@ -323,12 +336,22 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     //    root-scoped workspace, no custom .pi/workspaces provisioning.
     //    Checkouts live in ~/.herdr/worktrees/<repo>/<slug> (outside the
     //    repo), so concurrent sessions on the root checkout are unaffected.
-    const contractId = extractContractId(this._contractId);
-    const runToken = this._runId.replace(/^run-/, '').split('-')[0];
-    const baseBranchName = `contract-task-${contractId.toLowerCase()}-${runToken}`;
-    const branch = remoteBranchExists({ branchName: baseBranchName, repoRoot: this._repoRoot })
-      ? `${baseBranchName}-${Date.now().toString(36).slice(-6)}`
-      : baseBranchName;
+    const baseBranchName = this._baseContractBranch();
+    // Collision guard: a LOCAL branch with the same name (surviving a prior
+    // run that was never pushed, or whose remote branch was deleted) breaks
+    // `herdr worktree create --branch <existing>` just like a remote one.
+    const localExists = ((): boolean => {
+      try {
+        runGit(`rev-parse --verify refs/heads/${baseBranchName}`, { cwd: this._repoRoot });
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+    const branch =
+      localExists || remoteBranchExists({ branchName: baseBranchName, repoRoot: this._repoRoot })
+        ? `${baseBranchName}-${Date.now().toString(36).slice(-6)}`
+        : baseBranchName;
 
     const w = await createWorktree({
       slug: this._runId,
@@ -347,7 +370,9 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       `🔧 herdr worktree: ${w.checkoutPath} (branch: ${w.branch}, workspace: ${w.workspaceId})`,
     );
 
-    await runHerdr(['tab', 'rename', `${this._workspaceId}:1`, 'pipeline']);
+    // Rename the worktree's root tab by its real tab id (positional
+    // `${workspaceId}:1` selectors can drift).
+    await runHerdr(['tab', 'rename', w.tabId || `${this._workspaceId}:1`, 'pipeline']);
     await runPaneCommand({
       paneId: this._pipelinePaneId,
       command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
@@ -380,27 +405,55 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       this._workspacePath = '';
       return;
     }
+    const worktrees = await listWorktrees(this._repoRoot);
     // 1. Look up the open worktree by workspace id.
-    let entry = (await listWorktrees(this._repoRoot)).find(
-      (w) => w.openWorkspaceId === workspaceId,
-    );
+    let entry = worktrees.find((w) => w.openWorkspaceId === workspaceId);
     // 2. Fall back: the workspace may have been closed but the checkout
-    //    persists — find it by branch name and re-open it.
+    //    persists — find it by branch name and re-open it. Accept only the
+    //    exact branch or its single collision-suffix form, and prefer the
+    //    exact name (publishWorktree may append a further suffix after a
+    //    remote collision, so a looser tail is tolerated for the exact base).
     if (!entry) {
-      const contractId = extractContractId(this._contractId);
-      const runToken = this._runId.replace(/^run-/, '').split('-')[0];
-      const branch = `contract-task-${contractId.toLowerCase()}-${runToken}`;
-      const candidates = (await listWorktrees(this._repoRoot)).filter((w) =>
-        w.branch.startsWith(branch),
+      const branch = this._baseContractBranch();
+      const singleSuffix = new RegExp(`^${branch}-[0-9a-z]{1,6}$`);
+      const candidates = worktrees.filter(
+        (w) => w.branch === branch || singleSuffix.test(w.branch),
       );
-      const candidate = candidates.sort((a, b) => b.branch.localeCompare(a.branch))[0];
+      const candidate =
+        candidates.find((w) => w.branch === branch) ??
+        candidates.sort((a, b) => b.branch.localeCompare(a.branch))[0];
       if (candidate) {
         const opened = await openWorktree({
           checkoutPath: candidate.path,
           label: this._workspaceLabel,
           repoRoot: this._repoRoot,
         });
-        this._workspaceId = opened.workspaceId;
+        if (opened.workspaceId !== workspaceId) {
+          // The workspace changed — the old `_pipelinePaneId` points into a
+          // closed workspace. Re-create the pipeline tab in the new one so
+          // `_workspaceId` and `_pipelinePaneId` stay consistent.
+          this._workspaceId = opened.workspaceId;
+          const tab = await herdrJson<TabCreateResult>([
+            'tab',
+            'create',
+            '--workspace',
+            opened.workspaceId,
+            '--cwd',
+            this._repoRoot,
+            '--label',
+            'pipeline',
+            '--no-focus',
+          ]);
+          if (tab?.result) {
+            this._pipelinePaneId = tab.result.root_pane.pane_id;
+            await runPaneCommand({
+              paneId: this._pipelinePaneId,
+              command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+            });
+          }
+        } else {
+          this._workspaceId = opened.workspaceId;
+        }
         entry = candidate;
         entry.openWorkspaceId = opened.workspaceId;
       }
@@ -416,6 +469,13 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     console.log(
       `🔧 herdr worktree recovered: ${entry.path} (branch: ${entry.branch}, workspace: ${this._workspaceId})`,
     );
+  }
+
+  /** Base branch name for this run's worktree (no collision suffix). */
+  private _baseContractBranch(): string {
+    const contractId = extractContractId(this._contractId);
+    const runToken = this._runId.replace(/^run-/, '').split('-')[0];
+    return `contract-task-${contractId.toLowerCase()}-${runToken}`;
   }
 
   private async _closeTabByLabel(label: string): Promise<void> {
@@ -536,9 +596,17 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     if (this._workspacePath) {
       env.push(`CONTRACT_PIPELINE_WORKSPACE_PATH=${this._workspacePath}`);
     }
+    // 🔴 GH_TOKEN is a secret — never pass it as a `--env` CLI argument
+    // (readable via ps /proc/<pid>/cmdline). Write it to a mode-0600 file
+    // and let the worker shell export it from there.
+    let ghExport = '';
     const ghToken = getScriptsEnv('GH_TOKEN') || getScriptsEnv('GITHUB_TOKEN');
     if (ghToken) {
-      env.push(`GH_TOKEN=${ghToken}`);
+      const ghFile = ghTokenFilePath({ repoRoot: this._repoRoot, runId: request.runId });
+      mkdirSync(dirname(ghFile), { recursive: true });
+      writeFileSync(ghFile, ghToken, { mode: 0o600 });
+      env.push(`GH_TOKEN_FILE=${ghFile}`);
+      ghExport = `export GH_TOKEN="$(cat '${ghFile}' 2>/dev/null)"; `;
     }
     const ta = toolsForRole(request.role) ? ['--tools', toolsForRole(request.role)?.join(',')] : [];
     const sa = sessionId !== undefined ? ['--session-id', shellQuote(sessionId)] : [];
@@ -566,6 +634,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       return {
         command: [
           '\n',
+          ghExport,
           'pi',
           '--mode',
           'json',
@@ -585,6 +654,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     return {
       command: [
         '\n',
+        ghExport,
         'pi',
         '--approve',
         ...ma,
@@ -619,20 +689,20 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       options.sessionId,
       this._taskMessagePath(options.request),
     );
-    const tabArgs = [
-      'tab',
-      'create',
-      '--workspace',
-      this._workspaceId,
-      '--cwd',
-      cwd,
-      '--label',
-      options.tabLabel,
-      '--no-focus',
-    ];
-    for (const kv of env) {
-      tabArgs.push('--env', kv);
-    }
+    const tabArgs = withEnvArgs(
+      [
+        'tab',
+        'create',
+        '--workspace',
+        this._workspaceId,
+        '--cwd',
+        cwd,
+        '--label',
+        options.tabLabel,
+        '--no-focus',
+      ],
+      env,
+    );
     const tab = await herdrJson<TabCreateResult>(tabArgs);
     if (!tab?.result) {
       throw new Error(`Failed to create ${options.request.role} worker tab.`);
@@ -775,25 +845,32 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     if (this._workspacePath) {
       reviewEnv.push(`CONTRACT_PIPELINE_WORKSPACE_PATH=${this._workspacePath}`);
     }
+    // GH_TOKEN via a mode-0600 file — never as a --env CLI arg (see
+    // _buildWorkerCommand for the same pattern).
+    let ghExport = '';
     const ghToken = getScriptsEnv('GH_TOKEN') || getScriptsEnv('GITHUB_TOKEN');
     if (ghToken) {
-      reviewEnv.push(`GH_TOKEN=${ghToken}`);
+      const ghFile = ghTokenFilePath({ repoRoot: this._repoRoot, runId: this._runId });
+      mkdirSync(dirname(ghFile), { recursive: true });
+      writeFileSync(ghFile, ghToken, { mode: 0o600 });
+      reviewEnv.push(`GH_TOKEN_FILE=${ghFile}`);
+      ghExport = `export GH_TOKEN="$(cat '${ghFile}' 2>/dev/null)"; `;
     }
 
-    const tabArgs = [
-      'tab',
-      'create',
-      '--workspace',
-      this._workspaceId,
-      '--cwd',
-      options.yolo && this._workspacePath ? this._workspacePath : this._repoRoot,
-      '--label',
-      'review',
-      '--no-focus',
-    ];
-    for (const kv of reviewEnv) {
-      tabArgs.push('--env', kv);
-    }
+    const tabArgs = withEnvArgs(
+      [
+        'tab',
+        'create',
+        '--workspace',
+        this._workspaceId,
+        '--cwd',
+        options.yolo && this._workspacePath ? this._workspacePath : this._repoRoot,
+        '--label',
+        'review',
+        '--no-focus',
+      ],
+      reviewEnv,
+    );
     const tab = await herdrJson<TabCreateResult>(tabArgs);
     if (!tab?.result) {
       throw new Error('Failed to create review tab.');
@@ -817,6 +894,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     // newline so the dropped char is never the first letter of the command.
     const command = [
       '\n',
+      ghExport,
       'pi',
       '--approve',
       '--model',

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -1,12 +1,17 @@
 // scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
 // biome-ignore-all lint/style/useNamingConvention: Herdr JSON fields mirror the external CLI contract
 
-import { execSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { getScriptsEnv } from '../../env/scripts_env';
 import { ensureServer, findWorkspace, herdr, herdrJson } from '../../herdr/session.ts';
-import { provisionGitWorktree } from '../git_worktree.ts';
+import {
+  bootstrapWorktree,
+  createWorktree,
+  listWorktrees,
+  openWorktree,
+} from '../../herdr/worktree.ts';
+import { remoteBranchExists } from '../git_worktree.ts';
 import { logPath } from './manifest_store.ts';
 import { getContractModelForRole, getContractThinkingForRole } from './models.ts';
 import type { ContractWorkerRole, WorkerLaunchRequest } from './types.ts';
@@ -151,6 +156,8 @@ export type ContractHerdrAdapterInterface = {
   initialize(): Promise<{ workspaceId: string; pipelinePaneId: string }>;
   getWorkspaceId(): string;
   getWorkspacePath(): string;
+  /** Branch the herdr-native worktree has checked out (worktree mode only). */
+  getWorktreeBranch(): string;
   launchWorker(request: WorkerLaunchRequest): Promise<{ paneId: string }>;
   isWorkerActive(paneId: string): Promise<boolean>;
   nudgeWorker(options: { paneId: string; message: string }): Promise<void>;
@@ -188,6 +195,7 @@ export const buildWorkspaceLabel = (options: {
 export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
   private readonly _repoRoot: string;
   private readonly _runId: string;
+  private readonly _contractId: string;
   private readonly _workspaceLabel: string;
   private readonly _headless: boolean;
   /** When true, the writer stage runs in interactive TUI mode so the user can
@@ -200,6 +208,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
   private _workspaceId = '';
   private _pipelinePaneId = '';
   private _workspacePath = '';
+  private _worktreeBranch = '';
 
   constructor(options: {
     repoRoot: string;
@@ -211,6 +220,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
   }) {
     this._repoRoot = options.repoRoot;
     this._runId = options.runId;
+    this._contractId = options.contractId;
     this._workspaceLabel = buildWorkspaceLabel({
       contractId: options.contractId,
       rootMode: options.rootMode,
@@ -253,7 +263,7 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
           });
         }
         if (!this._rootMode) {
-          this._provisionGitWorktree();
+          await this._provisionHerdrWorktree(existingWorkspaceId);
         }
         return { workspaceId: this._workspaceId, pipelinePaneId: this._pipelinePaneId };
       }
@@ -278,32 +288,70 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
         command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
       });
       if (!this._rootMode) {
-        this._provisionGitWorktree();
+        await this._provisionHerdrWorktree(existingWorkspaceId);
       }
       return { workspaceId: this._workspaceId, pipelinePaneId: this._pipelinePaneId };
     }
-    const result = await herdrJson<WorkspaceCreateResult>([
-      'workspace',
-      'create',
-      '--cwd',
-      this._repoRoot,
-      '--label',
-      label,
-      '--no-focus',
-    ]);
-    if (!result?.result) {
-      throw new Error(`Failed to create Herdr workspace for ${this._runId}.`);
+
+    if (this._rootMode) {
+      // Root mode: standard aikami-{mode} workspace at the repo root, no worktree.
+      const result = await herdrJson<WorkspaceCreateResult>([
+        'workspace',
+        'create',
+        '--cwd',
+        this._repoRoot,
+        '--label',
+        label,
+        '--no-focus',
+      ]);
+      if (!result?.result) {
+        throw new Error(`Failed to create Herdr workspace for ${this._runId}.`);
+      }
+      this._workspaceId = result.result.workspace.workspace_id;
+      this._pipelinePaneId = result.result.root_pane.pane_id;
+      await runHerdr(['tab', 'rename', result.result.tab.tab_id, 'pipeline']);
+      await runPaneCommand({
+        paneId: this._pipelinePaneId,
+        command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+      });
+      return { workspaceId: this._workspaceId, pipelinePaneId: this._pipelinePaneId };
     }
-    this._workspaceId = result.result.workspace.workspace_id;
-    this._pipelinePaneId = result.result.root_pane.pane_id;
-    await runHerdr(['tab', 'rename', result.result.tab.tab_id, 'pipeline']);
+
+    // ── Worktree mode: `herdr worktree create` provisions the checkout AND
+    //    opens it as a herdr workspace grouped with the parent repo. The
+    //    worktree workspace IS the pipeline workspace — no separate
+    //    root-scoped workspace, no custom .pi/workspaces provisioning.
+    //    Checkouts live in ~/.herdr/worktrees/<repo>/<slug> (outside the
+    //    repo), so concurrent sessions on the root checkout are unaffected.
+    const contractId = extractContractId(this._contractId);
+    const runToken = this._runId.replace(/^run-/, '').split('-')[0];
+    const baseBranchName = `contract-task-${contractId.toLowerCase()}-${runToken}`;
+    const branch = remoteBranchExists({ branchName: baseBranchName, repoRoot: this._repoRoot })
+      ? `${baseBranchName}-${Date.now().toString(36).slice(-6)}`
+      : baseBranchName;
+
+    const w = await createWorktree({
+      slug: this._runId,
+      branch,
+      base: PIPELINE_BASE_BRANCH,
+      label,
+      repoRoot: this._repoRoot,
+    });
+    this._workspaceId = w.workspaceId;
+    this._pipelinePaneId = w.rootPaneId;
+    this._workspacePath = w.checkoutPath;
+    this._worktreeBranch = w.branch;
+
+    await bootstrapWorktree({ checkoutPath: w.checkoutPath, repoRoot: this._repoRoot });
+    console.log(
+      `🔧 herdr worktree: ${w.checkoutPath} (branch: ${w.branch}, workspace: ${w.workspaceId})`,
+    );
+
+    await runHerdr(['tab', 'rename', `${this._workspaceId}:1`, 'pipeline']);
     await runPaneCommand({
       paneId: this._pipelinePaneId,
       command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
     });
-    if (!this._rootMode) {
-      this._provisionGitWorktree();
-    }
     return { workspaceId: this._workspaceId, pipelinePaneId: this._pipelinePaneId };
   }
 
@@ -316,19 +364,58 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
   getWorkspacePath(): string {
     return this._workspacePath;
   }
+  /** Branch the worktree has checked out (worktree mode only). */
+  getWorktreeBranch(): string {
+    return this._worktreeBranch;
+  }
 
-  private _provisionGitWorktree(): void {
+  /**
+   * Resolve the herdr-native worktree state for an existing pipeline
+   * workspace (recovery after a crash / resume). The checkout survives
+   * `workspace close` — re-derive its path from herdr provenance and
+   * re-open it if the workspace was closed.
+   */
+  private async _provisionHerdrWorktree(workspaceId: string): Promise<void> {
     if (this._rootMode) {
       this._workspacePath = '';
       return;
     }
-    const { workspacePath, branchName, headCommit } = provisionGitWorktree({
-      repoRoot: this._repoRoot,
-      name: this._runId,
-      baseRevision: PIPELINE_BASE_BRANCH,
-    });
-    this._workspacePath = workspacePath;
-    console.log(`🔧 git worktree: ${workspacePath} (branch: ${branchName}, commit: ${headCommit})`);
+    // 1. Look up the open worktree by workspace id.
+    let entry = (await listWorktrees(this._repoRoot)).find(
+      (w) => w.openWorkspaceId === workspaceId,
+    );
+    // 2. Fall back: the workspace may have been closed but the checkout
+    //    persists — find it by branch name and re-open it.
+    if (!entry) {
+      const contractId = extractContractId(this._contractId);
+      const runToken = this._runId.replace(/^run-/, '').split('-')[0];
+      const branch = `contract-task-${contractId.toLowerCase()}-${runToken}`;
+      const candidates = (await listWorktrees(this._repoRoot)).filter((w) =>
+        w.branch.startsWith(branch),
+      );
+      const candidate = candidates.sort((a, b) => b.branch.localeCompare(a.branch))[0];
+      if (candidate) {
+        const opened = await openWorktree({
+          checkoutPath: candidate.path,
+          label: this._workspaceLabel,
+          repoRoot: this._repoRoot,
+        });
+        this._workspaceId = opened.workspaceId;
+        entry = candidate;
+        entry.openWorkspaceId = opened.workspaceId;
+      }
+    }
+    if (!entry) {
+      throw new Error(
+        `Cannot recover herdr worktree for run ${this._runId} (workspace ${workspaceId}). ` +
+          'The checkout was removed externally — start a fresh run.',
+      );
+    }
+    this._workspacePath = entry.path;
+    this._worktreeBranch = entry.branch;
+    console.log(
+      `🔧 herdr worktree recovered: ${entry.path} (branch: ${entry.branch}, workspace: ${this._workspaceId})`,
+    );
   }
 
   private async _closeTabByLabel(label: string): Promise<void> {
@@ -429,29 +516,30 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     request: WorkerLaunchRequest,
     sessionId: string | undefined,
     taskMessagePath: string,
-  ): string {
+  ): { command: string; env: string[] } {
     const pd = join(this._repoRoot, '.pi/contract-runs', request.runId, 'prompts');
     mkdirSync(pd, { recursive: true });
     const pp = join(pd, `${request.stage}-${request.attempt}.md`);
     atomicWrite({ path: pp, content: request.prompt });
-    const wsEnv = this._workspacePath
-      ? `CONTRACT_PIPELINE_WORKSPACE_PATH=${shellQuote(this._workspacePath)}`
-      : '';
-    const ghToken = getScriptsEnv('GH_TOKEN') || getScriptsEnv('GITHUB_TOKEN');
-    const ghEnv = ghToken ? `GH_TOKEN=${shellQuote(ghToken)}` : '';
-    const env = [
-      `CONTRACT_PIPELINE_RUN_ID=${shellQuote(request.runId)}`,
-      `CONTRACT_PIPELINE_ROLE=${shellQuote(request.role)}`,
-      `CONTRACT_PIPELINE_STAGE=${shellQuote(request.stage)}`,
+    // Env vars are passed via `tab create --env KEY=VALUE` (herdr sets them
+    // on the tab's shell) instead of inline `KEY=V pi ...` shell prefixes.
+    // This eliminates the inline-env first-character-drop hazard entirely.
+    const env: string[] = [
+      `CONTRACT_PIPELINE_RUN_ID=${request.runId}`,
+      `CONTRACT_PIPELINE_ROLE=${request.role}`,
+      `CONTRACT_PIPELINE_STAGE=${request.stage}`,
       `CONTRACT_PIPELINE_ATTEMPT=${String(request.attempt)}`,
-      `CONTRACT_PIPELINE_CONTRACT_PATH=${shellQuote(request.contractPath)}`,
-      `CONTRACT_PIPELINE_RESULT_PATH=${shellQuote(request.resultPath)}`,
+      `CONTRACT_PIPELINE_CONTRACT_PATH=${request.contractPath}`,
+      `CONTRACT_PIPELINE_RESULT_PATH=${request.resultPath}`,
       'HERDR_DISABLE_SOUND=1',
-      wsEnv,
-      ghEnv,
-    ]
-      .filter(Boolean)
-      .join(' ');
+    ];
+    if (this._workspacePath) {
+      env.push(`CONTRACT_PIPELINE_WORKSPACE_PATH=${this._workspacePath}`);
+    }
+    const ghToken = getScriptsEnv('GH_TOKEN') || getScriptsEnv('GITHUB_TOKEN');
+    if (ghToken) {
+      env.push(`GH_TOKEN=${ghToken}`);
+    }
     const ta = toolsForRole(request.role) ? ['--tools', toolsForRole(request.role)?.join(',')] : [];
     const sa = sessionId !== undefined ? ['--session-id', shellQuote(sessionId)] : [];
     const ma = [
@@ -469,41 +557,44 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     // - interactiveWriter + writer role → TUI so the user can chat directly
     //   with the writer pi session to describe the feature
     //
-    // 🔴 Herdr PTY drops the first character via pane run too — prepend newline
-    // to protect inline env vars ('C' in CONTRACT_PIPELINE_RUN_ID).
-    // Without this, the shell tries to execute "ONTRACT_PIPELINE_RUN_ID=..." as a
-    // command, losing all pipeline env vars.
+    // 🔴 Herdr PTY drops the first character via pane run — keep the leading
+    // newline so the dropped char is never 'p' of 'pi'. With env vars moved
+    // to tab --env there is no inline env prefix to corrupt.
     const useHeadless = this._useJsonMode(request.role);
     if (useHeadless) {
       const cf = `$(cat ${shellQuote(taskMessagePath)})`;
-      return [
-        '\n',
+      return {
+        command: [
+          '\n',
+          'pi',
+          '--mode',
+          'json',
+          '--approve',
+          ...ma,
+          ...sa,
+          '--append-system-prompt',
+          shellQuote(pp),
+          ...ta,
+          '-p',
+          `"${cf}"`,
+        ].join(' '),
         env,
+      };
+    }
+    // TUI mode — no -p, prompt is sent via _sendTaskText to the PTY.
+    return {
+      command: [
+        '\n',
         'pi',
-        '--mode',
-        'json',
         '--approve',
         ...ma,
         ...sa,
         '--append-system-prompt',
         shellQuote(pp),
         ...ta,
-        '-p',
-        `"${cf}"`,
-      ].join(' ');
-    }
-    // TUI mode — no -p, prompt is sent via _sendTaskText to the PTY.
-    return [
-      '\n',
+      ].join(' '),
       env,
-      'pi',
-      '--approve',
-      ...ma,
-      ...sa,
-      '--append-system-prompt',
-      shellQuote(pp),
-      ...ta,
-    ].join(' ');
+    };
   }
 
   private async _createWorkerTab(options: {
@@ -521,31 +612,14 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       mkdirSync(dirname(wcp), { recursive: true });
       copyFileSync(options.request.contractPath, wcp);
     }
-    // Copy generated paraglide files from main repo to worktree.
-    // These are gitignored and generated by Vite/bun install — without
-    // them the client can't typecheck, build, or start dev servers.
-    if (cwd !== this._repoRoot) {
-      const paraglideSrc = join(this._repoRoot, 'apps/frontend/client/src/lib/paraglide');
-      const paraglideDst = join(cwd, 'apps/frontend/client/src/lib/paraglide');
-      if (existsSync(paraglideSrc) && !existsSync(paraglideDst)) {
-        try {
-          execSync(`cp -r '${paraglideSrc}' '${paraglideDst}'`, { stdio: 'pipe' });
-        } catch {
-          /* non-fatal */
-        }
-      }
-      // Also copy .env files for dev server configuration.
-      for (const envFile of ['.env', '.env.local', '.env.emulator']) {
-        const envSrc = join(this._repoRoot, `apps/frontend/client/${envFile}`);
-        const envDst = join(cwd, `apps/frontend/client/${envFile}`);
-        if (existsSync(envSrc) && !existsSync(envDst)) {
-          try {
-            copyFileSync(envSrc, envDst);
-          } catch {}
-        }
-      }
-    }
-    const tab = await herdrJson<TabCreateResult>([
+    // (Paraglide + .env seeding moved to bootstrapWorktree — it runs once
+    // at initialize(), so worker tabs no longer need to copy them.)
+    const { command, env } = this._buildWorkerCommand(
+      options.request,
+      options.sessionId,
+      this._taskMessagePath(options.request),
+    );
+    const tabArgs = [
       'tab',
       'create',
       '--workspace',
@@ -555,7 +629,11 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       '--label',
       options.tabLabel,
       '--no-focus',
-    ]);
+    ];
+    for (const kv of env) {
+      tabArgs.push('--env', kv);
+    }
+    const tab = await herdrJson<TabCreateResult>(tabArgs);
     if (!tab?.result) {
       throw new Error(`Failed to create ${options.request.role} worker tab.`);
     }
@@ -625,22 +703,11 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       );
     }
 
-    const taskMessagePath = join(
-      this._repoRoot,
-      '.pi/contract-runs',
-      options.request.runId,
-      'prompts',
-      `${options.request.stage}-${options.request.attempt}-task.md`,
-    );
+    const taskMessagePath = this._taskMessagePath(options.request);
     mkdirSync(dirname(taskMessagePath), { recursive: true });
     atomicWrite({ path: taskMessagePath, content: parts.join('\n\n') });
 
-    const startCommand = this._buildWorkerCommand(
-      options.request,
-      options.sessionId,
-      taskMessagePath,
-    );
-    await runPaneCommand({ paneId, command: startCommand });
+    await runPaneCommand({ paneId, command });
 
     if (!this._useJsonMode(options.request.role)) {
       // TUI mode — send task text via PTY.
@@ -662,6 +729,17 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       }
     }
     return { paneId };
+  }
+
+  /** Path of the worker task brief (written by _createWorkerTab). */
+  private _taskMessagePath(request: WorkerLaunchRequest): string {
+    return join(
+      this._repoRoot,
+      '.pi/contract-runs',
+      request.runId,
+      'prompts',
+      `${request.stage}-${request.attempt}-task.md`,
+    );
   }
 
   async launchWorker(request: WorkerLaunchRequest): Promise<{ paneId: string }> {
@@ -687,7 +765,22 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     const sessionId = buildSessionId({ contractId, runId: this._runId, role: 'review' });
     await this._closeTabByLabel('review');
 
-    const tab = await herdrJson<TabCreateResult>([
+    // Review env vars via tab --env (same mechanism as workers).
+    const reviewEnv: string[] = [
+      `CONTRACT_PIPELINE_RUN_ID=${this._runId}`,
+      'CONTRACT_PIPELINE_ROLE=review',
+      `CONTRACT_PIPELINE_CONTRACT_PATH=${options.contractPath}`,
+      `CONTRACT_PIPELINE_REVIEW_PATH=${options.reviewDecisionPath}`,
+    ];
+    if (this._workspacePath) {
+      reviewEnv.push(`CONTRACT_PIPELINE_WORKSPACE_PATH=${this._workspacePath}`);
+    }
+    const ghToken = getScriptsEnv('GH_TOKEN') || getScriptsEnv('GITHUB_TOKEN');
+    if (ghToken) {
+      reviewEnv.push(`GH_TOKEN=${ghToken}`);
+    }
+
+    const tabArgs = [
       'tab',
       'create',
       '--workspace',
@@ -697,7 +790,11 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       '--label',
       'review',
       '--no-focus',
-    ]);
+    ];
+    for (const kv of reviewEnv) {
+      tabArgs.push('--env', kv);
+    }
+    const tab = await herdrJson<TabCreateResult>(tabArgs);
     if (!tab?.result) {
       throw new Error('Failed to create review tab.');
     }
@@ -713,28 +810,13 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     mkdirSync(dirname(options.reviewDecisionPath), { recursive: true });
     atomicWrite({ path: promptPath, content: options.prompt });
 
-    const ghToken = getScriptsEnv('GH_TOKEN') || getScriptsEnv('GITHUB_TOKEN');
-    const environment = [
-      `CONTRACT_PIPELINE_RUN_ID=${shellQuote(this._runId)}`,
-      'CONTRACT_PIPELINE_ROLE=review',
-      `CONTRACT_PIPELINE_CONTRACT_PATH=${shellQuote(options.contractPath)}`,
-      `CONTRACT_PIPELINE_REVIEW_PATH=${shellQuote(options.reviewDecisionPath)}`,
-      this._workspacePath
-        ? `CONTRACT_PIPELINE_WORKSPACE_PATH=${shellQuote(this._workspacePath)}`
-        : '',
-      ghToken ? `GH_TOKEN=${shellQuote(ghToken)}` : '',
-    ]
-      .filter(Boolean)
-      .join(' ');
-
     // Review captain runs in TUI mode — needs interactivity to inspect
     // findings, interrupt if needed, and manually intervene. JSON mode
     // is for automated workers only.
-    // 🔴 Herdr PTY drops the first character via pane run — prepend newline
-    // to protect inline env vars (same as worker branches).
+    // 🔴 Herdr PTY drops the first character via pane run — keep the leading
+    // newline so the dropped char is never the first letter of the command.
     const command = [
       '\n',
-      environment,
       'pi',
       '--approve',
       '--model',

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -227,6 +227,9 @@ const reconcileWorkspace = async (options: {
       authorName: 'Pi Agent',
       authorEmail: 'agent@pi.internal',
     });
+    // publishWorktree may rename the branch on a remote collision — persist
+    // the published name so recovery and cleanup use one value.
+    options.manifest.worktreeBranch = headBranch;
     return {
       changeId: headCommit,
       bookmarkName: headBranch,
@@ -1324,15 +1327,20 @@ export const runContractPipeline = async (options: {
     if (manifest.currentStage !== 'merged') {
       const wsPath = adapter.getWorkspacePath();
       const branchName = manifest.reconciliation?.headBranch;
+      // 🔴 `pr_created` leaves an OPEN PR — deleting its head branch closes
+      // the PR on GitHub. Only delete the remote branch when no PR remains.
+      const keepRemoteBranch = manifest.currentStage === 'pr_created';
       if (wsPath) {
         try {
           await removeWorktree({
             checkoutPath: wsPath,
             repoRoot: options.repoRoot,
-            branch: branchName,
-            deleteRemoteBranch: true,
+            branch: keepRemoteBranch ? undefined : branchName,
+            deleteRemoteBranch: !keepRemoteBranch,
           });
-          console.log(`\n🧹 Worktree + branch cleaned: ${branchName ?? 'unknown'}\n`);
+          console.log(
+            `\n🧹 Worktree cleaned${keepRemoteBranch ? ' (remote branch kept for open PR)' : ''}: ${branchName ?? 'unknown'}\n`,
+          );
         } catch (e: unknown) {
           console.warn(
             `⚠️  Cleanup failed: ${e instanceof Error ? e.message.slice(0, 200) : String(e)}`,

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -10,15 +10,9 @@ import {
   unlinkSync,
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
-import { findWorkspace, stopContractSession } from '../../herdr/session.ts';
-import {
-  commitAll,
-  provisionGitWorktree,
-  pushBranch,
-  remoteBranchExists,
-  removeWorktree,
-  runGit,
-} from '../git_worktree.ts';
+import { findWorkspace } from '../../herdr/session.ts';
+import { publishWorktree, removeWorktree } from '../../herdr/worktree.ts';
+import { commitAll, pushBranch, runGit } from '../git_worktree.ts';
 import { resolveContract } from './contract_resolver.ts';
 import { readContractStatus, updateContractStatus } from './contract_status.ts';
 import { captureGitState, currentCommit } from './git_state.ts';
@@ -196,72 +190,62 @@ const waitForReviewDecision = async (options: {
 
 // ── Reconciliation ───────────────────────────────────────────
 
-const reconcileWorkspace = (options: {
+/**
+ * Publish the run's branch for PR creation.
+ *
+ * Worktree mode: the herdr-native worktree (created by the adapter at
+ * initialize time, at ~/.herdr/worktrees/<repo>/<slug>) already carries the
+ * `contract-task-{id}-{token}` branch with all implementer/verifier commits.
+ * publishWorktree commits remaining changes and pushes — no re-provisioning,
+ * no branch rename, no base-restore dance (skip-worktree handles that).
+ *
+ * Root mode: unchanged — commit + push the root contract branch directly.
+ */
+const reconcileWorkspace = async (options: {
   manifest: RunManifest;
   repoRoot: string;
   baseBranch?: string;
   rootMode?: boolean;
-}): ReconciliationResult => {
+}): Promise<ReconciliationResult> => {
   const b = options.baseBranch ?? PIPELINE_BASE_BRANCH;
   const rootMode = options.rootMode ?? false;
 
-  let workspacePath: string;
-  let headBranch: string;
-
-  if (rootMode) {
-    // Root mode: no worktree — the implementation lives in the repo root on
-    // the contract branch (e.g. contract/C-372). Commit remaining changes and
-    // push that branch directly.
-    workspacePath = options.repoRoot;
-    try {
-      headBranch = runGit('rev-parse --abbrev-ref HEAD', { cwd: workspacePath });
-    } catch {
-      headBranch = `contract/${options.manifest.contractId}`;
+  if (!rootMode) {
+    const checkoutPath = options.manifest.worktreeCheckoutPath;
+    if (!checkoutPath || !existsSync(checkoutPath)) {
+      throw new Error(
+        `Cannot reconcile: worktree checkout missing for ${options.manifest.runId} ` +
+          `(path: ${checkoutPath ?? 'unset'}). ` +
+          'Resume the run to recover the worktree, or use --root mode.',
+      );
     }
-  } else {
-    const workspaceRunName = options.manifest.runId;
-    const provisioned = provisionGitWorktree({
+    const { headBranch, headCommit } = await publishWorktree({
+      checkoutPath,
       repoRoot: options.repoRoot,
-      name: workspaceRunName,
-      baseRevision: b,
+      base: b,
+      message: `Feat: Contract ${options.manifest.contractId} (run ${options.manifest.runId})`,
+      authorName: 'Pi Agent',
+      authorEmail: 'agent@pi.internal',
     });
-    workspacePath = provisioned.workspacePath;
+    return {
+      changeId: headCommit,
+      bookmarkName: headBranch,
+      headBranch,
+      baseBranch: b,
+      prTitle: `Contract ${options.manifest.contractId}`,
+      prBody: '',
+    };
+  }
 
-    // Restore .envrc / .pi/settings.json from base (origin/main), not HEAD.
-    let resolvedBase: string | undefined;
-    try {
-      resolvedBase = runGit(`rev-parse --verify origin/${b}`, { cwd: options.repoRoot });
-    } catch {
-      try {
-        resolvedBase = runGit(`rev-parse --verify ${b}`, { cwd: options.repoRoot });
-      } catch {}
-    }
-    if (resolvedBase) {
-      for (const fp of [
-        '.envrc',
-        '.pi/settings.json',
-        'docs/contracts/PROGRESS.md',
-        'docs/contracts/PROMOTION.md',
-      ]) {
-        try {
-          runGit(`restore --source=${resolvedBase} -- '${fp}'`, { cwd: workspacePath });
-        } catch {}
-      }
-    }
-
-    const runToken = options.manifest.runId.replace(/^run-/, '').split('-')[0];
-    const baseBranchName = `contract-task-${options.manifest.contractId.toLowerCase()}-${runToken}`;
-    headBranch = baseBranchName;
-    if (remoteBranchExists({ branchName: baseBranchName, repoRoot: options.repoRoot })) {
-      headBranch = `${baseBranchName}-${Date.now().toString(36).slice(-6)}`;
-    }
-    if (provisioned.branchName !== headBranch) {
-      try {
-        runGit(`branch -m ${provisioned.branchName} ${headBranch}`, { cwd: workspacePath });
-      } catch {
-        headBranch = provisioned.branchName;
-      }
-    }
+  // Root mode: no worktree — the implementation lives in the repo root on
+  // the contract branch (e.g. contract/C-372). Commit remaining changes and
+  // push that branch directly.
+  const workspacePath = options.repoRoot;
+  let headBranch: string;
+  try {
+    headBranch = runGit('rev-parse --abbrev-ref HEAD', { cwd: workspacePath });
+  } catch {
+    headBranch = `contract/${options.manifest.contractId}`;
   }
 
   const finalMsg = `Feat: Contract ${options.manifest.contractId} (run ${options.manifest.runId})`;
@@ -485,17 +469,17 @@ const syncMainOnMerge = (repoRoot: string): void => {
   }
 };
 
-const cleanupAfterMerge = (options: {
+const cleanupAfterMerge = async (options: {
   repoRoot: string;
   workspacePath: string;
   branchName: string;
   contractId: string;
-}): void => {
+}): Promise<void> => {
   try {
-    removeWorktree({
-      workspacePath: options.workspacePath,
+    await removeWorktree({
+      checkoutPath: options.workspacePath,
       repoRoot: options.repoRoot,
-      branchName: options.branchName,
+      branch: options.branchName,
       deleteRemoteBranch: true,
     });
     console.log(`\n🧹 Worktree cleaned: ${options.branchName}\n`);
@@ -504,17 +488,6 @@ const cleanupAfterMerge = (options: {
       `⚠️  Worktree cleanup failed: ${e instanceof Error ? e.message.slice(0, 200) : String(e)}`,
     );
   }
-
-  // Stop the contract-scoped herdr session (client, firebase, etc.).
-  const mode: 'emulator' | 'staging' | 'production' =
-    process.env.AIKAMI_MODE === 'staging' || process.env.AIKAMI_MODE === 'production'
-      ? process.env.AIKAMI_MODE
-      : 'emulator';
-  stopContractSession(mode, options.contractId).catch((e: unknown) => {
-    console.warn(
-      `⚠️  Herdr session cleanup failed: ${e instanceof Error ? e.message.slice(0, 200) : String(e)}`,
-    );
-  });
 };
 
 // ── Main orchestrator ─────────────────────────────────────────
@@ -677,6 +650,13 @@ export const runContractPipeline = async (options: {
     const ws = await adapter.initialize();
     manifest.workspaceId = ws.workspaceId;
     manifest.pipelinePaneId = ws.pipelinePaneId;
+    if (!rootMode) {
+      // Persist herdr-native worktree state so resume-after-crash can
+      // recover the checkout without re-deriving paths.
+      manifest.worktreeWorkspaceId = ws.workspaceId;
+      manifest.worktreeCheckoutPath = adapter.getWorkspacePath() || undefined;
+      manifest.worktreeBranch = adapter.getWorktreeBranch() || undefined;
+    }
     writeManifest({ manifest, cwd: options.repoRoot });
     options.onReady?.(manifest);
     pipelineLog({
@@ -905,7 +885,7 @@ export const runContractPipeline = async (options: {
               }
             } else {
               try {
-                manifest.reconciliation = reconcileWorkspace({
+                manifest.reconciliation = await reconcileWorkspace({
                   manifest,
                   repoRoot: options.repoRoot,
                   baseBranch: PIPELINE_BASE_BRANCH,
@@ -950,7 +930,7 @@ export const runContractPipeline = async (options: {
             // Force reconciliation: commit + push the branch so a PR can be created.
             if (!manifest.reconciliation?.headBranch) {
               try {
-                manifest.reconciliation = reconcileWorkspace({
+                manifest.reconciliation = await reconcileWorkspace({
                   manifest,
                   repoRoot: options.repoRoot,
                   baseBranch: PIPELINE_BASE_BRANCH,
@@ -1142,7 +1122,7 @@ export const runContractPipeline = async (options: {
               if (options.yolo) {
                 syncMainOnMerge(options.repoRoot);
                 if (headBranch && adapter.getWorkspacePath()) {
-                  cleanupAfterMerge({
+                  await cleanupAfterMerge({
                     repoRoot: options.repoRoot,
                     workspacePath: adapter.getWorkspacePath(),
                     branchName: headBranch,
@@ -1168,7 +1148,7 @@ export const runContractPipeline = async (options: {
                 });
                 syncMainOnMerge(options.repoRoot);
                 if (headBranch && adapter.getWorkspacePath()) {
-                  cleanupAfterMerge({
+                  await cleanupAfterMerge({
                     repoRoot: options.repoRoot,
                     workspacePath: adapter.getWorkspacePath(),
                     branchName: headBranch,
@@ -1240,7 +1220,7 @@ export const runContractPipeline = async (options: {
             console.log('\n🚀 YOLO: Captain merged — syncing main + cleanup.\n');
             syncMainOnMerge(options.repoRoot);
             if (headBranch && adapter.getWorkspacePath()) {
-              cleanupAfterMerge({
+              await cleanupAfterMerge({
                 repoRoot: options.repoRoot,
                 workspacePath: adapter.getWorkspacePath(),
                 branchName: headBranch,
@@ -1272,7 +1252,7 @@ export const runContractPipeline = async (options: {
             });
             syncMainOnMerge(options.repoRoot);
             if (headBranch && adapter.getWorkspacePath()) {
-              cleanupAfterMerge({
+              await cleanupAfterMerge({
                 repoRoot: options.repoRoot,
                 workspacePath: adapter.getWorkspacePath(),
                 branchName: headBranch,
@@ -1346,10 +1326,10 @@ export const runContractPipeline = async (options: {
       const branchName = manifest.reconciliation?.headBranch;
       if (wsPath) {
         try {
-          removeWorktree({
-            workspacePath: wsPath,
+          await removeWorktree({
+            checkoutPath: wsPath,
             repoRoot: options.repoRoot,
-            branchName,
+            branch: branchName,
             deleteRemoteBranch: true,
           });
           console.log(`\n🧹 Worktree + branch cleaned: ${branchName ?? 'unknown'}\n`);
@@ -1359,15 +1339,6 @@ export const runContractPipeline = async (options: {
           );
         }
       }
-    }
-
-    // Stop the contract-scoped herdr session on pipeline exit.
-    if (adapter.getWorkspacePath()) {
-      const mode: 'emulator' | 'staging' | 'production' =
-        process.env.AIKAMI_MODE === 'staging' || process.env.AIKAMI_MODE === 'production'
-          ? process.env.AIKAMI_MODE
-          : 'emulator';
-      stopContractSession(mode, manifest.contractId).catch(() => {});
     }
 
     return manifest;

--- a/scripts/src/lib/agents/contract_pipeline/types.ts
+++ b/scripts/src/lib/agents/contract_pipeline/types.ts
@@ -124,6 +124,12 @@ export type RunManifest = {
   workspaceId?: string;
   pipelinePaneId?: string;
   reviewPaneId?: string;
+  /** herdr-native worktree: workspace id (== pipeline workspace in worktree mode). */
+  worktreeWorkspaceId?: string;
+  /** herdr-native worktree: absolute checkout path (~/.herdr/worktrees/<repo>/...). */
+  worktreeCheckoutPath?: string;
+  /** herdr-native worktree: branch checked out in the worktree. */
+  worktreeBranch?: string;
   blockedReason?: string;
   /** Number of autofix cycles attempted during YOLO review. Used for circuit breaker. */
   autofixCycles: number;

--- a/scripts/src/lib/agents/git_worktree.ts
+++ b/scripts/src/lib/agents/git_worktree.ts
@@ -6,23 +6,14 @@
 // Do not fork; keep low-level (no herdr calls here).
 //
 // 🔴 Worktree PROVISIONING (create/bootstrap/remove via herdr) moved to
-//    scripts/src/lib/herdr/worktree.ts. `provisionGitWorktree` was removed
-//    when the pipeline switched to herdr-native worktrees.
+//    scripts/src/lib/herdr/worktree.ts. The legacy provisionGitWorktree /
+//    removeWorktree / WORKSPACES_DIR were deleted when the pipeline switched
+//    to herdr-native worktrees — this file holds only git primitives now.
 
 import { execSync } from 'node:child_process';
-import {
-  appendFileSync,
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from 'node:fs';
-import { join } from 'node:path';
 
 // ── Constants ────────────────────────────────────────────────
 
-export const WORKSPACES_DIR = '.pi/workspaces';
 export const MAX_BRANCH_NAME_LENGTH = 80;
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -40,11 +31,12 @@ const isGitExecError = (err: unknown): err is GitExecError => err instanceof Err
  * backoff: 100ms → 200ms → 400ms). Throws on any other failure.
  *
  * @param command  git subcommand and args (e.g. `"rev-parse HEAD"`)
- * @param options  cwd, env
+ * @param options  cwd, env, timeoutMs (default: none — callers that can
+ *                 stall, e.g. pushes, should pass an explicit bound)
  */
 export const runGit = (
   command: string,
-  options?: { cwd?: string; env?: Record<string, string> },
+  options?: { cwd?: string; env?: Record<string, string>; timeoutMs?: number },
 ): string => {
   const cmd = `git ${command}`;
 
@@ -53,11 +45,15 @@ export const runGit = (
     stdio: ['pipe', 'pipe', 'pipe'];
     cwd?: string;
     env?: Record<string, string>;
+    timeout?: number;
   } = {
     encoding: 'utf-8' as const,
     stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'],
     cwd: options?.cwd,
   };
+  if (options?.timeoutMs !== undefined) {
+    opts.timeout = options.timeoutMs;
+  }
   if (options?.env) {
     opts.env = { ...(process.env as Record<string, string>), ...options.env };
   }
@@ -116,261 +112,6 @@ export const isGitRepo = (cwd?: string): boolean => {
   }
 };
 
-/** Check if a git branch exists (local or remote). */
-const branchExistsLocal = (branch: string, cwd: string): boolean => {
-  try {
-    runGit(`rev-parse --verify refs/heads/${branch}`, { cwd });
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/**
- * Provision a Git Worktree on a new branch.
- *
- * Creates `{repoRoot}/.pi/workspaces/{sanitizedName}` as an isolated
- * worktree on a new branch derived from `baseRevision` (default `dev`).
- * The root working copy is left untouched.
- *
- * If the worktree directory already exists (from a prior partial run),
- * returns its existing state without recreating.
- *
- * Returns the workspace path, branch name, and HEAD commit hash.
- */
-export const provisionGitWorktree = (options: {
-  repoRoot: string;
-  name: string;
-  baseRevision?: string;
-}): { workspacePath: string; branchName: string; headCommit: string } => {
-  const sanitized = sanitizeBranchName(options.name);
-  const wsDir = join(options.repoRoot, WORKSPACES_DIR, sanitized);
-  const base = options.baseRevision ?? 'dev';
-
-  mkdirSync(join(options.repoRoot, WORKSPACES_DIR), { recursive: true });
-
-  // Check if the worktree already exists (directory present with .git file)
-  const alreadyExists = existsSync(join(wsDir, '.git'));
-
-  if (!alreadyExists) {
-    // Clean up stale worktree references (directory deleted manually).
-    try {
-      runGit('worktree prune', { cwd: options.repoRoot });
-    } catch {}
-    // Generate a unique branch name. If sanitized already exists, append a
-    // short token to avoid collision.
-    let branchName = sanitized;
-    if (branchExistsLocal(branchName, options.repoRoot)) {
-      const token = Date.now().toString(36).slice(-6);
-      branchName = `${sanitized}-${token}`;
-    }
-
-    // Fetch latest from remote so the base revision is current.
-    try {
-      runGit('fetch origin', { cwd: options.repoRoot });
-    } catch {
-      // Non-fatal — may not have a remote configured.
-    }
-
-    // Resolve the base revision to a commit-ish. Try origin/<base> first,
-    // then <base> as a local ref.
-    let baseRef = `origin/${base}`;
-    try {
-      runGit(`rev-parse --verify ${baseRef}`, { cwd: options.repoRoot });
-    } catch {
-      baseRef = base;
-    }
-
-    // Create the worktree on the new branch.
-    runGit(`worktree add -b ${branchName} '${wsDir}' ${baseRef}`, {
-      cwd: options.repoRoot,
-    });
-
-    // Install dependencies so dev servers and tests can run.
-    try {
-      execSync('bun install --frozen-lockfile', {
-        cwd: wsDir,
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 60_000,
-      });
-    } catch {
-      // Non-fatal — implementer can run bun install manually.
-    }
-  }
-
-  // Resolve the branch name of the worktree.
-  let branchName: string;
-  try {
-    branchName = runGit('rev-parse --abbrev-ref HEAD', { cwd: wsDir });
-  } catch {
-    branchName = sanitized;
-  }
-
-  // Always ensure direnv is configured — even when recovering an existing
-  // workspace. Nix Flake requires flake.nix to be Git-tracked, but
-  // .pi/workspaces/ is gitignored. Replace .envrc with a source_env
-  // pointing at the repo root.
-  try {
-    writeFileSync(
-      join(wsDir, '.envrc'),
-      `# Workspace direnv — delegate to repo root where flake.nix is Git-tracked
-source_env ${options.repoRoot}
-`,
-    );
-    execSync('direnv allow', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: wsDir,
-      timeout: 5000,
-    });
-  } catch {
-    // direnv may not be installed — not fatal.
-  }
-
-  // 🔴 Safety: mark workspace-local and auto-generated files as
-  // skip-worktree so git ignores modifications. Git worktrees use
-  // a `.git` FILE (not directory) so .git/info/exclude is unavailable.
-  // skip-worktree is the ONLY reliable mechanism here.
-  try {
-    runGit(
-      'update-index --skip-worktree .envrc .pi/settings.json .context/llms.txt docs/contracts/PROGRESS.md docs/contracts/PROMOTION.md',
-      { cwd: wsDir },
-    );
-  } catch {
-    // Non-fatal.
-  }
-
-  // Symlink .pi/npm from root so pi extensions are available.
-  const workspaceNpmDir = join(wsDir, '.pi', 'npm');
-  const rootNpmDir = join(options.repoRoot, '.pi', 'npm');
-  if (existsSync(rootNpmDir)) {
-    try {
-      mkdirSync(join(wsDir, '.pi'), { recursive: true });
-      execSync(`rm -f '${join(workspaceNpmDir, 'npm')}'`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 5000,
-      });
-      if (existsSync(workspaceNpmDir)) {
-        const rm = join(rootNpmDir, 'node_modules');
-        const wm = join(workspaceNpmDir, 'node_modules');
-        if (existsSync(rm) && !existsSync(wm)) {
-          execSync(`ln -sfn '${rm}' '${wm}'`, {
-            encoding: 'utf-8',
-            stdio: ['pipe', 'pipe', 'pipe'],
-            timeout: 5000,
-          });
-        }
-      } else {
-        execSync(`ln -sfn '${rootNpmDir}' '${workspaceNpmDir}'`, {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-          timeout: 5000,
-        });
-      }
-    } catch {
-      /* fallback: pi auto-installs */
-    }
-  }
-
-  // Copy Pi settings from root to workspace.
-  const rootSettingsPath = join(options.repoRoot, '.pi', 'settings.json');
-  const workspaceSettingsPath = join(wsDir, '.pi', 'settings.json');
-  if (existsSync(rootSettingsPath)) {
-    try {
-      mkdirSync(join(wsDir, '.pi'), { recursive: true });
-      copyFileSync(rootSettingsPath, workspaceSettingsPath);
-    } catch {}
-  }
-
-  // Set env var so knowledge:sync scripts skip in worktrees.
-  // PROGRESS.md and PROMOTION.md are shared files that cause merge
-  // conflicts when modified in parallel contract branches.
-  // Sync should only run on main (after PR merge).
-  try {
-    const envrcPath = join(wsDir, '.envrc');
-    const existing = existsSync(envrcPath) ? readFileSync(envrcPath, 'utf-8') : '';
-    if (!existing.includes('CONTRACT_PIPELINE_WORKTREE')) {
-      appendFileSync(envrcPath, '\nexport CONTRACT_PIPELINE_WORKTREE=1\n');
-    }
-  } catch {
-    // Non-fatal.
-  }
-
-  return {
-    workspacePath: wsDir,
-    branchName,
-    headCommit: getGitHeadCommit(wsDir),
-  };
-};
-
-/**
- * Remove a Git Worktree and optionally delete its remote branch.
- * Used for both successful completions and error recovery.
- *
- * Does NOT abandon commits — git history is preserved on the branch
- * (or orphaned if the branch was never pushed).
- */
-export const removeWorktree = (options: {
-  workspacePath: string;
-  repoRoot: string;
-  branchName?: string;
-  deleteRemoteBranch?: boolean;
-}): void => {
-  // Remove the worktree (--force handles dirty state).
-  try {
-    runGit(`worktree remove '${options.workspacePath}' --force`, {
-      cwd: options.repoRoot,
-    });
-  } catch {
-    // Worktree may already be removed, or directory may not be a worktree.
-    // Fall back to rm -rf if git worktree remove fails.
-    try {
-      execSync(`rm -rf '${options.workspacePath}'`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 5000,
-      });
-    } catch {
-      // Last resort — nothing to do.
-    }
-  }
-
-  // Optionally delete the remote branch.
-  if (options.deleteRemoteBranch && options.branchName) {
-    try {
-      runGit(`push origin --delete ${options.branchName}`, {
-        cwd: options.repoRoot,
-      });
-    } catch {
-      // Branch may not exist on remote.
-    }
-  }
-
-  // Force-delete the local branch. git worktree remove prunes the branch
-  // when it succeeds, but if the worktree was already deleted manually or
-  // the remove failed, the local branch lingers. This is the safety net.
-  if (options.branchName) {
-    try {
-      runGit(`branch -D ${options.branchName}`, {
-        cwd: options.repoRoot,
-      });
-    } catch {
-      // Branch may already be deleted.
-    }
-  }
-
-  // Clean up the local branch reference (worktree remove may leave it).
-  if (options.branchName) {
-    try {
-      runGit(`branch -D ${options.branchName}`, { cwd: options.repoRoot });
-    } catch {
-      // Branch may already be deleted.
-    }
-  }
-};
-
 /**
  * Stage all changes and commit in the given worktree.
  * Returns the new HEAD commit hash.
@@ -414,10 +155,13 @@ export const pushBranch = (options: {
   cwd: string;
   branchName: string;
   setUpstream?: boolean;
+  /** Push timeout in ms (default 180_000 — a stalled remote must not hang the caller). */
+  timeoutMs?: number;
 }): string => {
   const upstreamFlag = options.setUpstream !== false ? '-u' : '';
   runGit(`push ${upstreamFlag} origin ${options.branchName}`.trim(), {
     cwd: options.cwd,
+    timeoutMs: options.timeoutMs ?? 180_000,
   });
   return options.branchName;
 };

--- a/scripts/src/lib/agents/git_worktree.ts
+++ b/scripts/src/lib/agents/git_worktree.ts
@@ -1,7 +1,13 @@
 // scripts/src/lib/agents/git_worktree.ts
 //
-// Git Worktree utilities used by the contract pipeline orchestrator,
-// herdr adapter, and Pi extensions. Single source of truth — do not fork.
+// Pure git primitives shared by the herdr-native worktree module
+// (scripts/src/lib/herdr/worktree.ts — THE source of truth for worktree
+// lifecycle), the contract pipeline orchestrator, and Pi extensions.
+// Do not fork; keep low-level (no herdr calls here).
+//
+// 🔴 Worktree PROVISIONING (create/bootstrap/remove via herdr) moved to
+//    scripts/src/lib/herdr/worktree.ts. `provisionGitWorktree` was removed
+//    when the pipeline switched to herdr-native worktrees.
 
 import { execSync } from 'node:child_process';
 import {

--- a/scripts/src/lib/herdr/task.ts
+++ b/scripts/src/lib/herdr/task.ts
@@ -36,7 +36,8 @@
 // biome-ignore-all lint/style/useNamingConvention: HerDr API response field names (snake_case) — must match external API contract
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { runGit, sanitizeBranchName } from '../agents/git_worktree.ts';
 import { findWorkspace, herdr, herdrJson, wrapCommand } from './session.ts';
 import {
@@ -54,8 +55,11 @@ import {
 
 // ── Constants ──────────────────────────────────────────────
 
-const DEV_STACK_OWNER_FILE = '.pi/dev-stack-owner.json';
 const DEFAULT_BASE = 'main';
+
+/** Dev-stack ownership marker — stored OUTSIDE the repo (herdr state dir) so
+ *  task sessions never write into the root checkout or a worktree checkout. */
+const devStackOwnerPath = (): string => join(homedir(), '.herdr', 'aikami', 'dev-stack-owner.json');
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -69,6 +73,25 @@ const argValue = (args: string[], flag: string): string | undefined => {
 
 const hasFlag = (args: string[], flag: string): boolean => args.includes(flag);
 
+/** Flags that take a following value. */
+const VALUE_FLAGS = new Set(['--base', '--title', '--body']);
+
+/** Positional arguments, excluding flags and the values they consume. */
+const positionalArgs = (args: string[]): string[] => {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith('-')) {
+      if (VALUE_FLAGS.has(a)) {
+        i++; // skip the flag's value
+      }
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+};
+
 /** Resolve the repo root (cwd or env). */
 const resolveRepoRoot = (): string => {
   const cwd = resolve(process.cwd());
@@ -81,7 +104,7 @@ const resolveRepoRoot = (): string => {
 
 /** Resolve the task slug + checkout from CLI args or the current directory. */
 const resolveTask = async (args: string[]): Promise<{ slug: string; w: TaskWorktree }> => {
-  const positional = args.filter((a) => !a.startsWith('-'));
+  const positional = positionalArgs(args);
   const repoRoot = resolveRepoRoot();
 
   let slug: string | undefined;
@@ -131,6 +154,7 @@ const resolveTask = async (args: string[]): Promise<{ slug: string; w: TaskWorkt
       checkoutPath,
       workspaceId: (await findWorkspace(`${TASK_WORKSPACE_PREFIX}${slug}`)) ?? '',
       rootPaneId: '',
+      tabId: '',
       repoRoot,
     },
   };
@@ -151,7 +175,7 @@ const launchPiInWorktree = async (w: TaskWorktree): Promise<void> => {
 // ── Subcommands ────────────────────────────────────────────
 
 const cmdNew = async (args: string[]): Promise<void> => {
-  const positional = args.filter((a) => !a.startsWith('-'));
+  const positional = positionalArgs(args);
   const slug = positional.length > 0 ? sanitizeBranchName(positional[0]) : undefined;
   if (!slug) {
     throw new Error('Usage: bun herdr:task new <slug> [--base main] [--join] [--no-install]');
@@ -176,38 +200,51 @@ const cmdNew = async (args: string[]): Promise<void> => {
   ok(`worktree: ${w.checkoutPath} (branch ${w.branch})`);
   ok(`workspace: ${w.workspaceId} (label ${TASK_WORKSPACE_PREFIX}${slug})`);
 
-  console.log(
-    `\n🔧 Bootstrapping worktree (direnv, seeds, ${doInstall ? 'bun install' : 'skipping install'})...`,
-  );
-  await bootstrapWorktree({
-    checkoutPath: w.checkoutPath,
-    repoRoot,
-    install: doInstall,
-  });
-  ok('bootstrap complete');
-
-  if (withServices) {
-    // Record dev-stack ownership. The stack itself must be restarted by the
-    // user — ports are per-mode constants, exactly one stack can run, and
-    // restarting it would kill the current owner's servers.
-    const owner = {
+  try {
+    console.log(
+      `\n🔧 Bootstrapping worktree (direnv, seeds, ${doInstall ? 'bun install' : 'skipping install'})...`,
+    );
+    const { installed } = await bootstrapWorktree({
       checkoutPath: w.checkoutPath,
-      branch: w.branch,
-      mode: process.env.AIKAMI_MODE ?? 'emulator',
-      claimedAt: new Date().toISOString(),
-    };
-    const ownerPath = join(repoRoot, DEV_STACK_OWNER_FILE);
-    mkdirSync(join(repoRoot, '.pi'), { recursive: true });
-    writeFileSync(ownerPath, JSON.stringify(owner, undefined, 2));
-    warn(
-      `dev stack ownership recorded for ${w.branch}. To serve the stack FROM this worktree:\n` +
-        `    bun herdr:stop all && bun herdr:start all\n` +
-        `  after cd ${w.checkoutPath} (or pass --mode explicitly).`,
+      repoRoot,
+      install: doInstall,
+    });
+    if (doInstall && !installed) {
+      warn(`bun install failed — run it manually: cd ${w.checkoutPath} && bun install`);
+    } else {
+      ok('bootstrap complete');
+    }
+
+    if (withServices) {
+      // Record dev-stack ownership OUTSIDE the repo (herdr state dir). The
+      // stack itself must be restarted by the user — ports are per-mode
+      // constants, exactly one stack can run, and restarting it would kill
+      // the current owner's servers.
+      const owner = {
+        checkoutPath: w.checkoutPath,
+        branch: w.branch,
+        mode: process.env.AIKAMI_MODE ?? 'emulator',
+        claimedAt: new Date().toISOString(),
+      };
+      const ownerPath = devStackOwnerPath();
+      mkdirSync(dirname(ownerPath), { recursive: true });
+      writeFileSync(ownerPath, JSON.stringify(owner, undefined, 2));
+      warn(
+        `dev stack ownership recorded for ${w.branch}. To serve the stack FROM this worktree:\n` +
+          `    bun herdr:stop all && bun herdr:start all\n` +
+          `  after cd ${w.checkoutPath} (or pass --mode explicitly).`,
+      );
+    }
+
+    await launchPiInWorktree(w);
+    ok(`task "${slug}" ready`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${message}\n  The worktree was created at ${w.checkoutPath}. ` +
+        `Clean it up with: bun herdr:task rm ${slug} --force`,
     );
   }
-
-  await launchPiInWorktree(w);
-  ok(`task "${slug}" ready`);
 
   console.log(`\nAttach:  herdr session attach default`);
   console.log(`PR:      bun herdr:task pr ${slug} --base ${base}`);
@@ -288,7 +325,7 @@ const cmdRm = async (args: string[]): Promise<void> => {
   const force = hasFlag(args, '--force');
 
   console.log(`🧹 Removing task "${w.slug}"...`);
-  await removeWorktree({
+  const result = await removeWorktree({
     workspaceId: w.workspaceId || undefined,
     checkoutPath: w.checkoutPath,
     branch: keepBranch ? undefined : w.branch,
@@ -296,10 +333,14 @@ const cmdRm = async (args: string[]): Promise<void> => {
     force,
     repoRoot: w.repoRoot,
   });
-  ok(`removed ${w.checkoutPath}${keepBranch ? ' (branch kept)' : ` and branch ${w.branch}`}`);
+  if (result.removed) {
+    ok(`removed ${w.checkoutPath}${keepBranch ? ' (branch kept)' : ` and branch ${w.branch}`}`);
+  } else {
+    warn(`removal incomplete: ${result.reason ?? 'unknown reason'}`);
+  }
 
   // Also clear dev-stack ownership if this worktree owned it.
-  const ownerPath = join(w.repoRoot, DEV_STACK_OWNER_FILE);
+  const ownerPath = devStackOwnerPath();
   if (existsSync(ownerPath)) {
     try {
       const owner = JSON.parse(readFileSync(ownerPath, 'utf-8')) as { checkoutPath?: string };
@@ -414,7 +455,7 @@ worktree (exactly one stack per mode — ports are constants).`);
 };
 
 try {
-  if (!subcommand || !handlers[subcommand]) {
+  if (!subcommand || !Object.hasOwn(handlers, subcommand)) {
     await handlers.help([]);
     process.exit(subcommand ? 1 : 0);
   }

--- a/scripts/src/lib/herdr/task.ts
+++ b/scripts/src/lib/herdr/task.ts
@@ -1,0 +1,426 @@
+#!/usr/bin/env bun
+
+// scripts/src/lib/herdr/task.ts
+//
+// `bun herdr:task` — parallel pi task sessions in herdr-native git worktrees.
+//
+// Each task gets:
+//   - a git worktree branched from origin/<base> (NEVER the dirty local main)
+//     checked out under ~/.herdr/worktrees/<repo>/<slug> — outside the repo,
+//     so concurrent sessions on the root checkout are completely unaffected
+//   - a herdr workspace (aikami-task-<slug>) auto-grouped with the repo
+//   - a pi session running in the worktree's root pane
+//
+// Usage:
+//   bun herdr:task new <slug> [--base main] [--join] [--no-install]
+//   bun herdr:task list
+//   bun herdr:task pr   [<slug>] [--base main] [--title T] [--body B] [--draft]
+//   bun herdr:task rm   <slug>   [--keep-branch] [--force]
+//   bun herdr:task prune [--legacy] [--force]
+//
+// PR flow after a task finishes (from anywhere):
+//   bun herdr:task pr my-feature --base main
+//     → publishes the worktree branch, then `gh pr create --base main`
+//
+// Cleanup after merge:
+//   bun herdr:task rm my-feature --force
+//     → herdr worktree remove + git branch -D (herdr never deletes branches)
+//
+// Dev services: by default task sessions run WITHOUT ports (typecheck/lint/
+// unit tests only — the vast majority of agent work). To run the full
+// firebase/client stack FROM the worktree, pass `--with-services` to `new`;
+// this records ownership in .pi/dev-stack-owner.json and prints the exact
+// restart commands. Exactly one dev stack can exist per mode (ports are
+// constants), so claiming it stops whatever the current stack serves.
+
+// biome-ignore-all lint/style/useNamingConvention: HerDr API response field names (snake_case) — must match external API contract
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { runGit, sanitizeBranchName } from '../agents/git_worktree.ts';
+import { findWorkspace, herdr, herdrJson, wrapCommand } from './session.ts';
+import {
+  bootstrapWorktree,
+  createWorktree,
+  findTaskWorkspace,
+  listWorktrees,
+  openPullRequest,
+  publishWorktree,
+  removeWorktree,
+  TASK_BRANCH_PREFIX,
+  TASK_WORKSPACE_PREFIX,
+  type TaskWorktree,
+} from './worktree.ts';
+
+// ── Constants ──────────────────────────────────────────────
+
+const DEV_STACK_OWNER_FILE = '.pi/dev-stack-owner.json';
+const DEFAULT_BASE = 'main';
+
+// ── Helpers ────────────────────────────────────────────────
+
+const ok = (m: string) => console.log(`  ✓ ${m}`);
+const warn = (m: string) => console.log(`  ⚠️  ${m}`);
+
+const argValue = (args: string[], flag: string): string | undefined => {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : undefined;
+};
+
+const hasFlag = (args: string[], flag: string): boolean => args.includes(flag);
+
+/** Resolve the repo root (cwd or env). */
+const resolveRepoRoot = (): string => {
+  const cwd = resolve(process.cwd());
+  try {
+    return runGit('rev-parse --show-toplevel', { cwd });
+  } catch {
+    return cwd;
+  }
+};
+
+/** Resolve the task slug + checkout from CLI args or the current directory. */
+const resolveTask = async (args: string[]): Promise<{ slug: string; w: TaskWorktree }> => {
+  const positional = args.filter((a) => !a.startsWith('-'));
+  const repoRoot = resolveRepoRoot();
+
+  let slug: string | undefined;
+  let checkoutPath: string | undefined;
+
+  if (positional.length > 0) {
+    slug = sanitizeBranchName(positional[0]);
+  }
+
+  if (!checkoutPath && !slug) {
+    // Running inside a worktree? Derive from the current checkout.
+    const cwd = resolve(process.cwd());
+    try {
+      const top = runGit('rev-parse --show-toplevel', { cwd });
+      if (top !== repoRoot) {
+        checkoutPath = top;
+        const branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: top });
+        slug = sanitizeBranchName(branch.replace(/^task\//, '').replace(/^worktree\//, ''));
+      }
+    } catch {
+      // Not in a git repo — slug will remain undefined.
+    }
+  }
+
+  if (!slug) {
+    throw new Error('Task slug required. Use: bun herdr:task <command> <slug>');
+  }
+  if (!checkoutPath) {
+    const wsId = await findTaskWorkspace(slug);
+    const entry = wsId
+      ? (await listWorktrees()).find((w) => w.openWorkspaceId === wsId)
+      : (await listWorktrees()).find((w) => w.branch === `${TASK_BRANCH_PREFIX}${slug}`);
+    if (!entry) {
+      throw new Error(
+        `No open worktree for task "${slug}". Start one with: bun herdr:task new ${slug}`,
+      );
+    }
+    checkoutPath = entry.path;
+  }
+
+  const branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: checkoutPath });
+  return {
+    slug,
+    w: {
+      slug,
+      branch,
+      checkoutPath,
+      workspaceId: (await findWorkspace(`${TASK_WORKSPACE_PREFIX}${slug}`)) ?? '',
+      rootPaneId: '',
+      repoRoot,
+    },
+  };
+};
+
+/** Launch pi in the worktree's root pane (mirrors start_pi.ts). */
+const launchPiInWorktree = async (w: TaskWorktree): Promise<void> => {
+  if (!w.workspaceId || !w.rootPaneId) {
+    throw new Error('Task workspace is not open — cannot launch pi.');
+  }
+  const r = await herdrJson<{ result: { pane_id: string } }>(['pane', 'get', w.rootPaneId]);
+  const paneId = r?.result?.pane_id ?? w.rootPaneId;
+  await herdr(['tab', 'rename', `${w.workspaceId}:1`, 'pi']);
+  await herdr(['pane', 'run', paneId, wrapCommand('pi')]);
+  ok(`pi running in workspace ${w.workspaceId} (tab "pi")`);
+};
+
+// ── Subcommands ────────────────────────────────────────────
+
+const cmdNew = async (args: string[]): Promise<void> => {
+  const positional = args.filter((a) => !a.startsWith('-'));
+  const slug = positional.length > 0 ? sanitizeBranchName(positional[0]) : undefined;
+  if (!slug) {
+    throw new Error('Usage: bun herdr:task new <slug> [--base main] [--join] [--no-install]');
+  }
+
+  const repoRoot = resolveRepoRoot();
+  const base = argValue(args, '--base') ?? DEFAULT_BASE;
+  const doJoin = hasFlag(args, '--join');
+  const doInstall = !hasFlag(args, '--no-install');
+  const withServices = hasFlag(args, '--with-services');
+
+  // Guard: reject if a worktree for this slug already exists.
+  if (
+    (await findTaskWorkspace(slug)) ||
+    (await listWorktrees()).some((w) => w.branch === `${TASK_BRANCH_PREFIX}${slug}`)
+  ) {
+    throw new Error(`Task "${slug}" already exists. Use a different slug or remove it first.`);
+  }
+
+  console.log(`🚀 Creating task worktree "${slug}" (base: ${base})...`);
+  const w = await createWorktree({ slug, base, repoRoot });
+  ok(`worktree: ${w.checkoutPath} (branch ${w.branch})`);
+  ok(`workspace: ${w.workspaceId} (label ${TASK_WORKSPACE_PREFIX}${slug})`);
+
+  console.log(
+    `\n🔧 Bootstrapping worktree (direnv, seeds, ${doInstall ? 'bun install' : 'skipping install'})...`,
+  );
+  await bootstrapWorktree({
+    checkoutPath: w.checkoutPath,
+    repoRoot,
+    install: doInstall,
+  });
+  ok('bootstrap complete');
+
+  if (withServices) {
+    // Record dev-stack ownership. The stack itself must be restarted by the
+    // user — ports are per-mode constants, exactly one stack can run, and
+    // restarting it would kill the current owner's servers.
+    const owner = {
+      checkoutPath: w.checkoutPath,
+      branch: w.branch,
+      mode: process.env.AIKAMI_MODE ?? 'emulator',
+      claimedAt: new Date().toISOString(),
+    };
+    const ownerPath = join(repoRoot, DEV_STACK_OWNER_FILE);
+    mkdirSync(join(repoRoot, '.pi'), { recursive: true });
+    writeFileSync(ownerPath, JSON.stringify(owner, undefined, 2));
+    warn(
+      `dev stack ownership recorded for ${w.branch}. To serve the stack FROM this worktree:\n` +
+        `    bun herdr:stop all && bun herdr:start all\n` +
+        `  after cd ${w.checkoutPath} (or pass --mode explicitly).`,
+    );
+  }
+
+  await launchPiInWorktree(w);
+  ok(`task "${slug}" ready`);
+
+  console.log(`\nAttach:  herdr session attach default`);
+  console.log(`PR:      bun herdr:task pr ${slug} --base ${base}`);
+  console.log(`Remove:  bun herdr:task rm ${slug}`);
+
+  if (doJoin) {
+    await herdr(['workspace', 'focus', w.workspaceId]);
+    const proc = spawn('herdr', ['session', 'attach', 'default'], { stdio: 'inherit' });
+    await new Promise<number>((res) => proc.on('exit', res));
+  }
+};
+
+const cmdList = async (): Promise<void> => {
+  const repoRoot = resolveRepoRoot();
+  const worktrees = await listWorktrees(repoRoot);
+  const taskWts = worktrees.filter((w) => w.branch.startsWith(TASK_BRANCH_PREFIX));
+
+  if (taskWts.length === 0) {
+    console.log('No task worktrees. Start one: bun herdr:task new <slug>');
+    return;
+  }
+
+  const Green = '\x1b[32m';
+  const Yellow = '\x1b[33m';
+  const Dim = '\x1b[2m';
+  const Reset = '\x1b[0m';
+
+  for (const w of taskWts) {
+    const open = w.openWorkspaceId ? `${Green}● open${Reset}` : `${Dim}○ closed${Reset}`;
+    const dirty = (() => {
+      try {
+        return runGit('status --porcelain', { cwd: w.path }).length > 0
+          ? `${Yellow}✚ dirty${Reset}`
+          : '';
+      } catch {
+        return '';
+      }
+    })();
+    console.log(`  ${w.branch}  ${open} ${dirty}`);
+    console.log(`      ${Dim}${w.path}${Reset}`);
+  }
+  console.log(`\n${Dim}PR: bun herdr:task pr <slug> | Remove: bun herdr:task rm <slug>${Reset}`);
+};
+
+const cmdPr = async (args: string[]): Promise<void> => {
+  const { w } = await resolveTask(args);
+  const base = argValue(args, '--base') ?? DEFAULT_BASE;
+  const title = argValue(args, '--title') ?? `Task: ${w.slug}`;
+  const body = argValue(args, '--body');
+  const draft = hasFlag(args, '--draft');
+
+  console.log(`📦 Publishing ${w.branch} → origin (base ${base})...`);
+  const { headBranch, headCommit } = await publishWorktree({
+    checkoutPath: w.checkoutPath,
+    repoRoot: w.repoRoot,
+    base,
+    message: `Feat: ${w.slug}`,
+    authorName: 'Pi Agent',
+    authorEmail: 'agent@pi.internal',
+  });
+  ok(`pushed ${headBranch} @ ${headCommit.slice(0, 7)}`);
+
+  console.log(`🔀 Opening PR → ${base}...`);
+  const { prUrl, prNumber } = await openPullRequest({
+    headBranch,
+    base,
+    title,
+    body,
+    draft,
+  });
+  ok(`PR #${prNumber}: ${prUrl}`);
+  console.log(`\nReview:  gh pr view ${prNumber} | Merge: bun herdr:task rm ${w.slug}`);
+};
+
+const cmdRm = async (args: string[]): Promise<void> => {
+  const { w } = await resolveTask(args);
+  const keepBranch = hasFlag(args, '--keep-branch');
+  const force = hasFlag(args, '--force');
+
+  console.log(`🧹 Removing task "${w.slug}"...`);
+  await removeWorktree({
+    workspaceId: w.workspaceId || undefined,
+    checkoutPath: w.checkoutPath,
+    branch: keepBranch ? undefined : w.branch,
+    deleteRemoteBranch: false,
+    force,
+    repoRoot: w.repoRoot,
+  });
+  ok(`removed ${w.checkoutPath}${keepBranch ? ' (branch kept)' : ` and branch ${w.branch}`}`);
+
+  // Also clear dev-stack ownership if this worktree owned it.
+  const ownerPath = join(w.repoRoot, DEV_STACK_OWNER_FILE);
+  if (existsSync(ownerPath)) {
+    try {
+      const owner = JSON.parse(readFileSync(ownerPath, 'utf-8')) as { checkoutPath?: string };
+      if (owner.checkoutPath === w.checkoutPath) {
+        writeFileSync(ownerPath, JSON.stringify({ claimedAt: null }, undefined, 2));
+        ok('dev-stack ownership cleared');
+      }
+    } catch {
+      // Non-fatal.
+    }
+  }
+};
+
+const cmdPrune = async (args: string[]): Promise<void> => {
+  const repoRoot = resolveRepoRoot();
+  const legacy = hasFlag(args, '--legacy');
+  const force = hasFlag(args, '--force');
+
+  if (legacy) {
+    // Legacy: .pi/workspaces/* worktrees from the old provisioning code.
+    console.log('🏗️  Legacy .pi/workspaces/ worktrees:');
+    const all = await listWorktrees(repoRoot);
+    const legacyWts = all.filter((w) => w.path.includes('/.pi/workspaces/'));
+    if (legacyWts.length === 0) {
+      console.log('  none found — nothing to prune.');
+      return;
+    }
+    for (const w of legacyWts) {
+      console.log(`  ${w.branch}  ${w.path}`);
+    }
+    if (force) {
+      console.log('\nRemoving legacy worktrees...');
+      for (const w of legacyWts) {
+        await removeWorktree({
+          workspaceId: w.openWorkspaceId,
+          checkoutPath: w.path,
+          branch: w.branch,
+          deleteRemoteBranch: false,
+          force: true,
+          repoRoot,
+        });
+        ok(`removed ${w.branch}`);
+      }
+      try {
+        runGit('worktree prune', { cwd: repoRoot });
+      } catch {}
+    } else {
+      console.log('\nDry run — pass --force to remove them.');
+    }
+    return;
+  }
+
+  // Standard: prunable + closed task worktrees.
+  const all = await listWorktrees(repoRoot);
+  const candidates = all.filter(
+    (w) => w.branch.startsWith(TASK_BRANCH_PREFIX) && (w.isPrunable || !w.openWorkspaceId),
+  );
+  if (candidates.length === 0) {
+    console.log('No prunable task worktrees.');
+    return;
+  }
+  for (const w of candidates) {
+    console.log(`  ${w.branch}  ${w.path}${w.isPrunable ? ' (prunable)' : ''}`);
+  }
+  if (force) {
+    for (const w of candidates) {
+      await removeWorktree({
+        workspaceId: w.openWorkspaceId,
+        checkoutPath: w.path,
+        branch: w.branch,
+        force: true,
+        repoRoot,
+      });
+      ok(`removed ${w.branch}`);
+    }
+  } else {
+    console.log('\nDry run — pass --force to remove them.');
+  }
+};
+
+// ── Main ───────────────────────────────────────────────────
+
+const [subcommand, ...rest] = process.argv.slice(2);
+
+const handlers: Record<string, (args: string[]) => Promise<void>> = {
+  new: cmdNew,
+  list: cmdList,
+  pr: cmdPr,
+  rm: cmdRm,
+  prune: cmdPrune,
+  help: async () => {
+    console.log(`herdr:task — parallel pi sessions in herdr-native git worktrees
+
+Usage:
+  bun herdr:task new <slug> [--base main] [--join] [--no-install] [--with-services]
+      Create a worktree (branched from origin/<base>), bootstrap it, launch pi.
+  bun herdr:task list
+      Show task worktrees + open/dirty state.
+  bun herdr:task pr [<slug>] [--base main] [--title T] [--body B] [--draft]
+      Publish the worktree branch and open a PR to <base>. Resolves the task
+      from the current directory when no slug is given.
+  bun herdr:task rm <slug> [--keep-branch] [--force]
+      Remove worktree + herdr workspace + local branch.
+  bun herdr:task prune [--legacy] [--force]
+      Remove prunable/closed task worktrees. --legacy targets the old
+      .pi/workspaces/ worktrees from the previous provisioning code.
+
+Dev services: default task sessions run WITHOUT ports (typecheck/lint/tests).
+--with-services records dev-stack ownership for serving the stack from the
+worktree (exactly one stack per mode — ports are constants).`);
+  },
+};
+
+try {
+  if (!subcommand || !handlers[subcommand]) {
+    await handlers.help([]);
+    process.exit(subcommand ? 1 : 0);
+  }
+  await handlers[subcommand](rest);
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`\n❌ ${message}`);
+  process.exit(1);
+}

--- a/scripts/src/lib/herdr/worktree.ts
+++ b/scripts/src/lib/herdr/worktree.ts
@@ -55,6 +55,8 @@ export type TaskWorktree = {
   workspaceId: string;
   /** Root pane id of the worktree workspace ("" if not open). */
   rootPaneId: string;
+  /** Root tab id of the worktree workspace ("" if unknown). */
+  tabId: string;
   /** Absolute path of the parent repo checkout (the main working copy). */
   repoRoot: string;
 };
@@ -78,6 +80,14 @@ export type BootstrapOptions = {
   seed?: boolean;
   /** Install timeout in ms (default 180_000 — cold worktrees are slow). */
   installTimeoutMs?: number;
+};
+
+export type RemoveWorktreeResult = {
+  /** True when the checkout (and herdr state) was removed AND, when
+   *  requested, the branch was deleted. False otherwise. */
+  removed: boolean;
+  /** Human-readable reason when `removed` is false. */
+  reason?: string;
 };
 
 export type RemoveWorktreeOptions = {
@@ -264,6 +274,7 @@ type WorktreeCreateResult = {
       path: string;
       is_linked_worktree: boolean;
     };
+    tab: { tab_id: string };
     root_pane: {
       pane_id: string;
     };
@@ -307,14 +318,21 @@ type WorktreeOpenResult = {
 
 // ── Helpers ────────────────────────────────────────────────
 
-/** Root checkout directory for a worktree (from .git file). */
-const worktreeRepoRoot = (checkoutPath: string): string => {
+/** Root checkout directory of the MAIN repo for a worktree (from .git file). */
+export const worktreeRepoRoot = (checkoutPath: string): string => {
   try {
     const gitFile = readFileSync(join(checkoutPath, '.git'), 'utf-8').trim();
-    const m = gitFile.match(/^gitdir:\s*(.+)$/);
+    const m = gitFile.match(/^gitdir:\s*(.+)$/m);
     if (m?.[1]) {
-      // <repo>/.git/worktrees/<name> → walk up 3 levels
-      return resolve(m[1], '../..');
+      const gitDir = resolve(m[1].trim());
+      // <repo>/.git/worktrees/<name> → repo root is everything before
+      // "/.git/worktrees/". Fall back to walking up 3 levels for other
+      // layouts (<repo>/.git/worktrees/name → ../../.. → <repo>).
+      const idx = gitDir.indexOf('/.git/worktrees/');
+      if (idx !== -1) {
+        return gitDir.slice(0, idx);
+      }
+      return resolve(gitDir, '../../..');
     }
   } catch {
     // Not a linked worktree — fall back to rev-parse.
@@ -392,16 +410,18 @@ export const createWorktree = async (options: {
   }
 
   const r = await herdrJson<WorktreeCreateResult>(args);
-  if (!r?.result?.workspace) {
+  const checkoutPath = r?.result?.workspace?.worktree?.checkout_path ?? r?.result?.worktree?.path;
+  if (!(r?.result?.workspace && checkoutPath)) {
     throw new Error(`herdr worktree create failed for slug "${slug}" (branch ${branch})`);
   }
 
   return {
     slug,
     branch: r.result.worktree?.branch ?? branch,
-    checkoutPath: r.result.workspace.worktree?.checkout_path ?? r.result.worktree.path,
+    checkoutPath,
     workspaceId: r.result.workspace.workspace_id,
     rootPaneId: r.result.root_pane?.pane_id ?? '',
+    tabId: r.result.tab?.tab_id ?? '',
     repoRoot: options.repoRoot,
   };
 };
@@ -444,6 +464,7 @@ export const openWorktree = async (options: {
     checkoutPath: options.checkoutPath,
     workspaceId: r.result.workspace.workspace_id,
     rootPaneId: r.result.root_pane?.pane_id ?? '',
+    tabId: '',
     repoRoot: root,
   };
 };
@@ -466,9 +487,12 @@ export const listWorktrees = async (repoRoot?: string): Promise<WorktreeEntry[]>
   }));
 };
 
-/** Find a worktree by branch name (herdr-native lookup). */
-export const findWorktreeByBranch = async (branch: string): Promise<WorktreeEntry | null> => {
-  const worktrees = await listWorktrees();
+/** Find a worktree by branch name (herdr-native lookup, repo-scoped). */
+export const findWorktreeByBranch = async (
+  branch: string,
+  repoRoot?: string,
+): Promise<WorktreeEntry | null> => {
+  const worktrees = await listWorktrees(repoRoot);
   return worktrees.find((w) => w.branch === branch) ?? null;
 };
 
@@ -480,7 +504,9 @@ export const findWorktreeByBranch = async (branch: string): Promise<WorktreeEntr
  *   4. seed gitignored-but-required files (.env*, paraglide, .secrets)
  *   5. bun install --frozen-lockfile
  */
-export const bootstrapWorktree = async (options: BootstrapOptions): Promise<void> => {
+export const bootstrapWorktree = async (
+  options: BootstrapOptions,
+): Promise<{ installed: boolean }> => {
   const { checkoutPath, repoRoot, seed = true } = options;
   if (!existsSync(checkoutPath)) {
     throw new Error(`Cannot bootstrap missing checkout: ${checkoutPath}`);
@@ -506,24 +532,29 @@ export CONTRACT_PIPELINE_WORKTREE=1
   }
 
   // ── 2. skip-worktree — workspace-local tracked files stay local ──
-  try {
-    runGit(`update-index --skip-worktree ${WORKTREE_SKIP_WORKTREE_PATHS.join(' ')}`, {
-      cwd: checkoutPath,
-    });
-  } catch {
-    // Non-fatal — files may not exist in older revisions.
+  // Per path: `git update-index --skip-worktree` fails the WHOLE invocation
+  // if any listed path is not in the index, so one missing file would
+  // disable the bit for all of them.
+  for (const path of WORKTREE_SKIP_WORKTREE_PATHS) {
+    try {
+      runGit(`update-index --skip-worktree '${path}'`, { cwd: checkoutPath });
+    } catch {
+      // Non-fatal — the file may not exist in older revisions.
+    }
   }
 
-  // ── 3. .pi/npm — symlink node_modules so pi extensions resolve deps ──
-  const rootNpmDir = join(repoRoot, '.pi', 'npm');
-  const wsNpmDir = join(checkoutPath, '.pi', 'npm');
-  if (existsSync(rootNpmDir)) {
-    mkdirSync(join(checkoutPath, '.pi'), { recursive: true });
-    const rootNpmModules = join(rootNpmDir, 'node_modules');
-    const wsNpmModules = join(wsNpmDir, 'node_modules');
-    if (existsSync(rootNpmModules)) {
+  // ── 3. .pi deps — symlink node_modules so pi + extensions resolve deps ──
+  // `.pi/node_modules` is bun's resolution path when loading extension files
+  // from .pi/extensions/; `.pi/npm/node_modules` serves the pi-extensions
+  // package. Both are gitignored and absent in a fresh checkout — link them
+  // to the root copies (shared bun cache makes a local install unnecessary).
+  mkdirSync(join(checkoutPath, '.pi'), { recursive: true });
+  for (const rel of ['.pi/node_modules', '.pi/npm/node_modules']) {
+    const src = join(repoRoot, rel);
+    const dst = join(checkoutPath, rel);
+    if (existsSync(src) && !existsSync(dst)) {
       try {
-        symlinkSync(rootNpmModules, wsNpmModules, 'dir');
+        symlinkSync(src, dst, 'dir');
       } catch {
         // Already exists or unsupported — fall through.
       }
@@ -536,6 +567,7 @@ export CONTRACT_PIPELINE_WORKTREE=1
   }
 
   // ── 5. bun install ──
+  let installed = false;
   if (options.install !== false) {
     const timeoutMs = options.installTimeoutMs ?? 180_000;
     try {
@@ -545,14 +577,16 @@ export CONTRACT_PIPELINE_WORKTREE=1
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout: timeoutMs,
       });
+      installed = true;
     } catch {
-      // Surface the failure — a worktree without deps is broken, but the
+      // Report the failure — a worktree without deps is broken, but the
       // caller may choose to continue (e.g. docs-only tasks).
       console.warn(
         `⚠️  bun install failed in ${checkoutPath}. Run it manually: cd ${checkoutPath} && bun install`,
       );
     }
   }
+  return { installed };
 };
 
 /** Copy gitignored-but-required files from the root checkout into the worktree. */
@@ -590,7 +624,9 @@ export const seedWorktreeFiles = (options: { checkoutPath: string; repoRoot: str
  * local and/or remote branch. herdr `worktree remove` NEVER deletes the
  * branch — that is always a separate explicit git step here.
  */
-export const removeWorktree = async (options: RemoveWorktreeOptions): Promise<void> => {
+export const removeWorktree = async (
+  options: RemoveWorktreeOptions,
+): Promise<RemoveWorktreeResult> => {
   const { repoRoot } = options;
   ensureGitRepo(repoRoot);
 
@@ -601,46 +637,63 @@ export const removeWorktree = async (options: RemoveWorktreeOptions): Promise<vo
     workspaceId = entry?.openWorkspaceId;
   }
 
+  let checkoutRemoved = false;
+  let reason: string | undefined;
   if (workspaceId) {
     const args = ['worktree', 'remove', '--workspace', workspaceId];
     if (options.force) {
       args.push('--force');
     }
     const r = await herdrJson<WorktreeRemoveResult>(args);
-    if (!r?.result) {
-      console.warn(`⚠️  herdr worktree remove returned no result for workspace ${workspaceId}`);
+    if (r?.result) {
+      checkoutRemoved = true;
+    } else {
+      reason = `herdr worktree remove returned no result for workspace ${workspaceId}`;
     }
   } else if (options.checkoutPath) {
     // herdr state is gone — fall back to raw git worktree remove.
     try {
       runGit(`worktree remove '${options.checkoutPath}' --force`, { cwd: repoRoot });
-    } catch {
+      checkoutRemoved = true;
+    } catch (gitErr: unknown) {
       try {
         execSync(`rm -rf '${options.checkoutPath}'`, {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 30_000,
         });
-      } catch {
-        // Last resort — nothing more we can do.
+        checkoutRemoved = true;
+      } catch (rmErr: unknown) {
+        const g = gitErr instanceof Error ? gitErr.message : String(gitErr);
+        const r2 = rmErr instanceof Error ? rmErr.message : String(rmErr);
+        reason = `git worktree remove failed (${g}); rm -rf failed (${r2})`;
       }
     }
+  } else {
+    reason = 'No workspace id or checkout path provided';
   }
 
+  let branchDeleted = !options.branch;
   if (options.branch) {
+    // Quote the branch — git refnames permit shell metacharacters.
+    const quoted = `'${options.branch.replaceAll("'", "'\\''")}'`;
     if (options.deleteRemoteBranch) {
       try {
-        runGit(`push origin --delete ${options.branch}`, { cwd: repoRoot });
+        runGit(`push origin --delete ${quoted}`, { cwd: repoRoot });
       } catch {
         // Branch may not exist on remote.
       }
     }
     try {
-      runGit(`branch -D ${options.branch}`, { cwd: repoRoot });
+      runGit(`branch -D ${quoted}`, { cwd: repoRoot });
+      branchDeleted = true;
     } catch {
-      // Branch may already be gone.
+      reason = reason ?? `local branch ${options.branch} could not be deleted`;
     }
   }
+
+  const removed = checkoutRemoved && branchDeleted;
+  return { removed, reason: removed ? undefined : (reason ?? 'removal incomplete') };
 };
 
 // ── Publishing ─────────────────────────────────────────────
@@ -666,26 +719,42 @@ export const publishWorktree = async (
 
   let headBranch = runGit('rev-parse --abbrev-ref HEAD', { cwd: checkoutPath });
   if (headBranch === 'HEAD' || headBranch.startsWith('(detached')) {
-    // Detached — name a branch from the current commit so push can work.
+    // Detached — create a branch at the current commit so push can work.
     const short = runGit('rev-parse --short HEAD', { cwd: checkoutPath });
     headBranch = `task/${sanitizeBranchName(short)}`;
     try {
-      runGit(`branch -m ${headBranch}`, { cwd: checkoutPath });
+      runGit(`switch -c ${headBranch}`, { cwd: checkoutPath });
     } catch {
       // Fall through — push will fail loudly if the branch is unusable.
     }
   }
 
-  // Idempotency guard: if the branch exists on the remote (prior partial
-  // push), append a token to avoid non-fast-forward rejection.
+  // Idempotency guard: if the branch already exists on the remote, prefer
+  // updating it when the remote ref is an ancestor of the local head (same
+  // task, re-publish → the existing PR updates). Only create a new branch
+  // on true divergence (rewritten history / unrelated push).
   if (remoteBranchExists({ branchName: headBranch, repoRoot })) {
-    const token = Date.now().toString(36).slice(-6);
-    const renamed = `${headBranch}-${token}`;
     try {
-      runGit(`branch -m ${headBranch} ${renamed}`, { cwd: checkoutPath });
-      headBranch = renamed;
+      runGit(`fetch origin ${headBranch}`, { cwd: checkoutPath });
     } catch {
-      // Rename failed — leave as-is; push will surface the real error.
+      // Non-fatal — ref may already be present locally.
+    }
+    let isAncestor = false;
+    try {
+      runGit(`merge-base --is-ancestor origin/${headBranch} HEAD`, { cwd: checkoutPath });
+      isAncestor = true;
+    } catch {
+      // Not an ancestor → divergence.
+    }
+    if (!isAncestor) {
+      const token = Date.now().toString(36).slice(-6);
+      const renamed = `${headBranch}-${token}`;
+      try {
+        runGit(`branch -m ${headBranch} ${renamed}`, { cwd: checkoutPath });
+        headBranch = renamed;
+      } catch {
+        // Rename failed — leave as-is; push will surface the real error.
+      }
     }
   }
 
@@ -732,12 +801,12 @@ export const openPullRequest = async (
     timeout: 30_000,
   }).trim();
   const m = result.match(/https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/);
-  return { prUrl: result, prNumber: m?.[1] ?? '' };
+  return { prUrl: m?.[0] ?? result, prNumber: m?.[1] ?? '' };
 };
 
 /** Convenience: publish + open PR in one call (used by task_open_pr tool). */
 export const publishAndOpenPr = async (
-  options: PublishOptions & PullRequestOptions,
+  options: PublishOptions & Omit<PullRequestOptions, 'headBranch'>,
 ): Promise<{
   headBranch: string;
   headCommit: string;
@@ -762,13 +831,16 @@ export const findTaskWorkspace = async (slug: string): Promise<string | null> =>
   return findWorkspace(`${TASK_WORKSPACE_PREFIX}${sanitizeBranchName(slug)}`);
 };
 
-/** Get a TaskWorktree for an open task workspace label. */
-export const getTaskWorktreeByLabel = async (label: string): Promise<TaskWorktree | null> => {
+/** Get a TaskWorktree for an open task workspace label (repo-scoped). */
+export const getTaskWorktreeByLabel = async (
+  label: string,
+  repoRoot?: string,
+): Promise<TaskWorktree | null> => {
   const wsId = await findWorkspace(label);
   if (!wsId) {
     return null;
   }
-  const entry = (await listWorktrees()).find((w) => w.openWorkspaceId === wsId);
+  const entry = (await listWorktrees(repoRoot)).find((w) => w.openWorkspaceId === wsId);
   if (!entry) {
     return null;
   }
@@ -779,6 +851,7 @@ export const getTaskWorktreeByLabel = async (label: string): Promise<TaskWorktre
     checkoutPath: entry.path,
     workspaceId: wsId,
     rootPaneId: '',
+    tabId: '',
     repoRoot: worktreeRepoRoot(entry.path),
   };
 };

--- a/scripts/src/lib/herdr/worktree.ts
+++ b/scripts/src/lib/herdr/worktree.ts
@@ -1,0 +1,784 @@
+// scripts/src/lib/herdr/worktree.ts
+//
+// Herdr-native Git Worktree lifecycle — THE single source of truth for
+// task/contract worktree provisioning, bootstrapping, publishing, and cleanup.
+//
+// Why herdr-native instead of raw `git worktree add` (see git_worktree.ts):
+//   - `herdr worktree create` makes a real git worktree AND opens it as a
+//     herdr workspace, grouped with the parent repo (repo provenance tracked).
+//   - Checkouts live in ~/.herdr/worktrees/<repo>/<slug> by default — OUTSIDE
+//     the repo — so they never pollute root git state or .gitignore, and the
+//     root checkout (possibly mid-refactor by another session) is untouched.
+//   - `herdr worktree remove --workspace <id>` tears down herdr state + the
+//     checkout together; branch deletion stays a separate git step (herdr
+//     never deletes branches by design).
+//
+// Consumers:
+//   1. scripts/src/lib/herdr/task.ts  → `bun herdr:task` CLI (parallel pi sessions)
+//   2. contract pipeline (herdr_adapter.ts / orchestrator.ts)
+//   3. pi extension tools (contract_workspace_reconcile, task_open_pr)
+//
+// The low-level git primitives (runGit, commitAll, pushBranch, ...) remain in
+// scripts/src/lib/agents/git_worktree.ts — do not fork them.
+
+// biome-ignore-all lint/style/useNamingConvention: HerDr API response field names (snake_case) — must match external API contract
+import { execSync } from 'node:child_process';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  commitAll,
+  pushBranch,
+  remoteBranchExists,
+  runGit,
+  sanitizeBranchName,
+} from '../agents/git_worktree.ts';
+import { findWorkspace, herdrJson } from './session.ts';
+
+// ── Types ──────────────────────────────────────────────────
+
+export type TaskWorktree = {
+  /** Short human slug (task/<slug> → branch, aikami-task-<slug> → label). */
+  slug: string;
+  /** Git branch the worktree has checked out (e.g. task/my-feature). */
+  branch: string;
+  /** Absolute checkout path (~/.herdr/worktrees/<repo>/<dir>). */
+  checkoutPath: string;
+  /** herdr workspace id for the worktree ("" if not open). */
+  workspaceId: string;
+  /** Root pane id of the worktree workspace ("" if not open). */
+  rootPaneId: string;
+  /** Absolute path of the parent repo checkout (the main working copy). */
+  repoRoot: string;
+};
+
+export type WorktreeEntry = {
+  branch: string;
+  path: string;
+  label: string;
+  openWorkspaceId?: string;
+  isLinked: boolean;
+  isDetached: boolean;
+  isPrunable: boolean;
+};
+
+export type BootstrapOptions = {
+  checkoutPath: string;
+  repoRoot: string;
+  /** Run `bun install --frozen-lockfile` (default true). */
+  install?: boolean;
+  /** Copy gitignored-but-required seed files (.env*, paraglide, .secrets). */
+  seed?: boolean;
+  /** Install timeout in ms (default 180_000 — cold worktrees are slow). */
+  installTimeoutMs?: number;
+};
+
+export type RemoveWorktreeOptions = {
+  /** herdr workspace id (when the worktree is open as a workspace). */
+  workspaceId?: string;
+  /** Checkout path — used for fallback removal if no workspace id. */
+  checkoutPath?: string;
+  /** Branch to delete locally (and remotely when requested). */
+  branch?: string;
+  /** Also delete the remote branch (git push origin --delete). */
+  deleteRemoteBranch?: boolean;
+  /** Force removal (dirty checkout). */
+  force?: boolean;
+  repoRoot: string;
+};
+
+export type PublishOptions = {
+  checkoutPath: string;
+  repoRoot: string;
+  /** Base branch for PR + collision-guard naming (default: current branch). */
+  base?: string;
+  /** Final commit message (default: descriptive generic). */
+  message?: string;
+  authorName?: string;
+  authorEmail?: string;
+};
+
+export type PullRequestOptions = {
+  headBranch: string;
+  base: string;
+  title: string;
+  body?: string;
+  draft?: boolean;
+};
+
+// ── Constants ──────────────────────────────────────────────
+
+/**
+ * Workspace label prefix for task worktrees. `parseWorkspaceName()`
+ * in session.ts returns null for these, so listServices() correctly
+ * ignores task workspaces in the dev-service listing.
+ */
+export const TASK_WORKSPACE_PREFIX = 'aikami-task-';
+export const TASK_BRANCH_PREFIX = 'task/';
+
+/**
+ * Tracked files that must not be committed from a worktree. They are
+ * workspace-local state (direnv delegation, pi settings, shared progress
+ * docs) — `git add -A` would otherwise sweep them into every PR.
+ * Marked skip-worktree during bootstrap (git worktrees use a .git FILE,
+ * so .git/info/exclude is unavailable — skip-worktree is the only
+ * reliable mechanism).
+ */
+export const WORKTREE_SKIP_WORKTREE_PATHS = [
+  '.envrc',
+  '.pi/settings.json',
+  '.context/llms.txt',
+  'docs/contracts/PROGRESS.md',
+  'docs/contracts/PROMOTION.md',
+];
+
+/**
+ * Gitignored-but-required files copied from the root checkout during
+ * bootstrap. Without these, dev servers / typecheck / tests can't run
+ * in a worktree (they are gitignored, so a fresh checkout lacks them).
+ * Each entry: { from (relative to repoRoot), to (relative to checkout),
+ * kind: 'file' | 'dir', optional: true }.
+ */
+export const WORKTREE_SEED_PATHS: Array<{
+  from: string;
+  to: string;
+  kind: 'file' | 'dir';
+  optional?: boolean;
+}> = [
+  // Root env files
+  { from: '.env', to: '.env', kind: 'file', optional: true },
+  { from: '.env.emulator', to: '.env.emulator', kind: 'file', optional: true },
+  { from: '.env.local', to: '.env.local', kind: 'file', optional: true },
+  // Client env files (SvelteKit dev servers need these)
+  {
+    from: 'apps/frontend/client/.env.emulator',
+    to: 'apps/frontend/client/.env.emulator',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/client/.env.local',
+    to: 'apps/frontend/client/.env.local',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/client/.env.staging',
+    to: 'apps/frontend/client/.env.staging',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/client/.env.production',
+    to: 'apps/frontend/client/.env.production',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/client/.env.testing',
+    to: 'apps/frontend/client/.env.testing',
+    kind: 'file',
+    optional: true,
+  },
+  // Site + hub env files
+  {
+    from: 'apps/frontend/site/.env.local',
+    to: 'apps/frontend/site/.env.local',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/site/.env.staging',
+    to: 'apps/frontend/site/.env.staging',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/site/.env.production',
+    to: 'apps/frontend/site/.env.production',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/frontend/hub/.env.local',
+    to: 'apps/frontend/hub/.env.local',
+    kind: 'file',
+    optional: true,
+  },
+  // Firebase function env files
+  {
+    from: 'apps/backend/firebase/.env.emulator',
+    to: 'apps/backend/firebase/.env.emulator',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/backend/firebase/.env.staging',
+    to: 'apps/backend/firebase/.env.staging',
+    kind: 'file',
+    optional: true,
+  },
+  {
+    from: 'apps/backend/firebase/.env.production',
+    to: 'apps/backend/firebase/.env.production',
+    kind: 'file',
+    optional: true,
+  },
+  // E2E + scripts env
+  { from: 'apps/e2e/.env', to: 'apps/e2e/.env', kind: 'file', optional: true },
+  { from: 'scripts/.env', to: 'scripts/.env', kind: 'file', optional: true },
+  // GCP service-account keys (needed by gcloud/firebase deploys)
+  { from: '.secrets', to: '.secrets', kind: 'dir', optional: true },
+  // Paraglide generated i18n files — gitignored, required for client
+  // typecheck/build/dev (Vite re-generates them, but only when running).
+  {
+    from: 'apps/frontend/client/src/lib/paraglide',
+    to: 'apps/frontend/client/src/lib/paraglide',
+    kind: 'dir',
+    optional: true,
+  },
+];
+
+// ── Herdr CLI result shapes ────────────────────────────────
+
+type WorktreeCreateResult = {
+  result: {
+    type: 'worktree_created';
+    workspace: {
+      workspace_id: string;
+      label: string;
+      worktree?: {
+        checkout_path: string;
+        repo_root: string;
+      };
+    };
+    worktree: {
+      branch: string;
+      path: string;
+      is_linked_worktree: boolean;
+    };
+    root_pane: {
+      pane_id: string;
+    };
+  };
+};
+
+type WorktreeListResult = {
+  result: {
+    worktrees: Array<{
+      branch: string;
+      path: string;
+      label: string;
+      open_workspace_id?: string;
+      is_linked_worktree: boolean;
+      is_detached: boolean;
+      is_prunable: boolean;
+    }>;
+  };
+};
+
+type WorktreeRemoveResult = {
+  result: {
+    type: 'worktree_removed';
+    path: string;
+    workspace_id: string;
+    forced: boolean;
+  };
+};
+
+type WorktreeOpenResult = {
+  result: {
+    workspace: {
+      workspace_id: string;
+      label: string;
+      worktree?: { checkout_path: string; repo_root: string };
+    };
+    worktree?: { branch: string; path: string };
+    root_pane: { pane_id: string };
+  };
+};
+
+// ── Helpers ────────────────────────────────────────────────
+
+/** Root checkout directory for a worktree (from .git file). */
+const worktreeRepoRoot = (checkoutPath: string): string => {
+  try {
+    const gitFile = readFileSync(join(checkoutPath, '.git'), 'utf-8').trim();
+    const m = gitFile.match(/^gitdir:\s*(.+)$/);
+    if (m?.[1]) {
+      // <repo>/.git/worktrees/<name> → walk up 3 levels
+      return resolve(m[1], '../..');
+    }
+  } catch {
+    // Not a linked worktree — fall back to rev-parse.
+  }
+  try {
+    return runGit('rev-parse --show-toplevel', { cwd: checkoutPath });
+  } catch {
+    throw new Error(`Cannot determine repo root for ${checkoutPath}`);
+  }
+};
+
+const ensureGitRepo = (repoRoot: string): void => {
+  try {
+    runGit('rev-parse --git-dir', { cwd: repoRoot });
+  } catch {
+    throw new Error(`Not a git repository: ${repoRoot}`);
+  }
+};
+
+// ── Worktree lifecycle ─────────────────────────────────────
+
+/**
+ * Create a herdr-native Git Worktree.
+ *
+ * Branches from `origin/<base>` (fetched fresh) so the worktree NEVER
+ * includes uncommitted work or unpushed commits from the root checkout —
+ * critical when another session is refactoring on main concurrently.
+ *
+ * The worktree is automatically opened as a herdr workspace grouped with
+ * the parent repo. Returns workspace id + checkout path + root pane id.
+ */
+export const createWorktree = async (options: {
+  slug: string;
+  /** Explicit branch name. Default: task/<slug>. */
+  branch?: string;
+  /** Base ref to branch from. Default: current branch of repo root. */
+  base?: string;
+  /** Workspace label. Default: aikami-task-<slug>. */
+  label?: string;
+  repoRoot: string;
+  focus?: boolean;
+}): Promise<TaskWorktree> => {
+  ensureGitRepo(options.repoRoot);
+  const slug = sanitizeBranchName(options.slug);
+  if (!slug) {
+    throw new Error('Worktree slug must be a non-empty identifier (a-z, 0-9, -).');
+  }
+
+  const currentBranch = runGit('rev-parse --abbrev-ref HEAD', { cwd: options.repoRoot });
+  const base = options.base ?? (currentBranch === 'HEAD' ? 'main' : currentBranch);
+
+  // Fetch the base ref so the worktree starts from origin, not a dirty local.
+  try {
+    runGit('fetch origin', { cwd: options.repoRoot });
+  } catch {
+    // Non-fatal — may not have a remote configured.
+  }
+
+  // Resolve origin/<base> first; fall back to the local ref.
+  let baseRef = `origin/${base}`;
+  try {
+    runGit(`rev-parse --verify ${baseRef}`, { cwd: options.repoRoot });
+  } catch {
+    baseRef = base;
+  }
+
+  const branch = options.branch ?? `${TASK_BRANCH_PREFIX}${slug}`;
+  const label = options.label ?? `${TASK_WORKSPACE_PREFIX}${slug}`;
+
+  const args = ['worktree', 'create', '--branch', branch, '--base', baseRef, '--label', label];
+  if (options.focus) {
+    args.push('--focus');
+  } else {
+    args.push('--no-focus');
+  }
+
+  const r = await herdrJson<WorktreeCreateResult>(args);
+  if (!r?.result?.workspace) {
+    throw new Error(`herdr worktree create failed for slug "${slug}" (branch ${branch})`);
+  }
+
+  return {
+    slug,
+    branch: r.result.worktree?.branch ?? branch,
+    checkoutPath: r.result.workspace.worktree?.checkout_path ?? r.result.worktree.path,
+    workspaceId: r.result.workspace.workspace_id,
+    rootPaneId: r.result.root_pane?.pane_id ?? '',
+    repoRoot: options.repoRoot,
+  };
+};
+
+/**
+ * Re-open an existing worktree checkout as a herdr workspace.
+ * Recovery path: the checkout survives but its herdr workspace was closed
+ * (herdr `workspace close` closes state only).
+ */
+export const openWorktree = async (options: {
+  checkoutPath: string;
+  label?: string;
+  repoRoot?: string;
+  focus?: boolean;
+}): Promise<TaskWorktree> => {
+  if (!existsSync(join(options.checkoutPath, '.git'))) {
+    throw new Error(`Not a git worktree: ${options.checkoutPath}`);
+  }
+  const root = options.repoRoot ?? worktreeRepoRoot(options.checkoutPath);
+  const branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: options.checkoutPath });
+
+  const args = ['worktree', 'open', '--path', options.checkoutPath];
+  if (options.label) {
+    args.push('--label', options.label);
+  }
+  if (options.focus) {
+    args.push('--focus');
+  } else {
+    args.push('--no-focus');
+  }
+
+  const r = await herdrJson<WorktreeOpenResult>(args);
+  if (!r?.result?.workspace) {
+    throw new Error(`herdr worktree open failed for ${options.checkoutPath}`);
+  }
+
+  return {
+    slug: sanitizeBranchName(branch.replace(/^task\//, '')),
+    branch,
+    checkoutPath: options.checkoutPath,
+    workspaceId: r.result.workspace.workspace_id,
+    rootPaneId: r.result.root_pane?.pane_id ?? '',
+    repoRoot: root,
+  };
+};
+
+/** List all herdr-tracked worktrees for the repo (with provenance). */
+export const listWorktrees = async (repoRoot?: string): Promise<WorktreeEntry[]> => {
+  const args = repoRoot ? ['worktree', 'list', '--cwd', repoRoot] : ['worktree', 'list'];
+  const r = await herdrJson<WorktreeListResult>(args);
+  if (!r?.result?.worktrees) {
+    return [];
+  }
+  return r.result.worktrees.map((w) => ({
+    branch: w.branch,
+    path: w.path,
+    label: w.label,
+    openWorkspaceId: w.open_workspace_id,
+    isLinked: w.is_linked_worktree,
+    isDetached: w.is_detached,
+    isPrunable: w.is_prunable,
+  }));
+};
+
+/** Find a worktree by branch name (herdr-native lookup). */
+export const findWorktreeByBranch = async (branch: string): Promise<WorktreeEntry | null> => {
+  const worktrees = await listWorktrees();
+  return worktrees.find((w) => w.branch === branch) ?? null;
+};
+
+/**
+ * Bootstrap a worktree checkout so pi, moon, bun, and dev servers work:
+ *   1. .envrc delegating to the repo root (flake.nix is git-tracked there)
+ *   2. skip-worktree for workspace-local tracked files (never in PRs)
+ *   3. .pi/npm/node_modules symlink (pi extensions deps)
+ *   4. seed gitignored-but-required files (.env*, paraglide, .secrets)
+ *   5. bun install --frozen-lockfile
+ */
+export const bootstrapWorktree = async (options: BootstrapOptions): Promise<void> => {
+  const { checkoutPath, repoRoot, seed = true } = options;
+  if (!existsSync(checkoutPath)) {
+    throw new Error(`Cannot bootstrap missing checkout: ${checkoutPath}`);
+  }
+
+  // ── 1. .envrc — delegate to repo root where flake.nix is git-tracked ──
+  writeFileSync(
+    join(checkoutPath, '.envrc'),
+    `# Worktree direnv — delegate to repo root where flake.nix is Git-tracked
+source_env ${repoRoot}
+export CONTRACT_PIPELINE_WORKTREE=1
+`,
+  );
+  try {
+    execSync('direnv allow', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: checkoutPath,
+      timeout: 5000,
+    });
+  } catch {
+    // direnv may not be installed — not fatal.
+  }
+
+  // ── 2. skip-worktree — workspace-local tracked files stay local ──
+  try {
+    runGit(`update-index --skip-worktree ${WORKTREE_SKIP_WORKTREE_PATHS.join(' ')}`, {
+      cwd: checkoutPath,
+    });
+  } catch {
+    // Non-fatal — files may not exist in older revisions.
+  }
+
+  // ── 3. .pi/npm — symlink node_modules so pi extensions resolve deps ──
+  const rootNpmDir = join(repoRoot, '.pi', 'npm');
+  const wsNpmDir = join(checkoutPath, '.pi', 'npm');
+  if (existsSync(rootNpmDir)) {
+    mkdirSync(join(checkoutPath, '.pi'), { recursive: true });
+    const rootNpmModules = join(rootNpmDir, 'node_modules');
+    const wsNpmModules = join(wsNpmDir, 'node_modules');
+    if (existsSync(rootNpmModules)) {
+      try {
+        symlinkSync(rootNpmModules, wsNpmModules, 'dir');
+      } catch {
+        // Already exists or unsupported — fall through.
+      }
+    }
+  }
+
+  // ── 4. Seed gitignored-but-required files ──
+  if (seed) {
+    seedWorktreeFiles({ checkoutPath, repoRoot });
+  }
+
+  // ── 5. bun install ──
+  if (options.install !== false) {
+    const timeoutMs = options.installTimeoutMs ?? 180_000;
+    try {
+      execSync('bun install --frozen-lockfile', {
+        cwd: checkoutPath,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: timeoutMs,
+      });
+    } catch {
+      // Surface the failure — a worktree without deps is broken, but the
+      // caller may choose to continue (e.g. docs-only tasks).
+      console.warn(
+        `⚠️  bun install failed in ${checkoutPath}. Run it manually: cd ${checkoutPath} && bun install`,
+      );
+    }
+  }
+};
+
+/** Copy gitignored-but-required files from the root checkout into the worktree. */
+export const seedWorktreeFiles = (options: { checkoutPath: string; repoRoot: string }): void => {
+  const { checkoutPath, repoRoot } = options;
+  for (const entry of WORKTREE_SEED_PATHS) {
+    const src = join(repoRoot, entry.from);
+    const dst = join(checkoutPath, entry.to);
+    if (!existsSync(src)) {
+      if (!entry.optional) {
+        console.warn(`⚠️  Required seed file missing in root: ${entry.from}`);
+      }
+      continue;
+    }
+    try {
+      if (entry.kind === 'dir') {
+        if (!existsSync(dst)) {
+          cpSync(src, dst, { recursive: true });
+        }
+      } else {
+        mkdirSync(join(dst, '..'), { recursive: true });
+        if (!existsSync(dst)) {
+          copyFileSync(src, dst);
+        }
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`⚠️  Could not seed ${entry.from} → ${entry.to}: ${message}`);
+    }
+  }
+};
+
+/**
+ * Remove a worktree: herdr state + checkout together, then optionally the
+ * local and/or remote branch. herdr `worktree remove` NEVER deletes the
+ * branch — that is always a separate explicit git step here.
+ */
+export const removeWorktree = async (options: RemoveWorktreeOptions): Promise<void> => {
+  const { repoRoot } = options;
+  ensureGitRepo(repoRoot);
+
+  let workspaceId = options.workspaceId;
+  // If no workspace id given, resolve from the checkout path.
+  if (!workspaceId && options.checkoutPath) {
+    const entry = (await listWorktrees(repoRoot)).find((w) => w.path === options.checkoutPath);
+    workspaceId = entry?.openWorkspaceId;
+  }
+
+  if (workspaceId) {
+    const args = ['worktree', 'remove', '--workspace', workspaceId];
+    if (options.force) {
+      args.push('--force');
+    }
+    const r = await herdrJson<WorktreeRemoveResult>(args);
+    if (!r?.result) {
+      console.warn(`⚠️  herdr worktree remove returned no result for workspace ${workspaceId}`);
+    }
+  } else if (options.checkoutPath) {
+    // herdr state is gone — fall back to raw git worktree remove.
+    try {
+      runGit(`worktree remove '${options.checkoutPath}' --force`, { cwd: repoRoot });
+    } catch {
+      try {
+        execSync(`rm -rf '${options.checkoutPath}'`, {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 30_000,
+        });
+      } catch {
+        // Last resort — nothing more we can do.
+      }
+    }
+  }
+
+  if (options.branch) {
+    if (options.deleteRemoteBranch) {
+      try {
+        runGit(`push origin --delete ${options.branch}`, { cwd: repoRoot });
+      } catch {
+        // Branch may not exist on remote.
+      }
+    }
+    try {
+      runGit(`branch -D ${options.branch}`, { cwd: repoRoot });
+    } catch {
+      // Branch may already be gone.
+    }
+  }
+};
+
+// ── Publishing ─────────────────────────────────────────────
+
+/**
+ * Publish a worktree: collision-guard the branch name, commit all changes,
+ * push to origin with upstream tracking. Returns the final head branch.
+ *
+ * Mirrors the contract pipeline's reconcile step but operates on the
+ * EXISTING worktree (no re-provisioning).
+ */
+export const publishWorktree = async (
+  options: PublishOptions,
+): Promise<{
+  headBranch: string;
+  headCommit: string;
+  checkoutPath: string;
+}> => {
+  const { checkoutPath, repoRoot } = options;
+  if (!existsSync(checkoutPath)) {
+    throw new Error(`Cannot publish missing worktree: ${checkoutPath}`);
+  }
+
+  let headBranch = runGit('rev-parse --abbrev-ref HEAD', { cwd: checkoutPath });
+  if (headBranch === 'HEAD' || headBranch.startsWith('(detached')) {
+    // Detached — name a branch from the current commit so push can work.
+    const short = runGit('rev-parse --short HEAD', { cwd: checkoutPath });
+    headBranch = `task/${sanitizeBranchName(short)}`;
+    try {
+      runGit(`branch -m ${headBranch}`, { cwd: checkoutPath });
+    } catch {
+      // Fall through — push will fail loudly if the branch is unusable.
+    }
+  }
+
+  // Idempotency guard: if the branch exists on the remote (prior partial
+  // push), append a token to avoid non-fast-forward rejection.
+  if (remoteBranchExists({ branchName: headBranch, repoRoot })) {
+    const token = Date.now().toString(36).slice(-6);
+    const renamed = `${headBranch}-${token}`;
+    try {
+      runGit(`branch -m ${headBranch} ${renamed}`, { cwd: checkoutPath });
+      headBranch = renamed;
+    } catch {
+      // Rename failed — leave as-is; push will surface the real error.
+    }
+  }
+
+  const message =
+    options.message ??
+    `Feat: ${sanitizeBranchName(headBranch.replace(/^task\//, ''))} (${headBranch})`;
+  const headCommit = commitAll({
+    cwd: checkoutPath,
+    message,
+    authorName: options.authorName,
+    authorEmail: options.authorEmail,
+  });
+  pushBranch({ cwd: checkoutPath, branchName: headBranch });
+
+  return { headBranch, headCommit, checkoutPath };
+};
+
+/**
+ * Open a GitHub PR (headBranch → base). Thin wrapper over `gh pr create`
+ * so both the CLI and pi extension tools share one implementation.
+ */
+export const openPullRequest = async (
+  options: PullRequestOptions,
+): Promise<{ prUrl: string; prNumber: string }> => {
+  const args = [
+    'pr',
+    'create',
+    '--head',
+    options.headBranch,
+    '--base',
+    options.base,
+    '--title',
+    options.title,
+  ];
+  if (options.body) {
+    args.push('--body', options.body);
+  }
+  if (options.draft) {
+    args.push('--draft');
+  }
+  const result = execSync(`gh ${args.map((a) => `'${a.replaceAll("'", "'\\''")}'`).join(' ')}`, {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 30_000,
+  }).trim();
+  const m = result.match(/https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/);
+  return { prUrl: result, prNumber: m?.[1] ?? '' };
+};
+
+/** Convenience: publish + open PR in one call (used by task_open_pr tool). */
+export const publishAndOpenPr = async (
+  options: PublishOptions & PullRequestOptions,
+): Promise<{
+  headBranch: string;
+  headCommit: string;
+  prUrl: string;
+  prNumber: string;
+}> => {
+  const { headBranch, headCommit } = await publishWorktree(options);
+  const { prUrl, prNumber } = await openPullRequest({
+    headBranch,
+    base: options.base,
+    title: options.title,
+    body: options.body,
+    draft: options.draft,
+  });
+  return { headBranch, headCommit, prUrl, prNumber };
+};
+
+// ── Lookup helpers ─────────────────────────────────────────
+
+/** Find an open task worktree by slug (workspace label aikami-task-<slug>). */
+export const findTaskWorkspace = async (slug: string): Promise<string | null> => {
+  return findWorkspace(`${TASK_WORKSPACE_PREFIX}${sanitizeBranchName(slug)}`);
+};
+
+/** Get a TaskWorktree for an open task workspace label. */
+export const getTaskWorktreeByLabel = async (label: string): Promise<TaskWorktree | null> => {
+  const wsId = await findWorkspace(label);
+  if (!wsId) {
+    return null;
+  }
+  const entry = (await listWorktrees()).find((w) => w.openWorkspaceId === wsId);
+  if (!entry) {
+    return null;
+  }
+  const branch = runGit('rev-parse --abbrev-ref HEAD', { cwd: entry.path });
+  return {
+    slug: sanitizeBranchName(label.replace(TASK_WORKSPACE_PREFIX, '')),
+    branch,
+    checkoutPath: entry.path,
+    workspaceId: wsId,
+    rootPaneId: '',
+    repoRoot: worktreeRepoRoot(entry.path),
+  };
+};

--- a/scripts/src/lib/ops/workspace_cleanup.ts
+++ b/scripts/src/lib/ops/workspace_cleanup.ts
@@ -12,12 +12,17 @@
 //   bun run workspace:cleanup --all          clean up ALL workspaces
 //   bun run workspace:cleanup <path>         clean a specific workspace
 //   bun run workspace:cleanup --pr-merged    clean workspaces whose branch has a merged PR
+//   bun run workspace:cleanup --legacy       only legacy .pi/workspaces/ worktrees
+//
+// 🔴 Drive off `git worktree list --porcelain` — the AUTHORITATIVE source.
+// Covers BOTH legacy .pi/workspaces/ checkouts AND herdr-native worktrees
+// (~/.herdr/worktrees/<repo>/). herdr-native worktrees are also removed via
+// `herdr worktree remove` (closes herdr workspace state + checkout together).
 
 import { execSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
-import { join, relative } from 'node:path';
-
-const WORKSPACES_DIR = '.pi/workspaces';
+import { existsSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { removeWorktree } from '../herdr/worktree.ts';
 
 const runGit = (command: string, cwd: string): string => {
   try {
@@ -38,110 +43,161 @@ type WorkspaceInfo = {
   headCommit: string;
   description: string;
   prMerged: boolean;
+  isLegacy: boolean;
+  herdrWorkspaceId?: string;
 };
 
-const listWorkspaces = (): WorkspaceInfo[] => {
-  const wsParent = join(process.cwd(), WORKSPACES_DIR);
-  if (!existsSync(wsParent)) {
+/** Parse `git worktree list --porcelain` into entries. */
+const listAllWorktrees = (): Array<{ path: string; branch?: string; detached?: boolean }> => {
+  const out = execSync('git worktree list --porcelain', {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10000,
+  }).trim();
+  if (!out) {
     return [];
   }
 
+  const entries: Array<{ path: string; branch?: string; detached?: boolean }> = [];
+  let current: { path: string; branch?: string; detached?: boolean } | null = null;
+  for (const line of out.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current) {
+        entries.push(current);
+      }
+      current = { path: line.slice('worktree '.length).trim() };
+    } else if (line.startsWith('branch ')) {
+      if (current) {
+        current.branch = line.slice('branch '.length).replace('refs/heads/', '');
+      }
+    } else if (line === 'detached') {
+      if (current) {
+        current.detached = true;
+      }
+    }
+  }
+  if (current) {
+    entries.push(current);
+  }
+  return entries;
+};
+
+const prMergedForBranch = (branchName: string): boolean => {
+  try {
+    const prList = execSync(
+      `gh pr list --head "${branchName}" --state merged --json number --jq 'length'`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 },
+    ).trim();
+    return prList !== '0' && prList !== '';
+  } catch {
+    return false;
+  }
+};
+
+const listWorkspaces = async (): Promise<WorkspaceInfo[]> => {
+  const repoRoot = resolve(process.cwd());
+  const legacyParent = join(repoRoot, '.pi', 'workspaces');
+  const worktrees = listAllWorktrees().filter((w) => w.path !== repoRoot); // skip main checkout
+
   const items: WorkspaceInfo[] = [];
-  const entries = readdirSync(wsParent, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
+  for (const wt of worktrees) {
+    if (!existsSync(wt.path)) {
       continue;
     }
-    const wsPath = join(wsParent, entry.name);
-    try {
-      const headCommit = runGit('rev-parse HEAD', wsPath);
-      if (!headCommit) {
-        continue;
-      }
-      const branchName = runGit('rev-parse --abbrev-ref HEAD', wsPath);
-      const desc = runGit('log -1 --format=%s', wsPath);
-
-      // Check if this branch has a merged PR
-      let prMerged = false;
-      try {
-        const prList = execSync(
-          `gh pr list --head "${branchName}" --state merged --json number --jq 'length'`,
-          { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 },
-        ).trim();
-        prMerged = prList !== '0' && prList !== '';
-      } catch {
-        // gh CLI may not be available — assume not merged
-      }
-
-      items.push({
-        path: wsPath,
-        branchName,
-        headCommit: headCommit.slice(0, 12),
-        description: desc.trim(),
-        prMerged,
-      });
-    } catch {
-      // Skip non-worktree directories
+    const headCommit = runGit('rev-parse HEAD', wt.path);
+    if (!headCommit) {
+      continue;
     }
+    const branchName = wt.branch ?? '(detached)';
+    const desc = runGit('log -1 --format=%s', wt.path);
+    const isLegacy = wt.path.startsWith(legacyParent);
+
+    // Resolve the herdr workspace id for herdr-native worktrees so cleanup
+    // can tear herdr state + checkout together.
+    let herdrWorkspaceId: string | undefined;
+    if (!isLegacy) {
+      try {
+        const r = execSync('herdr worktree list --cwd ' + `'${repoRoot}'`, {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 10000,
+        }).trim();
+        const parsed = JSON.parse(r) as {
+          result: { worktrees: Array<{ path: string; open_workspace_id?: string }> };
+        };
+        herdrWorkspaceId = parsed.result.worktrees.find(
+          (w) => w.path === wt.path,
+        )?.open_workspace_id;
+      } catch {
+        // herdr unavailable — fall back to plain git removal.
+      }
+    }
+
+    items.push({
+      path: wt.path,
+      branchName,
+      headCommit: headCommit.slice(0, 12),
+      description: desc.trim(),
+      prMerged: prMergedForBranch(branchName),
+      isLegacy,
+      herdrWorkspaceId,
+    });
   }
   return items;
 };
 
-const cleanupWorkspace = (ws: WorkspaceInfo): void => {
+const cleanupWorkspace = async (ws: WorkspaceInfo, repoRoot: string): Promise<void> => {
   console.log(`🧹 Cleaning up: ${ws.path} (branch: ${ws.branchName})`);
-  try {
-    runGit(`worktree remove '${ws.path}' --force`, process.cwd());
-    console.log(`   ✅ Worktree removed`);
-  } catch {
-    // Fall back to rm -rf
-    try {
-      execSync(`rm -rf '${ws.path}'`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
-      console.log(`   ✅ Directory removed (force)`);
-    } catch {
-      console.log(`   ❌ Failed to remove`);
-    }
-  }
-  // Delete the local branch
-  try {
-    runGit(`branch -D ${ws.branchName}`, process.cwd());
-    console.log(`   ✅ Branch deleted: ${ws.branchName}`);
-  } catch {
-    console.log(`   ⚠️  Branch may already be deleted`);
-  }
+  await removeWorktree({
+    workspaceId: ws.herdrWorkspaceId,
+    checkoutPath: ws.path,
+    branch: ws.branchName === '(detached)' ? undefined : ws.branchName,
+    deleteRemoteBranch: false,
+    force: true,
+    repoRoot,
+  });
+  console.log(`   ✅ Removed worktree${ws.herdrWorkspaceId ? ' + herdr workspace' : ''}`);
 };
 
-const main = (): void => {
+const main = async (): Promise<void> => {
   const args = process.argv.slice(2);
-  const workspaces = listWorkspaces();
+  const repoRoot = resolve(process.cwd());
+  const workspaces = await listWorkspaces();
+  const legacyOnly = args.includes('--legacy');
+  const filtered = legacyOnly ? workspaces.filter((ws) => ws.isLegacy) : workspaces;
 
-  // No workspaces
-  if (workspaces.length === 0) {
-    console.log('No active workspaces found.');
+  if (filtered.length === 0) {
+    console.log(
+      legacyOnly ? 'No legacy .pi/workspaces/ worktrees found.' : 'No active worktrees found.',
+    );
     return;
   }
 
   // Just list
-  if (args.length === 0) {
-    console.log(`Active workspaces (${workspaces.length}):\n`);
-    for (const ws of workspaces) {
+  if (args.length === 0 || (args.length === 1 && legacyOnly)) {
+    console.log(`Active worktrees (${filtered.length}):\n`);
+    for (const ws of filtered) {
       const merged = ws.prMerged ? ' 🔀 MERGED' : '';
-      console.log(`  📂 ${relative(process.cwd(), ws.path)}`);
+      const herdr = ws.herdrWorkspaceId ? ' [herdr]' : '';
+      const legacy = ws.isLegacy ? ' [legacy]' : '';
+      console.log(`  📂 ${relative(repoRoot, ws.path)}`);
       console.log(`     Branch: ${ws.branchName}  Commit: ${ws.headCommit}`);
-      console.log(`     ${ws.description || '(no description)'}${merged}`);
+      console.log(`     ${ws.description || '(no description)'}${merged}${herdr}${legacy}`);
       console.log();
     }
     console.log('Usage:');
-    console.log('  bun run workspace:cleanup --all          Clean ALL workspaces');
-    console.log('  bun run workspace:cleanup --pr-merged    Clean only workspaces with merged PRs');
-    console.log('  bun run workspace:cleanup <path>         Clean a specific workspace');
+    console.log('  bun run workspace:cleanup --all          Clean ALL worktrees');
+    console.log('  bun run workspace:cleanup --pr-merged    Clean only worktrees with merged PRs');
+    console.log('  bun run workspace:cleanup --legacy       Clean only legacy .pi/workspaces/');
+    console.log('  bun run workspace:cleanup <path>         Clean a specific worktree');
     return;
   }
 
   // Clean all
   if (args.includes('--all')) {
-    console.log(`Cleaning up ${workspaces.length} workspace(s)...\n`);
-    for (const ws of workspaces) {
-      cleanupWorkspace(ws);
+    console.log(`Cleaning up ${filtered.length} worktree(s)...\n`);
+    for (const ws of filtered) {
+      await cleanupWorkspace(ws, repoRoot);
     }
     console.log('\nDone.');
     return;
@@ -149,14 +205,14 @@ const main = (): void => {
 
   // Clean only PR-merged
   if (args.includes('--pr-merged')) {
-    const merged = workspaces.filter((ws) => ws.prMerged);
+    const merged = filtered.filter((ws) => ws.prMerged);
     if (merged.length === 0) {
-      console.log('No workspaces with merged PRs found.');
+      console.log('No worktrees with merged PRs found.');
       return;
     }
-    console.log(`Cleaning up ${merged.length} merged workspace(s)...\n`);
+    console.log(`Cleaning up ${merged.length} merged worktree(s)...\n`);
     for (const ws of merged) {
-      cleanupWorkspace(ws);
+      await cleanupWorkspace(ws, repoRoot);
     }
     console.log('\nDone.');
     return;
@@ -164,15 +220,15 @@ const main = (): void => {
 
   // Clean specific path
   const targetPath = args[0];
-  const match = workspaces.find(
-    (ws) => ws.path === targetPath || relative(process.cwd(), ws.path) === targetPath,
+  const match = filtered.find(
+    (ws) => ws.path === targetPath || relative(repoRoot, ws.path) === targetPath,
   );
   if (!match) {
-    console.log(`Workspace not found: ${targetPath}`);
-    console.log('Run without arguments to list workspaces.');
+    console.log(`Worktree not found: ${targetPath}`);
+    console.log('Run without arguments to list worktrees.');
     return;
   }
-  cleanupWorkspace(match);
+  await cleanupWorkspace(match, repoRoot);
 };
 
-main();
+await main();

--- a/scripts/src/lib/ops/workspace_cleanup.ts
+++ b/scripts/src/lib/ops/workspace_cleanup.ts
@@ -19,10 +19,24 @@
 // (~/.herdr/worktrees/<repo>/). herdr-native worktrees are also removed via
 // `herdr worktree remove` (closes herdr workspace state + checkout together).
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { join, relative, resolve, sep } from 'node:path';
 import { removeWorktree } from '../herdr/worktree.ts';
+
+/** Run an argv array with execFileSync — no shell interpolation of values. */
+const runArgv = (command: string, args: string[], cwd: string): string => {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+      timeout: 10000,
+    }).trim();
+  } catch {
+    return '';
+  }
+};
 
 const runGit = (command: string, cwd: string): string => {
   try {
@@ -49,7 +63,7 @@ type WorkspaceInfo = {
 
 /** Parse `git worktree list --porcelain` into entries. */
 const listAllWorktrees = (): Array<{ path: string; branch?: string; detached?: boolean }> => {
-  const out = execSync('git worktree list --porcelain', {
+  const out = execFileSync('git', ['worktree', 'list', '--porcelain'], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 10000,
@@ -83,15 +97,12 @@ const listAllWorktrees = (): Array<{ path: string; branch?: string; detached?: b
 };
 
 const prMergedForBranch = (branchName: string): boolean => {
-  try {
-    const prList = execSync(
-      `gh pr list --head "${branchName}" --state merged --json number --jq 'length'`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 },
-    ).trim();
-    return prList !== '0' && prList !== '';
-  } catch {
-    return false;
-  }
+  const prList = runArgv(
+    'gh',
+    ['pr', 'list', '--head', branchName, '--state', 'merged', '--json', 'number', '--jq', 'length'],
+    process.cwd(),
+  );
+  return prList !== '' && prList !== '0';
 };
 
 const listWorkspaces = async (): Promise<WorkspaceInfo[]> => {
@@ -110,24 +121,24 @@ const listWorkspaces = async (): Promise<WorkspaceInfo[]> => {
     }
     const branchName = wt.branch ?? '(detached)';
     const desc = runGit('log -1 --format=%s', wt.path);
-    const isLegacy = wt.path.startsWith(legacyParent);
+    // Path-boundary check: exactly the legacy parent or a child directory,
+    // NOT a sibling like `.pi/workspaces-old`.
+    const isLegacy = wt.path === legacyParent || wt.path.startsWith(`${legacyParent}${sep}`);
 
     // Resolve the herdr workspace id for herdr-native worktrees so cleanup
     // can tear herdr state + checkout together.
     let herdrWorkspaceId: string | undefined;
     if (!isLegacy) {
       try {
-        const r = execSync('herdr worktree list --cwd ' + `'${repoRoot}'`, {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-          timeout: 10000,
-        }).trim();
-        const parsed = JSON.parse(r) as {
-          result: { worktrees: Array<{ path: string; open_workspace_id?: string }> };
-        };
-        herdrWorkspaceId = parsed.result.worktrees.find(
-          (w) => w.path === wt.path,
-        )?.open_workspace_id;
+        const r = runArgv('herdr', ['worktree', 'list', '--cwd', repoRoot], process.cwd());
+        if (r) {
+          const parsed = JSON.parse(r) as {
+            result: { worktrees: Array<{ path: string; open_workspace_id?: string }> };
+          };
+          herdrWorkspaceId = parsed.result.worktrees.find(
+            (w) => w.path === wt.path,
+          )?.open_workspace_id;
+        }
       } catch {
         // herdr unavailable — fall back to plain git removal.
       }
@@ -161,9 +172,15 @@ const cleanupWorkspace = async (ws: WorkspaceInfo, repoRoot: string): Promise<vo
 
 const main = async (): Promise<void> => {
   const args = process.argv.slice(2);
+  // Flags and the optional target path are parsed independently so
+  // `--legacy <path>` cleans that path with legacy filtering applied.
+  const FLAG_SET = new Set(['--all', '--pr-merged', '--legacy', '--force']);
+  const flags = args.filter((a) => FLAG_SET.has(a));
+  const targetPath = args.find((a) => !FLAG_SET.has(a));
+  const legacyOnly = flags.includes('--legacy');
+
   const repoRoot = resolve(process.cwd());
   const workspaces = await listWorkspaces();
-  const legacyOnly = args.includes('--legacy');
   const filtered = legacyOnly ? workspaces.filter((ws) => ws.isLegacy) : workspaces;
 
   if (filtered.length === 0) {
@@ -174,7 +191,7 @@ const main = async (): Promise<void> => {
   }
 
   // Just list
-  if (args.length === 0 || (args.length === 1 && legacyOnly)) {
+  if (flags.length === 0 && !targetPath) {
     console.log(`Active worktrees (${filtered.length}):\n`);
     for (const ws of filtered) {
       const merged = ws.prMerged ? ' 🔀 MERGED' : '';
@@ -193,8 +210,8 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Clean all
-  if (args.includes('--all')) {
+  // Clean all (optionally legacy-filtered: `--legacy --all`)
+  if (flags.includes('--all')) {
     console.log(`Cleaning up ${filtered.length} worktree(s)...\n`);
     for (const ws of filtered) {
       await cleanupWorkspace(ws, repoRoot);
@@ -203,8 +220,8 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Clean only PR-merged
-  if (args.includes('--pr-merged')) {
+  // Clean only PR-merged (optionally legacy-filtered)
+  if (flags.includes('--pr-merged')) {
     const merged = filtered.filter((ws) => ws.prMerged);
     if (merged.length === 0) {
       console.log('No worktrees with merged PRs found.');
@@ -218,8 +235,11 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Clean specific path
-  const targetPath = args[0];
+  // Clean specific path (`--legacy <path>` keeps the legacy filter)
+  if (!targetPath) {
+    console.log('Run without arguments to list worktrees.');
+    return;
+  }
   const match = filtered.find(
     (ws) => ws.path === targetPath || relative(repoRoot, ws.path) === targetPath,
   );


### PR DESCRIPTION
## Summary

Replaces the custom `.pi/workspaces/` git-worktree provisioning with **herdr's native worktree support** (`herdr worktree create`), enabling multiple concurrent pi sessions — each on its own isolated branch — without touching the root checkout. This is what lets you run parallel tasks safely while another session refactors on `main`.

## Why herdr-native?

- `herdr worktree create` makes a real git worktree **and** opens it as a herdr workspace, auto-grouped with the repo (provenance tracked)
- Checkouts land in `~/.herdr/worktrees/<repo>/<slug>` — **outside the repo**, so zero `.gitignore` pollution and zero interference with the root checkout's git state
- `herdr worktree remove` tears down workspace + checkout together; branch deletion stays an explicit git step (herdr never deletes branches)
- Eliminates ~180 lines of custom provisioning (direnv hacks, skip-worktree bookkeeping, `.pi/npm` symlinks moved into one shared bootstrap)

## Changes

| File | Change |
|---|---|
| `scripts/src/lib/herdr/worktree.ts` **(new)** | Single source of truth: `createWorktree`, `openWorktree`, `listWorktrees`, `bootstrapWorktree` (direnv delegation, skip-worktree, `.pi/npm` symlink, env/paraglide seeds, `bun install`), `removeWorktree`, `publishWorktree` (collision guard + commit + push), `openPullRequest` |
| `scripts/src/lib/herdr/task.ts` **(new)** + `bun herdr:task` | `new <slug>` (worktree branched from `origin/main` + bootstrap + pi session), `list`, `pr` (publish + PR to main), `rm`, `prune --legacy` |
| `herdr_adapter.ts` | Worktree workspace **is** the pipeline workspace; worker/review env vars via `tab create --env` (drops the PTY first-character inline-env hack); crash recovery re-opens the persisted checkout |
| `orchestrator.ts` | `reconcileWorkspace` → `publishWorktree` on the existing worktree (no re-provisioning/rename/base-restore); cleanup via herdr `removeWorktree`; contract-scoped dev sessions retired |
| `types.ts` | Manifest persists `worktreeWorkspaceId` / `worktreeCheckoutPath` / `worktreeBranch` for deterministic resume |
| `.pi/extensions/*` | `contract_workspace_reconcile` delegates to `publishWorktree`; `contract_workspace_create`/`list` use herdr-native worktrees; new **`task_pr`** tool |
| `workspace_cleanup.ts` | Rewritten on `git worktree list --porcelain` — covers legacy `.pi/workspaces/` **and** `~/.herdr/worktrees/` |

## Usage

```bash
bun herdr:task new my-feature --join      # worktree + herdr workspace + pi, attach
# ... work in the isolated pi session ...
bun herdr:task pr my-feature --base main  # publish + PR to main
bun herdr:task rm my-feature              # teardown after merge
```

## Validation

- `scripts:typecheck` + `scripts:test` pass (moon)
- Biome clean on all touched files
- End-to-end smoke tested: create → bootstrap → pi launch → publish (verified only intended file in commit — skip-worktree integrity) → push to origin → remove
- `--base origin/main` verified to branch from origin, never the dirty local checkout

## Notes

- The 15 orphaned legacy `.pi/workspaces/` worktrees are left untouched — cleanup tooling ready: `bun run workspace:cleanup --pr-merged` / `bun herdr:task prune --legacy --force`
- The concurrent refactor session's uncommitted work is **not** included in this PR (committed only the 11 files above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `herdr:task` for creating, launching, monitoring, publishing, and cleaning up parallel task worktrees.
  * Added a task workflow for publishing changes and opening GitHub pull requests with configurable branches, titles, descriptions, and draft status.
  * Worktree setup now bootstraps required environment files and dependencies automatically.
* **Improvements**
  * Worktree discovery now includes both legacy and Herdr-managed worktrees.
  * Task recovery and workspace reopening are more reliable.
  * Cleanup supports detached worktrees, legacy filtering, dry runs, and optional branch removal.
* **Bug Fixes**
  * Improved handling of branch collisions, publishing failures, and cleanup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->