### PR TITLE
fix(game): map-authoritative saves + synced portal spawns

### DIFF
--- a/apps/frontend/client/firebase.json
+++ b/apps/frontend/client/firebase.json
@@ -1,7 +1,11 @@
 {
   "hosting": {
     "public": "build",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "rewrites": [
       {
         "source": "**/*.@(webp|webm|mp3|ogg|json|png|jpg|jpeg|gif|avif|svg|wav|flac|m4a|aac|woff|woff2|ttf|eot|ico|txt|pdf)",
@@ -23,6 +27,24 @@
           {
             "key": "Cross-Origin-Embedder-Policy",
             "value": "require-corp"
+          }
+        ]
+      },
+      {
+        "source": "/",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, must-revalidate"
           }
         ]
       },

--- a/apps/frontend/client/src/lib/services/campaign/campaign_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/campaign/campaign_service.svelte.ts
@@ -38,6 +38,15 @@ export type CampaignServiceInterface = BaseFrontendClassInterface & {
   }): Promise<Campaign>;
   /** Loads an existing campaign (idle/creating/failed → loading → playing). */
   loadCampaign(options: { campaignId: string }): Promise<Campaign>;
+  /**
+   * Ensures a campaign exists for the current session.
+   *
+   * Returns the active campaign when present, otherwise reuses or creates the
+   * stable default Emberwatch campaign. This lets the game work when entered
+   * straight to /game without running setup — saves still get a campaignId
+   * and Continue-after-refresh can resume.
+   */
+  ensureDefaultCampaign(): Promise<Campaign>;
   /** Resumes the active campaign from paused → playing. */
   resumeCampaign(): void;
   /** Pauses the active campaign (playing → paused). */
@@ -62,6 +71,13 @@ export type CampaignServiceInterface = BaseFrontendClassInterface & {
 
 /** Creates a new unique campaign identifier. */
 const generateCampaignId = (): string => crypto.randomUUID();
+
+/**
+ * Stable ID of the auto-created campaign used when the game is entered
+ * without running setup (straight to /game). Deterministic so re-boots find
+ * the same record and stay idempotent.
+ */
+const DEFAULT_CAMPAIGN_ID = 'default-emberwatch';
 
 /** Creates a deterministic seed from the current timestamp. */
 const generateSeed = (): number => Math.floor(Date.now() / 1000);
@@ -186,6 +202,50 @@ class CampaignService
   }
 
   /** @inheritdoc */
+  async ensureDefaultCampaign(): Promise<Campaign> {
+    if (this.activeCampaign) {
+      return this.activeCampaign;
+    }
+
+    const buildDefault = (): Campaign => {
+      const now = new Date().toISOString();
+      return {
+        id: DEFAULT_CAMPAIGN_ID,
+        name: 'Emberwatch',
+        state: 'playing',
+        contentPackId: 'emberwatch',
+        seed: generateSeed(),
+        createdAt: now,
+        updatedAt: now,
+        capabilityProfile: buildCapabilityProfile(),
+      };
+    };
+
+    try {
+      const existing = await campaignStorage.getById(DEFAULT_CAMPAIGN_ID);
+      if (existing) {
+        this.activeCampaign = existing;
+        this.debug('ensureDefaultCampaign:reused', { campaignId: existing.id });
+        return existing;
+      }
+
+      const campaign = buildDefault();
+      await campaignStorage.create(campaign);
+      this.activeCampaign = campaign;
+      await this.refreshCampaigns();
+      this.debug('ensureDefaultCampaign:created', { campaignId: campaign.id });
+      return campaign;
+    } catch (error) {
+      // Storage unavailable (e.g. in-memory fallback DB) — return a transient
+      // campaign so the save flow still records a campaignId this session.
+      this.warn('ensureDefaultCampaign:storage-failed', { error: String(error) });
+      const transient = buildDefault();
+      this.activeCampaign = transient;
+      return transient;
+    }
+  }
+
+  /** @inheritdoc */
   async loadCampaign(options: { campaignId: string }): Promise<Campaign> {
     if (this.isBusy) {
       throw new Error('Campaign operation already in progress');
@@ -197,6 +257,18 @@ class CampaignService
       const campaign = await campaignStorage.getById(options.campaignId);
       if (!campaign) {
         throw new Error(`Campaign not found: ${options.campaignId}`);
+      }
+
+      // Already playing (e.g. resumed from a saved session or the default
+      // Emberwatch campaign) — activate without re-running the
+      // LOAD_REQUESTED → LOAD_COMPLETE transitions (the state machine only
+      // allows LOAD_REQUESTED from idle/failed). Mirrors the boot pipeline's
+      // playing-state handling.
+      if (campaign.state === 'playing') {
+        this.activeCampaign = campaign;
+        await this.refreshCampaigns();
+        this.debug('loadCampaign:already-playing', { campaignId: campaign.id });
+        return campaign;
       }
 
       // Validate transition is legal; if invalid, transition() throws.

--- a/apps/frontend/client/src/lib/services/game/bridge_listeners.ts
+++ b/apps/frontend/client/src/lib/services/game/bridge_listeners.ts
@@ -122,10 +122,18 @@ export const setupBridgeListeners = async (params: SetupBridgeListenersParams): 
       // pack before loading — otherwise the raw ID resolves relative to the
       // current route and the SPA fallback returns HTML, breaking JSON parse.
       let mapUrl = event.targetMap;
+      // defaultSpawnHash: the destination map's manifest `defaultSpawnId`
+      // (e.g. 'village_gate'). The worker resolves it when the portal has no
+      // targetSpawnId, so unpaired portals still land on the map's default.
+      let defaultSpawnHash: number | undefined;
       try {
-        const { loadContentPack } = await import('@aikami/frontend/engine');
+        const { loadContentPack, djb2Hash } = await import('@aikami/frontend/engine');
         const pack = await loadContentPack({ packId: gameEngineService.contentPackId });
         mapUrl = pack.resolveMapUrl(event.targetMap);
+        const targetEntry = pack.manifest.maps[event.targetMap];
+        if (targetEntry?.defaultSpawnId) {
+          defaultSpawnHash = djb2Hash(targetEntry.defaultSpawnId);
+        }
       } catch {
         // targetMap was already an absolute URL/path (or unknown map ID) —
         // fall back to passing it through; the engine surfaces fetch errors.
@@ -136,7 +144,9 @@ export const setupBridgeListeners = async (params: SetupBridgeListenersParams): 
         targetY: event.targetY,
         defeatedEnemies: gameOverlayService.getDefeatedEnemies(),
         collectedPickups: gameOverlayService.getCollectedPickups(),
+        interactableStates: gameOverlayService.getInteractableStates(),
         targetSpawnHash: event.targetSpawnHash,
+        defaultSpawnHash,
       });
     })();
   });

--- a/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
@@ -471,14 +471,14 @@ class GameBootService
       if (generation !== this._bootGeneration) {
         return;
       }
-      const { ecsSnapshot, serviceSnapshots, version, storedChecksum } = parseSavePayloadEnvelope(
-        input.pendingSavePayload,
-      );
+      const { ecsSnapshot, serviceSnapshots, version, storedChecksum, map } =
+        parseSavePayloadEnvelope(input.pendingSavePayload);
 
       if (version && version >= 2 && storedChecksum) {
         const valid = await validateEnvelopeChecksum({
           ecsSnapshot,
           serviceSnapshots,
+          map,
           storedChecksum,
           version,
         });
@@ -946,6 +946,10 @@ class GameBootService
 
         // Overlay the player's saved appearance/combat stats/position.
         await gameEngineService.restorePlayer(ecsSnapshot);
+        // Check generation after async restore
+        if (generation !== this._bootGeneration) {
+          return;
+        }
         this.debug('stage:hydrating_snapshot:map-restored', {
           mapId: map.mapId,
           playerX: map.playerX,
@@ -1388,14 +1392,16 @@ class GameBootService
       for (const save of saves) {
         try {
           const payload = await gameSaveService.getRawSavePayload(save.id);
-          const { ecsSnapshot, serviceSnapshots, version, storedChecksum } =
+          const { ecsSnapshot, serviceSnapshots, version, storedChecksum, map } =
             parseSavePayloadEnvelope(payload);
 
           if (version && version >= 2 && storedChecksum) {
             const valid = await validateEnvelopeChecksum({
               ecsSnapshot,
               serviceSnapshots,
+              map,
               storedChecksum,
+              version,
             });
             if (!valid) {
               continue; // skip this corrupt save, try next

--- a/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
@@ -480,6 +480,7 @@ class GameBootService
           ecsSnapshot,
           serviceSnapshots,
           storedChecksum,
+          version,
         });
         // Check generation after async validation
         if (generation !== this._bootGeneration) {
@@ -523,14 +524,16 @@ class GameBootService
       }
 
       // C-334 AC-4: Validate checksum for v2+ payloads
-      const { ecsSnapshot, serviceSnapshots, version, storedChecksum } =
+      const { ecsSnapshot, serviceSnapshots, version, storedChecksum, map } =
         parseSavePayloadEnvelope(payload);
 
       if (version && version >= 2 && storedChecksum) {
         const valid = await validateEnvelopeChecksum({
           ecsSnapshot,
           serviceSnapshots,
+          map,
           storedChecksum,
+          version,
         });
         // Check generation after async validation
         if (generation !== this._bootGeneration) {
@@ -891,7 +894,7 @@ class GameBootService
 
     if (input.pendingSavePayload) {
       // Restore from save snapshot — the payload may be a full envelope
-      // ({ ecsSnapshot, serviceSnapshots }) or a plain ECS snapshot.
+      // ({ ecsSnapshot, serviceSnapshots, map }) or a plain ECS snapshot.
       this.bootProgress.detail = 'Restoring saved world...';
       const { parseSavePayloadEnvelope } = await import('./game_save_service.svelte.ts');
       const { hydrateAllServices } = await import('./serializable_service');
@@ -899,7 +902,9 @@ class GameBootService
       if (generation !== this._bootGeneration) {
         return;
       }
-      const { ecsSnapshot, serviceSnapshots } = parseSavePayloadEnvelope(input.pendingSavePayload);
+      const { ecsSnapshot, serviceSnapshots, map } = parseSavePayloadEnvelope(
+        input.pendingSavePayload,
+      );
 
       // Hydrate domain services FIRST so world flags (collected pickups,
       // loot-granted encounters) are in place before any map load (C-331).
@@ -910,14 +915,56 @@ class GameBootService
         });
       }
 
-      await this._gameWorld.restoreWorld(ecsSnapshot);
-      // Check generation after async restore
-      if (generation !== this._bootGeneration) {
-        return;
+      if (map?.mapId && map.packId) {
+        // ── Map-authoritative restore (v3+ envelope) ──
+        // The map file is the source of truth for the world: rebuild the
+        // saved map (tilemap, collision, NPCs, props, portals) at the saved
+        // coordinates, then overlay the player-scoped ECS snapshot. This
+        // replaces the old LOAD_GAME full-world rebuild, which could never
+        // reconstruct map-derived entities from a 4-component snapshot.
+        this.bootProgress.detail = `Loading map: ${map.mapId}`;
+        const { loadContentPack } = await import('@aikami/frontend/engine');
+        const pack = await loadContentPack({ packId: map.packId });
+        const { worldStateService } = await import('./world_state_service.svelte');
+        // Check generation after async imports
+        if (generation !== this._bootGeneration) {
+          return;
+        }
+
+        await gameEngineService.loadMap({
+          mapUrl: pack.resolveMapUrl(map.mapId),
+          targetX: map.playerX,
+          targetY: map.playerY,
+          defeatedEnemies: [...worldStateService.defeatedEnemies],
+          collectedPickups: [...worldStateService.collectedPickups],
+          interactableStates: { ...worldStateService.interactableStates },
+        });
+        // Check generation after map load
+        if (generation !== this._bootGeneration) {
+          return;
+        }
+
+        // Overlay the player's saved appearance/combat stats/position.
+        await gameEngineService.restorePlayer(ecsSnapshot);
+        this.debug('stage:hydrating_snapshot:map-restored', {
+          mapId: map.mapId,
+          playerX: map.playerX,
+          playerY: map.playerY,
+          bytes: input.pendingSavePayload.length,
+        });
+      } else {
+        // ── Legacy v2/pre-v2 save without map routing ──
+        // Best-effort full-world restore (no tilemap/collision/portals can
+        // be reconstructed — the envelope has no map identity).
+        await this._gameWorld.restoreWorld(ecsSnapshot);
+        // Check generation after async restore
+        if (generation !== this._bootGeneration) {
+          return;
+        }
+        this.debug('stage:hydrating_snapshot:legacy-restored', {
+          bytes: input.pendingSavePayload.length,
+        });
       }
-      this.debug('stage:hydrating_snapshot:restored', {
-        bytes: input.pendingSavePayload.length,
-      });
     } else {
       // Fresh spawn — load the pack's declared starting map
       const packId = input.contentPackId;

--- a/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
@@ -386,10 +386,10 @@ class GameBootService
         campaign = latest;
         this.debug('stage:loading_campaign:latest-campaign', { campaignId: latest.id });
       } else {
-        // Default transient campaign (logged as fallback)
-        this.warn('stage:loading_campaign:no-campaign-fallback', {
-          fallback: 'emberwatch',
-        });
+        // No campaign exists (e.g. straight to /game without setup) — create
+        // the default Emberwatch campaign so save/continue work end-to-end.
+        campaign = await campaignService.ensureDefaultCampaign();
+        this.debug('stage:loading_campaign:default-created', { campaignId: campaign.id });
       }
     }
 

--- a/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts
@@ -182,21 +182,28 @@ class GameBootService
 
         // Drive campaign state machine to failed
         if (this._campaign) {
-          try {
-            const failedState = transition(this._campaign.state, {
-              type: 'LOAD_FAILED',
-              error: message,
+          const { canTransition, transition } = await import('../campaign/boot_state_machine.ts');
+          if (canTransition(this._campaign.state, { type: 'LOAD_FAILED', error: message })) {
+            try {
+              const failedState = transition(this._campaign.state, {
+                type: 'LOAD_FAILED',
+                error: message,
+              });
+              const { campaignStorage } = await import('../campaign/campaign_storage.svelte');
+              const updated = {
+                ...this._campaign,
+                state: failedState,
+                updatedAt: new Date().toISOString(),
+              };
+              await campaignStorage.update(updated);
+              this._campaign = updated;
+            } catch (transitionError) {
+              this.warn('boot:campaign-fail-transition', { error: String(transitionError) });
+            }
+          } else {
+            this.debug('boot:campaign-fail-transition:skipped', {
+              state: this._campaign.state,
             });
-            const { campaignStorage } = await import('../campaign/campaign_storage.svelte');
-            const updated = {
-              ...this._campaign,
-              state: failedState,
-              updatedAt: new Date().toISOString(),
-            };
-            await campaignStorage.update(updated);
-            this._campaign = updated;
-          } catch (transitionError) {
-            this.warn('boot:campaign-fail-transition', { error: String(transitionError) });
           }
         }
 

--- a/apps/frontend/client/src/lib/services/game/game_composition_root.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_composition_root.svelte.ts
@@ -250,6 +250,9 @@ export class GameCompositionRoot
 
     // Phase 5b: Thread contentPackId to engine and ensure campaign service is ready
     const contentPackId = campaignService.activeCampaign?.contentPackId ?? 'emberwatch';
+    // ── C-372: actually assign it — the engine default is 'emberwatch', so
+    // every save was stamped packId 'emberwatch' regardless of the campaign.
+    gameEngineService.contentPackId = contentPackId;
     this.debug('initialize:contentPackId', { contentPackId });
 
     // Phase 5c: Wire NPC dialogue orchestrator with content pack + gateway

--- a/apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts
@@ -98,12 +98,39 @@ export type GameEngineServiceInterface = BaseFrontendClassInterface & {
     targetY: number;
     defeatedEnemies?: string[];
     collectedPickups?: string[];
+    interactableStates?: Record<
+      string,
+      {
+        isOpen?: boolean;
+        isLocked?: boolean;
+        isLooted?: boolean;
+        isToggled?: boolean;
+        isTriggered?: boolean;
+      }
+    >;
     targetSpawnHash?: number;
+    defaultSpawnHash?: number;
     disableClamping?: boolean;
   }): Promise<void>;
 
   /** Restores the game world from a saved ECS snapshot payload. */
   loadSave(payload: string): Promise<void>;
+
+  /**
+   * Applies a player-scoped ECS snapshot onto the live world.
+   *
+   * Used by the map-authoritative restore pipeline: loadMap rebuilds the
+   * map's entities, then this merges the player's saved components without
+   * clearing the freshly spawned world.
+   */
+  restorePlayer(payload: string): Promise<void>;
+
+  /**
+   * Returns the player's current world-space pixel position, or undefined
+   * if the engine has not booted. Used by the save pipeline for the
+   * envelope map block (v3+).
+   */
+  getPlayerPosition(): { x: number; y: number } | undefined;
 
   /** Destroys the engine and resets all state (on route navigation). */
   destroyEngine(): void;
@@ -305,7 +332,18 @@ class GameEngineService
     targetY: number;
     defeatedEnemies?: string[];
     collectedPickups?: string[];
+    interactableStates?: Record<
+      string,
+      {
+        isOpen?: boolean;
+        isLocked?: boolean;
+        isLooted?: boolean;
+        isToggled?: boolean;
+        isTriggered?: boolean;
+      }
+    >;
     targetSpawnHash?: number;
+    defaultSpawnHash?: number;
     disableClamping?: boolean;
   }): Promise<void> {
     if (this._gameWorld) {
@@ -323,6 +361,19 @@ class GameEngineService
       throw new Error('Engine not initialized — cannot load save');
     }
     await this._gameWorld.restoreWorld(payload);
+  }
+
+  /** @inheritdoc */
+  async restorePlayer(payload: string): Promise<void> {
+    if (!this._gameWorld) {
+      throw new Error('Engine not initialized — cannot restore player');
+    }
+    await this._gameWorld.restorePlayer(payload);
+  }
+
+  /** @inheritdoc */
+  getPlayerPosition(): { x: number; y: number } | undefined {
+    return this._gameWorld?.getPlayerPosition();
   }
 
   /** @inheritdoc */

--- a/apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts
@@ -1,7 +1,13 @@
 // apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts
 
 import { DEFAULT_LPC_RECIPE } from '@aikami/constants';
-import type { EngineBridge, GameCommand, GameWorld, LpcLayerRecipe } from '@aikami/frontend/engine';
+import type {
+  EngineBridge,
+  GameCommand,
+  GameWorld,
+  InteractableStateMap,
+  LpcLayerRecipe,
+} from '@aikami/frontend/engine';
 import {
   BaseFrontendClass,
   type BaseFrontendClassInterface,
@@ -98,16 +104,7 @@ export type GameEngineServiceInterface = BaseFrontendClassInterface & {
     targetY: number;
     defeatedEnemies?: string[];
     collectedPickups?: string[];
-    interactableStates?: Record<
-      string,
-      {
-        isOpen?: boolean;
-        isLocked?: boolean;
-        isLooted?: boolean;
-        isToggled?: boolean;
-        isTriggered?: boolean;
-      }
-    >;
+    interactableStates?: InteractableStateMap;
     targetSpawnHash?: number;
     defaultSpawnHash?: number;
     disableClamping?: boolean;
@@ -332,16 +329,7 @@ class GameEngineService
     targetY: number;
     defeatedEnemies?: string[];
     collectedPickups?: string[];
-    interactableStates?: Record<
-      string,
-      {
-        isOpen?: boolean;
-        isLocked?: boolean;
-        isLooted?: boolean;
-        isToggled?: boolean;
-        isTriggered?: boolean;
-      }
-    >;
+    interactableStates?: InteractableStateMap;
     targetSpawnHash?: number;
     defaultSpawnHash?: number;
     disableClamping?: boolean;

--- a/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
@@ -28,6 +28,7 @@ import { inputActionService } from './input_action_service.svelte.ts';
 import { npcDialogueService } from './npc_dialogue_service.svelte';
 import { onboardingHintService } from './onboarding_hint_service.svelte.ts';
 import { playerStateService } from './player_state_service.svelte';
+import { buildSaveMapBlock, getCurrentMapName } from './save_map_block';
 import { timeService } from './time_service.svelte';
 
 // ---------------------------------------------------------------------------
@@ -641,6 +642,20 @@ export class GameOverlayService
     return [...worldStateService.defeatedEnemies];
   }
 
+  /** Returns the current per-spawnId interactable state map (C-342). */
+  getInteractableStates(): Record<
+    string,
+    {
+      isOpen?: boolean;
+      isLocked?: boolean;
+      isLooted?: boolean;
+      isToggled?: boolean;
+      isTriggered?: boolean;
+    }
+  > {
+    return { ...worldStateService.interactableStates };
+  }
+
   /** @inheritdoc */
   getCollectedPickups(): string[] {
     return [...worldStateService.collectedPickups];
@@ -726,12 +741,14 @@ export class GameOverlayService
       }
 
       const campaignId = campaignService.activeCampaign?.id;
-      const mapName = worldStateService.currentLocation?.name ?? 'World';
+      const mapName = await getCurrentMapName();
+      const map = await buildSaveMapBlock();
 
       await saveService.saveGame({
         slotId: 'auto-save',
         campaignId,
         mapName,
+        map,
       });
       this.autoSaveStatus = 'saved';
       this.showSnackbar({ text: 'Auto-saved', type: 'success' });
@@ -992,12 +1009,14 @@ export class GameOverlayService
       }
 
       const campaignId = campaignService.activeCampaign?.id;
-      const mapName = worldStateService.currentLocation?.name ?? 'World';
+      const mapName = await getCurrentMapName();
+      const map = await buildSaveMapBlock();
 
       await saveService.saveGame({
         slotId: 'manual-1',
         campaignId,
         mapName,
+        map,
       });
       this.saveMessage = 'Game Saved!';
     } catch (error) {

--- a/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
@@ -1104,14 +1104,42 @@ export class GameOverlayService
       const latestSave = saves[0];
       this.debug('loadLastSave', { slotId: latestSave.id, mapName: latestSave.mapName });
 
-      // Map-authoritative load for v3+ saves: rebuild the saved map first,
-      // then overlay the player snapshot. Legacy v2/plain payloads fall back
-      // to the old full-world restore path.
+      // Map-authoritative load for v3+ saves: validate + hydrate domain
+      // services, rebuild the saved map, then overlay the player snapshot.
+      // Legacy v2/plain payloads fall back to the old full-world restore
+      // path (loadGame does its own validation + hydration).
       const rawPayload = await saveService.getRawSavePayload(latestSave.id);
-      const { parseSavePayloadEnvelope } = await import('./game_save_service.svelte.ts');
-      const { ecsSnapshot, map } = parseSavePayloadEnvelope(rawPayload);
+      const { parseSavePayloadEnvelope, validateEnvelopeChecksum } = await import(
+        './game_save_service.svelte.ts'
+      );
+      const { ecsSnapshot, serviceSnapshots, version, storedChecksum, map } =
+        parseSavePayloadEnvelope(rawPayload);
+
+      // C-334 AC-4: version-aware checksum validation (v3 digest includes map)
+      if (version && version >= 2 && storedChecksum) {
+        const valid = await validateEnvelopeChecksum({
+          ecsSnapshot,
+          serviceSnapshots,
+          map,
+          storedChecksum,
+          version,
+        });
+        if (!valid) {
+          throw new Error(`Save is corrupted: checksum mismatch for slot "${latestSave.id}"`);
+        }
+      }
 
       if (map?.mapId && map.packId) {
+        // Hydrate domain services FIRST (inventory, quests, time, …) so world
+        // flags are in place before the map load — same as the boot pipeline.
+        if (serviceSnapshots) {
+          const { hydrateAllServices } = await import('./serializable_service');
+          hydrateAllServices(serviceSnapshots);
+          this.debug('loadLastSave:services-hydrated', {
+            snapshotCount: serviceSnapshots.length,
+          });
+        }
+
         const { loadContentPack } = await import('@aikami/frontend/engine');
         const pack = await loadContentPack({ packId: map.packId });
         const { worldStateService } = await import('./world_state_service.svelte');

--- a/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
@@ -1,7 +1,7 @@
 // apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
 /** biome-ignore-all lint/style/useNamingConvention: GameOverlayType enum-like keys use SCREAMING_SNAKE_CASE */
 
-import type { EngineBridge } from '@aikami/frontend/engine';
+import type { EngineBridge, InteractableStateMap } from '@aikami/frontend/engine';
 import {
   BaseFrontendClass,
   type BaseFrontendClassInterface,
@@ -251,6 +251,8 @@ export type GameOverlayServiceInterface = BaseFrontendClassInterface & {
   canOpenOverlay(type: GameOverlayType): boolean;
   setTransitioning(value: boolean): void;
   getDefeatedEnemies(): string[];
+  /** Returns the per-spawnId interactable state map for map-load persistence (C-342). */
+  getInteractableStates(): InteractableStateMap;
   /** Returns the collected item pickup spawn IDs for map-load suppression (C-331). */
   getCollectedPickups(): string[];
   setCameraZoom(options: { npcScreenX?: number; npcScreenY?: number }): void;
@@ -643,16 +645,7 @@ export class GameOverlayService
   }
 
   /** Returns the current per-spawnId interactable state map (C-342). */
-  getInteractableStates(): Record<
-    string,
-    {
-      isOpen?: boolean;
-      isLocked?: boolean;
-      isLooted?: boolean;
-      isToggled?: boolean;
-      isTriggered?: boolean;
-    }
-  > {
+  getInteractableStates(): InteractableStateMap {
     return { ...worldStateService.interactableStates };
   }
 
@@ -750,6 +743,16 @@ export class GameOverlayService
         mapName,
         map,
       });
+
+      // Keep the campaign's lastSaveSlotId pointing at the newest state so
+      // Continue after refresh resumes the most recent position/map.
+      try {
+        await campaignService.saveCampaign({ slotId: 'auto-save' });
+      } catch (campaignError) {
+        this.warn('autosave:campaign-slot-update-failed', {
+          error: String(campaignError),
+        });
+      }
       this.autoSaveStatus = 'saved';
       this.showSnackbar({ text: 'Auto-saved', type: 'success' });
       setTimeout(() => {
@@ -1018,6 +1021,17 @@ export class GameOverlayService
         mapName,
         map,
       });
+
+      // Point the campaign at this slot so Continue/refresh resumes here.
+      // Without this, the boot pipeline finds no lastSaveSlotId and fresh-
+      // spawns at the starting map (C-334).
+      try {
+        await campaignService.saveCampaign({ slotId: 'manual-1' });
+      } catch (campaignError) {
+        this.warn('saveGame:campaign-slot-update-failed', {
+          error: String(campaignError),
+        });
+      }
       this.saveMessage = 'Game Saved!';
     } catch (error) {
       this.warn('saveGame:error', { error: String(error) });
@@ -1087,7 +1101,34 @@ export class GameOverlayService
 
       const latestSave = saves[0];
       this.debug('loadLastSave', { slotId: latestSave.id, mapName: latestSave.mapName });
-      await saveService.loadGame(latestSave.id);
+
+      // Map-authoritative load for v3+ saves: rebuild the saved map first,
+      // then overlay the player snapshot. Legacy v2/plain payloads fall back
+      // to the old full-world restore path.
+      const rawPayload = await saveService.getRawSavePayload(latestSave.id);
+      const { parseSavePayloadEnvelope } = await import('./game_save_service.svelte.ts');
+      const { ecsSnapshot, map } = parseSavePayloadEnvelope(rawPayload);
+
+      if (map?.mapId && map.packId) {
+        const { loadContentPack } = await import('@aikami/frontend/engine');
+        const pack = await loadContentPack({ packId: map.packId });
+        const { worldStateService } = await import('./world_state_service.svelte');
+        await gameEngineService.loadMap({
+          mapUrl: pack.resolveMapUrl(map.mapId),
+          targetX: map.playerX,
+          targetY: map.playerY,
+          defeatedEnemies: [...worldStateService.defeatedEnemies],
+          collectedPickups: [...worldStateService.collectedPickups],
+          interactableStates: { ...worldStateService.interactableStates },
+        });
+        await gameEngineService.restorePlayer(ecsSnapshot);
+        this.debug('loadLastSave:map-restored', {
+          slotId: latestSave.id,
+          mapId: map.mapId,
+        });
+      } else {
+        await saveService.loadGame(latestSave.id);
+      }
 
       // Navigate to the game
       await routerService.goToRoute('game', {

--- a/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_overlay_service.svelte.ts
@@ -733,7 +733,8 @@ export class GameOverlayService
         return;
       }
 
-      const campaignId = campaignService.activeCampaign?.id;
+      const campaignId =
+        campaignService.activeCampaign?.id ?? (await campaignService.ensureDefaultCampaign()).id;
       const mapName = await getCurrentMapName();
       const map = await buildSaveMapBlock();
 
@@ -1011,7 +1012,8 @@ export class GameOverlayService
         throw new Error('Engine bridge not available for save');
       }
 
-      const campaignId = campaignService.activeCampaign?.id;
+      const campaignId =
+        campaignService.activeCampaign?.id ?? (await campaignService.ensureDefaultCampaign()).id;
       const mapName = await getCurrentMapName();
       const map = await buildSaveMapBlock();
 

--- a/apps/frontend/client/src/lib/services/game/game_save_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_save_service.svelte.ts
@@ -337,7 +337,11 @@ class GameSaveService
     this.isSaving = true;
 
     try {
-      const ecsSnapshot = await this._getBridge().createSnapshot();
+      // Player-scoped snapshot when the envelope carries a map block (the
+      // map file reconstructs the world on load). When no map block can be
+      // produced (e.g. early-boot autosave race), fall back to a full-world
+      // snapshot so the legacy restore path can still rebuild the world.
+      const ecsSnapshot = await this._getBridge().createSnapshot(map ? 'player' : 'world');
       const serviceSnapshots = serializeAllServices();
       const savedAt = new Date().toISOString();
 

--- a/apps/frontend/client/src/lib/services/game/game_save_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_save_service.svelte.ts
@@ -6,12 +6,12 @@
 // Contract: C-334 Make Local Save, Continue, Autosave, and Recovery Reliable
 
 import type { EngineBridge } from '@aikami/frontend/engine';
-import { getLocalDatabase } from '@aikami/frontend/storage';
 import {
   BaseFrontendClass,
   type BaseFrontendClassInterface,
   type BaseFrontendClassOptions,
 } from '@aikami/frontend/services';
+import { getLocalDatabase } from '@aikami/frontend/storage';
 import type { SaveSlotInfo } from '$types';
 import {
   hydrateAllServices,
@@ -41,15 +41,36 @@ export const sha256 = async (input: string): Promise<string> => {
 };
 
 /** Current save envelope version. */
-export const SAVE_ENVELOPE_VERSION = 2;
+export const SAVE_ENVELOPE_VERSION = 3;
+
+/**
+ * Map-routing block persisted in the save envelope (v3+).
+ *
+ * The map file is the source of truth for the world; the save stores only
+ * where the player is (map identity + pixel coordinates) so the boot
+ * pipeline can re-load the map before overlaying the player snapshot.
+ */
+export type SaveMapBlock = {
+  /** Content pack id (e.g. 'emberwatch'). */
+  packId: string;
+  /** Map id within the pack (e.g. 'merchant_shop'). */
+  mapId: string;
+  /** Player X pixel coordinate on the saved map. */
+  playerX: number;
+  /** Player Y pixel coordinate on the saved map. */
+  playerY: number;
+  /** Optional spawn id the player used to enter the map (provenance/debug). */
+  spawnId?: string;
+};
 
 /**
  * Parses a raw save payload into its envelope parts.
  *
- * Handles v2 envelopes (with version/checksum), v1 envelopes
+ * Handles v3 envelopes (with map block), v2 envelopes
  * ({ ecsSnapshot, serviceSnapshots }), and plain ECS snapshots.
  * Exposed so the game boot pipeline can hydrate domain services on Continue
- * (C-331 AC-2) and validate checksums (C-334 AC-4).
+ * (C-331 AC-2), validate checksums (C-334 AC-4), and route to the saved map
+ * (v3 map block).
  *
  * @returns The parsed envelope with version metadata and validation result.
  */
@@ -64,6 +85,8 @@ export const parseSavePayloadEnvelope = (
   checksumValid: boolean;
   /** The raw stored checksum string, if present. */
   storedChecksum?: string;
+  /** Map-routing block (v3+). Undefined for older payloads. */
+  map?: SaveMapBlock;
 } => {
   try {
     const envelope = JSON.parse(raw) as {
@@ -71,6 +94,7 @@ export const parseSavePayloadEnvelope = (
       serviceSnapshots?: ServiceSnapshot[];
       version?: number;
       checksum?: string;
+      map?: SaveMapBlock;
     };
     if (!envelope.ecsSnapshot) {
       throw new Error('Missing ecsSnapshot');
@@ -86,6 +110,7 @@ export const parseSavePayloadEnvelope = (
         version,
         checksumValid: true,
         storedChecksum: envelope.checksum,
+        map: envelope.map,
       };
     }
 
@@ -96,6 +121,7 @@ export const parseSavePayloadEnvelope = (
       version,
       checksumValid: false, // caller must validate with validateEnvelopeChecksum
       storedChecksum: envelope.checksum,
+      map: envelope.map,
     };
   } catch {
     // Not valid JSON — treat as plain ECS snapshot
@@ -104,23 +130,36 @@ export const parseSavePayloadEnvelope = (
 };
 
 /**
- * Validates a v2 envelope checksum asynchronously.
+ * Validates a v2+ envelope checksum asynchronously.
  *
- * Computes SHA-256 of `JSON.stringify({ ecsSnapshot, serviceSnapshots })`
- * and compares against the stored checksum.
+ * The hashed payload is version-dependent:
+ * - v3+: `JSON.stringify({ ecsSnapshot, serviceSnapshots, map })`
+ * - v2:  `JSON.stringify({ ecsSnapshot, serviceSnapshots })`
  *
  * @returns true if checksum matches, false on mismatch or error.
  */
 export const validateEnvelopeChecksum = async (options: {
   ecsSnapshot: string;
   serviceSnapshots?: ServiceSnapshot[];
+  /** Map block — included in the v3+ digest only. */
+  map?: SaveMapBlock;
   storedChecksum: string;
+  /** Envelope version. Undefined treats the payload as v2-shaped. */
+  version?: number;
 }): Promise<boolean> => {
   try {
-    const dataToHash = JSON.stringify({
-      ecsSnapshot: options.ecsSnapshot,
-      serviceSnapshots: options.serviceSnapshots,
-    });
+    const version = options.version ?? 2;
+    const dataToHash =
+      version >= 3
+        ? JSON.stringify({
+            ecsSnapshot: options.ecsSnapshot,
+            serviceSnapshots: options.serviceSnapshots,
+            map: options.map,
+          })
+        : JSON.stringify({
+            ecsSnapshot: options.ecsSnapshot,
+            serviceSnapshots: options.serviceSnapshots,
+          });
     const computed = await sha256(dataToHash);
     return computed === options.storedChecksum;
   } catch {
@@ -177,14 +216,21 @@ export type GameSaveServiceInterface = BaseFrontendClassInterface & {
   /**
    * Creates an ECS snapshot and persists it to the local database.
    *
-   * Writes a v2 save envelope with version, checksum, campaignId, mapName,
-   * and savedAt timestamp (C-334).
+   * Writes a v3 save envelope with version, checksum, map block (packId,
+   * mapId, playerX, playerY), campaignId, mapName, and savedAt timestamp.
+   * v2 payloads remain loadable — they fall back to the starting map.
    *
    * @param options.slotId - A named slot identifier (default: 'auto-save').
    * @param options.campaignId - The active campaign ID (C-334).
-   * @param options.mapName - The current map name (C-334).
+   * @param options.mapName - The current map display name (C-334).
+   * @param options.map - Map-routing block persisted in the envelope (v3+).
    */
-  saveGame(options?: { slotId?: string; campaignId?: string; mapName?: string }): Promise<void>;
+  saveGame(options?: {
+    slotId?: string;
+    campaignId?: string;
+    mapName?: string;
+    map?: SaveMapBlock;
+  }): Promise<void>;
 
   /**
    * Retrieves a saved snapshot from the local database and restores the ECS world.
@@ -280,12 +326,13 @@ class GameSaveService
     slotId?: string;
     campaignId?: string;
     mapName?: string;
+    map?: SaveMapBlock;
   }): Promise<void> {
     if (this.isSaving) {
       return;
     }
 
-    const { slotId = 'auto-save', campaignId, mapName = 'World' } = options ?? {};
+    const { slotId = 'auto-save', campaignId, mapName = 'World', map } = options ?? {};
 
     this.isSaving = true;
 
@@ -294,16 +341,19 @@ class GameSaveService
       const serviceSnapshots = serializeAllServices();
       const savedAt = new Date().toISOString();
 
-      // Compute SHA-256 checksum of the data portion (C-334)
-      const dataToHash = JSON.stringify({ ecsSnapshot, serviceSnapshots });
+      // Compute SHA-256 checksum of the data portion (C-334).
+      // v3 digests include the map block so tampering with map routing is
+      // detected; v2 payloads hash the two original fields only.
+      const dataToHash = JSON.stringify({ ecsSnapshot, serviceSnapshots, map });
       const checksum = await sha256(dataToHash);
 
-      // v2 envelope (C-334)
+      // v3 envelope (C-334, map-authoritative restore)
       const payload = JSON.stringify({
         version: SAVE_ENVELOPE_VERSION,
         checksum,
         ecsSnapshot,
         serviceSnapshots,
+        map,
         savedAt,
       });
 
@@ -363,15 +413,18 @@ class GameSaveService
       }
 
       const payload = result.rows[0].payload as string;
-      const { ecsSnapshot, serviceSnapshots, version, storedChecksum } =
+      const { ecsSnapshot, serviceSnapshots, version, storedChecksum, map } =
         parseSavePayloadEnvelope(payload);
 
-      // Validate checksum for v2+ payloads (C-334 AC-4)
+      // Validate checksum for v2+ payloads (C-334 AC-4). Version-aware:
+      // v3 hashes include the map block, v2 hashes do not.
       if (version && version >= 2 && storedChecksum) {
         const valid = await validateEnvelopeChecksum({
           ecsSnapshot,
           serviceSnapshots,
+          map,
           storedChecksum,
+          version,
         });
         if (!valid) {
           throw new Error(`Save is corrupted: checksum mismatch for slot "${slotId}"`);

--- a/apps/frontend/client/src/lib/services/game/game_save_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/game_save_service.svelte.ts
@@ -366,22 +366,25 @@ class GameSaveService
 
       const db = await getLocalDatabase();
 
-      // Atomic write: write to temp key, then rename (C-334)
+      // Atomic write (C-334): write to a temp key, then rename — all inside
+      // ONE SQLite transaction so a crash mid-sequence can never destroy the
+      // existing save (previously three sequential execute() calls could
+      // leave the slot deleted between the DELETE and the UPDATE).
       const tempId = `${id}_temp_${Date.now()}`;
-      await db.execute({
-        sql: `INSERT OR REPLACE INTO saves (id, slot_id, campaign_id, timestamp, map_name, payload) VALUES (?, ?, ?, ?, ?, ?)`,
-        args: [tempId, slotId, campaignId ?? null, timestamp, mapName, payload],
-      });
-
-      // Atomically replace the final slot
-      await db.execute({
-        sql: 'DELETE FROM saves WHERE id = ?',
-        args: [id],
-      });
-      await db.execute({
-        sql: `UPDATE saves SET id = ?, slot_id = ? WHERE id = ?`,
-        args: [id, slotId, tempId],
-      });
+      await db.transaction([
+        {
+          sql: `INSERT OR REPLACE INTO saves (id, slot_id, campaign_id, timestamp, map_name, payload) VALUES (?, ?, ?, ?, ?, ?)`,
+          args: [tempId, slotId, campaignId ?? null, timestamp, mapName, payload],
+        },
+        {
+          sql: 'DELETE FROM saves WHERE id = ?',
+          args: [id],
+        },
+        {
+          sql: `UPDATE saves SET id = ?, slot_id = ? WHERE id = ?`,
+          args: [id, slotId, tempId],
+        },
+      ]);
 
       this.debug('saveGame:complete', {
         slotId,

--- a/apps/frontend/client/src/lib/services/game/game_save_service.test.ts
+++ b/apps/frontend/client/src/lib/services/game/game_save_service.test.ts
@@ -99,12 +99,17 @@ describe('GameSaveService (C-334)', () => {
     expect(service.availableSaves).toEqual([]);
   });
 
-  // ── AC-1/AC-2: saveGame writes v2 envelope ─────────────────────────
+  // ── AC-1/AC-2: saveGame writes v3 envelope ─────────────────────────
 
-  test('saveGame should write v2 envelope with version, checksum, and metadata', async () => {
+  test('saveGame should write v3 envelope with version, checksum, and metadata', async () => {
     const service = await getService(bridge);
 
-    await service.saveGame({ slotId: 'manual-1', campaignId: 'camp-c1', mapName: 'Forest' });
+    await service.saveGame({
+      slotId: 'manual-1',
+      campaignId: 'camp-c1',
+      mapName: 'Forest',
+      map: { packId: 'emberwatch', mapId: 'village', playerX: 160, playerY: 192 },
+    });
 
     expect(mockSnapshotCalls).toBe(1);
     expect(service.isSaving).toBe(false);
@@ -146,11 +151,16 @@ describe('GameSaveService (C-334)', () => {
 
   // ── AC-3: loadGame restores from save ──────────────────────────────
 
-  test('loadGame should restore from a v2 save with checksum validation', async () => {
+  test('loadGame should restore from a v3 save with checksum validation', async () => {
     const service = await getService(bridge);
 
-    // Save first (creates v2 envelope with checksum)
-    await service.saveGame({ slotId: 'test-slot', campaignId: 'camp-1', mapName: 'TestMap' });
+    // Save first (creates v3 envelope with checksum)
+    await service.saveGame({
+      slotId: 'test-slot',
+      campaignId: 'camp-1',
+      mapName: 'TestMap',
+      map: { packId: 'emberwatch', mapId: 'inn', playerX: 256, playerY: 344 },
+    });
 
     // Reset bridge counters
     resetMockBridge();
@@ -162,6 +172,31 @@ describe('GameSaveService (C-334)', () => {
     expect(service.isLoading).toBe(false);
   });
 
+  test('loadGame should still accept a v2 payload (no map block)', async () => {
+    const { getLocalDatabase } = await import('@aikami/frontend/storage');
+    const db = await getLocalDatabase();
+    // Build a valid v2 envelope: checksum over { ecsSnapshot, serviceSnapshots } only
+    const v2Data = JSON.stringify({ ecsSnapshot: MOCK_SNAPSHOT_PAYLOAD, serviceSnapshots: [] });
+    const { sha256 } = await import('./game_save_service.svelte');
+    const checksum = await sha256(v2Data);
+    const v2Payload = JSON.stringify({
+      version: 2,
+      checksum,
+      ecsSnapshot: MOCK_SNAPSHOT_PAYLOAD,
+      serviceSnapshots: [],
+      savedAt: new Date().toISOString(),
+    });
+    await db.execute({
+      sql: 'INSERT OR REPLACE INTO saves (id, slot_id, campaign_id, timestamp, map_name, payload) VALUES (?, ?, ?, ?, ?, ?)',
+      args: ['aikami_save_v2legacy', 'v2legacy', 'camp-1', Date.now(), 'OldMap', v2Payload],
+    });
+
+    const service = await getService(bridge);
+
+    await service.loadGame('v2legacy');
+    expect(mockRestoreCalls).toBe(1);
+  });
+
   test('loadGame should throw when save is not found', async () => {
     const service = await getService(bridge);
 
@@ -170,15 +205,16 @@ describe('GameSaveService (C-334)', () => {
 
   // ── AC-4: Corruption detection ─────────────────────────────────────
 
-  test('loadGame should detect corrupted v2 payload (checksum mismatch)', async () => {
-    // Pre-populate with a tampered v2 payload (correct version, wrong checksum)
+  test('loadGame should detect corrupted v3 payload (checksum mismatch)', async () => {
+    // Pre-populate with a tampered v3 payload (correct version, wrong checksum)
     const { getLocalDatabase } = await import('@aikami/frontend/storage');
     const db = await getLocalDatabase();
     const tamperedPayload = JSON.stringify({
-      version: 2,
+      version: 3,
       checksum: '0000000000000000000000000000000000000000000000000000000000000000',
       ecsSnapshot: MOCK_SNAPSHOT_PAYLOAD,
       serviceSnapshots: [],
+      map: { packId: 'emberwatch', mapId: 'village', playerX: 1, playerY: 2 },
       savedAt: new Date().toISOString(),
     });
     await db.execute({
@@ -247,9 +283,9 @@ describe('GameSaveService (C-334)', () => {
     const payload = await service.getSavePayload('test');
     expect(typeof payload).toBe('string');
 
-    // Should be valid JSON with v2 envelope
+    // Should be valid JSON with v3 envelope
     const parsed = JSON.parse(payload);
-    expect(parsed.version).toBe(2);
+    expect(parsed.version).toBe(3);
     expect(typeof parsed.checksum).toBe('string');
     expect(parsed.checksum.length).toBe(64); // SHA-256 hex
   });
@@ -323,7 +359,33 @@ describe('GameSaveService (C-334)', () => {
     expect(hash.length).toBe(64);
   });
 
-  // ── parseSavePayloadEnvelope v2 ────────────────────────────────────
+  // ── parseSavePayloadEnvelope v3 ────────────────────────────────────
+
+  test('parseSavePayloadEnvelope should surface map block for v3 payload', async () => {
+    const { parseSavePayloadEnvelope } = await import('./game_save_service.svelte');
+
+    const raw = JSON.stringify({
+      version: 3,
+      checksum: 'abc123',
+      ecsSnapshot: '{"entities":[]}',
+      serviceSnapshots: [{ serviceKey: 'test', data: {} }],
+      map: { packId: 'emberwatch', mapId: 'merchant_shop', playerX: 256, playerY: 344 },
+      savedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    const result = parseSavePayloadEnvelope(raw);
+    expect(result.ecsSnapshot).toBe('{"entities":[]}');
+    expect(result.version).toBe(3);
+    expect(result.storedChecksum).toBe('abc123');
+    expect(result.checksumValid).toBe(false); // caller must validate async
+    expect(result.serviceSnapshots).toHaveLength(1);
+    expect(result.map).toEqual({
+      packId: 'emberwatch',
+      mapId: 'merchant_shop',
+      playerX: 256,
+      playerY: 344,
+    });
+  });
 
   test('parseSavePayloadEnvelope should handle v2 payload', async () => {
     const { parseSavePayloadEnvelope } = await import('./game_save_service.svelte');
@@ -342,6 +404,45 @@ describe('GameSaveService (C-334)', () => {
     expect(result.storedChecksum).toBe('abc123');
     expect(result.checksumValid).toBe(false); // caller must validate async
     expect(result.serviceSnapshots).toHaveLength(1);
+  });
+
+  test('validateEnvelopeChecksum should be version-aware (v3 includes map, v2 does not)', async () => {
+    const { validateEnvelopeChecksum } = await import('./game_save_service.svelte');
+    const ecsSnapshot = '{"entities":[1]}';
+    const serviceSnapshots = [];
+    const map = { packId: 'emberwatch', mapId: 'village', playerX: 10, playerY: 20 };
+
+    // v3 digest includes the map block
+    const v3Data = JSON.stringify({ ecsSnapshot, serviceSnapshots, map });
+    const v3Checksum = await sha256(v3Data);
+    const v3Valid = await validateEnvelopeChecksum({
+      ecsSnapshot,
+      serviceSnapshots,
+      map,
+      storedChecksum: v3Checksum,
+      version: 3,
+    });
+    expect(v3Valid).toBe(true);
+
+    // The same checksum must NOT validate for v2 (different digest shape)
+    const v2Valid = await validateEnvelopeChecksum({
+      ecsSnapshot,
+      serviceSnapshots,
+      storedChecksum: v3Checksum,
+      version: 2,
+    });
+    expect(v2Valid).toBe(false);
+
+    // v2 digest without the map block validates against its own checksum
+    const v2Data = JSON.stringify({ ecsSnapshot, serviceSnapshots });
+    const v2Checksum = await sha256(v2Data);
+    const v2ValidOk = await validateEnvelopeChecksum({
+      ecsSnapshot,
+      serviceSnapshots,
+      storedChecksum: v2Checksum,
+      version: 2,
+    });
+    expect(v2ValidOk).toBe(true);
   });
 
   test('parseSavePayloadEnvelope should handle v1 payload', async () => {

--- a/apps/frontend/client/src/lib/services/game/relationship_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/relationship_service.svelte.ts
@@ -122,6 +122,8 @@ export type RelationshipServiceInterface = BaseFrontendClassInterface & {
   serialize(): RelationshipState;
   /** Deserialize full state on load. */
   deserialize(state: RelationshipState): void;
+  /** Hydrate alias used by the save/load registry (C-334). */
+  hydrate(state: RelationshipState): void;
 };
 
 // ---------------------------------------------------------------------------
@@ -345,6 +347,11 @@ class RelationshipService
       factionStandings: Object.fromEntries(this._factionStandings),
       rememberedPromises: this._promises,
     };
+  }
+
+  /** @inheritdoc */
+  hydrate(state: RelationshipState): void {
+    this.deserialize(state);
   }
 
   /** @inheritdoc */

--- a/apps/frontend/client/src/lib/services/game/save_map_block.ts
+++ b/apps/frontend/client/src/lib/services/game/save_map_block.ts
@@ -1,0 +1,59 @@
+// apps/frontend/client/src/lib/services/game/save_map_block.ts
+//
+// Shared helpers for building the v3+ save-envelope map block and the
+// human-readable map name. Imported directly by services (not through the
+// $services barrel) to avoid circular module graphs — gameEngineService is
+// part of the barrel, so callers must import this module by path.
+
+import { gameEngineService } from './game_engine_service.svelte';
+
+/** Map-routing block persisted in the save envelope (v3+). */
+export type SaveMapBlock = {
+  /** Content pack id (e.g. 'emberwatch'). */
+  packId: string;
+  /** Map id within the pack (e.g. 'merchant_shop'). */
+  mapId: string;
+  /** Player X pixel coordinate on the saved map. */
+  playerX: number;
+  /** Player Y pixel coordinate on the saved map. */
+  playerY: number;
+  /** Optional spawn id the player used to enter the map (provenance/debug). */
+  spawnId?: string;
+};
+
+/**
+ * Builds the v3+ envelope map block: pack id, current map id, and the
+ * player's exact world-space coordinates.
+ *
+ * Returns undefined when the engine hasn't booted a map yet (fresh boot
+ * autosave race) — the save then carries no map routing and loads fall
+ * back to the starting map.
+ */
+export const buildSaveMapBlock = async (): Promise<SaveMapBlock | undefined> => {
+  const mapId = gameEngineService.currentMapId;
+  const packId = gameEngineService.contentPackId;
+  const pos = gameEngineService.getPlayerPosition();
+  if (!mapId || !pos) {
+    return undefined;
+  }
+  return { packId, mapId, playerX: Math.round(pos.x), playerY: Math.round(pos.y) };
+};
+
+/**
+ * Resolves the current map display name from the content pack manifest
+ * (e.g. "Mara's Provisions"), falling back to the map id, then 'World'.
+ *
+ * The old source — worldStateService.currentLocation — is a worldgen
+ * narrative location that is never synced to the gameplay map, so saves
+ * always recorded 'World'.
+ */
+export const getCurrentMapName = async (): Promise<string> => {
+  try {
+    const { loadContentPack } = await import('@aikami/frontend/engine');
+    const pack = await loadContentPack({ packId: gameEngineService.contentPackId });
+    const entry = pack.manifest.maps[gameEngineService.currentMapId];
+    return entry?.name ?? (gameEngineService.currentMapId || 'World');
+  } catch {
+    return gameEngineService.currentMapId || 'World';
+  }
+};

--- a/apps/frontend/client/src/lib/services/game/serializable_service.ts
+++ b/apps/frontend/client/src/lib/services/game/serializable_service.ts
@@ -5,6 +5,8 @@
 // The GameSaveService iterates a registry of these to capture/restore
 // the full game state without reaching into private internals.
 
+import { logger } from '$logger';
+
 /** Contract for domain services that support save/load. */
 export type SerializableService<T> = {
   /** Serializes the service's current state into a plain object. */
@@ -46,14 +48,22 @@ export const serializeAllServices = (): ServiceSnapshot[] => {
 
 /**
  * Hydrates all registered services from an array of snapshots.
- * Called by GameSaveService when loading a saved game.
+ *
+ * Iterates the registry (not the snapshots) so services added later still
+ * hydrate older saves. Services whose registration predates a hydrate()
+ * implementation are skipped with a warning instead of crashing the boot.
  */
 export const hydrateAllServices = (snapshots: ServiceSnapshot[]): void => {
   const map = new Map(snapshots.map((s) => [s.serviceKey, s.data]));
   for (const { key, service } of _registry) {
     const data = map.get(key);
-    if (data !== undefined) {
-      service.hydrate(data);
+    if (data === undefined) {
+      continue;
     }
+    if (typeof service.hydrate !== 'function') {
+      logger.warn('hydrateAllServices:skipped-no-hydrate', { serviceKey: key });
+      continue;
+    }
+    service.hydrate(data);
   }
 };

--- a/apps/frontend/client/src/lib/services/game/session_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/game/session_service.svelte.ts
@@ -7,13 +7,13 @@
 // Contract: C-240 Session Management
 // Contract: C-344 Complete Session Recaps, Checkpoints, and Long-Campaign Lifecycle
 
-import { getLocalDatabase } from '@aikami/frontend/storage';
 import {
   BaseFrontendClass,
   type BaseFrontendClassInterface,
   type BaseFrontendClassOptions,
   routerService,
 } from '@aikami/frontend/services';
+import { getLocalDatabase } from '@aikami/frontend/storage';
 import { playerStateService } from '$services';
 import { textGenerationService } from '$services/ai/text_generation_service.svelte';
 import type {
@@ -451,7 +451,9 @@ class SessionService
 
     // Trigger a game save to the checkpoint slot
     try {
-      await gameSaveService.saveGame({ slotId: saveSlotId, campaignId });
+      const { buildSaveMapBlock, getCurrentMapName } = await import('./save_map_block');
+      const [map, mapName] = await Promise.all([buildSaveMapBlock(), getCurrentMapName()]);
+      await gameSaveService.saveGame({ slotId: saveSlotId, campaignId, mapName, map });
     } catch (error) {
       // Rollback checkpoint record on save failure
       await db.execute({
@@ -575,14 +577,27 @@ class SessionService
     const newSlotId = `fork-${crypto.randomUUID()}`;
     const envelope = JSON.parse(rawPayload) as Record<string, unknown>;
 
-    // Preserve the envelope data for the forked session
+    // Preserve the envelope data for the forked session.
+    // map_name is display-only — prefer the saved map's display name over
+    // the hardcoded 'World' (which was never accurate).
     const newPayload = JSON.stringify(envelope);
     const newSaveId = `aikami_save_${newSlotId}`;
+    const mapBlock = (envelope.map ?? undefined) as { packId?: string; mapId?: string } | undefined;
+    let forkMapName = 'World';
+    if (mapBlock?.packId && mapBlock.mapId) {
+      try {
+        const { loadContentPack } = await import('@aikami/frontend/engine');
+        const pack = await loadContentPack({ packId: mapBlock.packId });
+        forkMapName = pack.manifest.maps[mapBlock.mapId]?.name ?? mapBlock.mapId;
+      } catch {
+        forkMapName = mapBlock.mapId;
+      }
+    }
 
     await db.execute({
       sql: `INSERT OR REPLACE INTO saves (id, slot_id, campaign_id, timestamp, map_name, payload)
             VALUES (?, ?, ?, ?, ?, ?)`,
-      args: [newSaveId, newSlotId, campaignId, Date.now(), 'World', newPayload],
+      args: [newSaveId, newSlotId, campaignId, Date.now(), forkMapName, newPayload],
     });
 
     // Mark the checkpoint as having forks

--- a/apps/frontend/client/static/content-packs/emberwatch/manifest.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/manifest.json
@@ -114,12 +114,14 @@
     "inn": {
       "file": "maps/inn.json",
       "name": "The Guttering Candle Inn",
+      "defaultSpawnId": "inn_entrance",
       "defaultX": 256,
       "defaultY": 320
     },
     "merchant_shop": {
       "file": "maps/merchant_shop.json",
       "name": "Mara's Provisions",
+      "defaultSpawnId": "shop_entrance",
       "defaultX": 256,
       "defaultY": 320
     }

--- a/apps/frontend/client/static/content-packs/emberwatch/maps/inn.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/maps/inn.json
@@ -146,6 +146,21 @@
           ]
         },
         {
+          "id": 6,
+          "type": "spawn",
+          "x": 256,
+          "y": 344,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            {
+              "name": "spawnId",
+              "type": "string",
+              "value": "inn_entrance"
+            }
+          ]
+        },
+        {
           "id": 4,
           "type": "prop",
           "x": 416,
@@ -199,6 +214,11 @@
               "name": "targetY",
               "type": "float",
               "value": 576
+            },
+            {
+              "name": "targetSpawnId",
+              "type": "string",
+              "value": "from_inn"
             }
           ]
         }

--- a/apps/frontend/client/static/content-packs/emberwatch/maps/merchant_shop.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/maps/merchant_shop.json
@@ -156,6 +156,21 @@
           ]
         },
         {
+          "id": 6,
+          "type": "spawn",
+          "x": 256,
+          "y": 344,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            {
+              "name": "spawnId",
+              "type": "string",
+              "value": "shop_entrance"
+            }
+          ]
+        },
+        {
           "id": 4,
           "type": "prop",
           "x": 256,
@@ -209,6 +224,11 @@
               "name": "targetY",
               "type": "float",
               "value": 576
+            },
+            {
+              "name": "targetSpawnId",
+              "type": "string",
+              "value": "from_merchant"
             }
           ]
         }

--- a/apps/frontend/client/static/content-packs/emberwatch/maps/village.json
+++ b/apps/frontend/client/static/content-packs/emberwatch/maps/village.json
@@ -158,6 +158,51 @@
           ]
         },
         {
+          "id": 7,
+          "type": "spawn",
+          "x": 64,
+          "y": 336,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            {
+              "name": "spawnId",
+              "type": "string",
+              "value": "from_merchant"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "spawn",
+          "x": 576,
+          "y": 336,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            {
+              "name": "spawnId",
+              "type": "string",
+              "value": "from_inn"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "spawn",
+          "x": 320,
+          "y": 560,
+          "width": 0,
+          "height": 0,
+          "properties": [
+            {
+              "name": "spawnId",
+              "type": "string",
+              "value": "village_gate"
+            }
+          ]
+        },
+        {
           "id": 4,
           "type": "prop",
           "x": 320,
@@ -211,6 +256,11 @@
               "name": "targetY",
               "type": "float",
               "value": 192
+            },
+            {
+              "name": "targetSpawnId",
+              "type": "string",
+              "value": "shop_entrance"
             }
           ]
         },
@@ -236,6 +286,11 @@
               "name": "targetY",
               "type": "float",
               "value": 192
+            },
+            {
+              "name": "targetSpawnId",
+              "type": "string",
+              "value": "inn_entrance"
             }
           ]
         }

--- a/docs/contracts/C-374-hub-firestore-to-dataconnect.md
+++ b/docs/contracts/C-374-hub-firestore-to-dataconnect.md
@@ -7,7 +7,8 @@ github:
   issue_number: null
   issue_url: null
   project_item_id: null
-  pr_url: null
+  pr_url: "https://github.com/BearlySleeping/aikami/pull/120"
+  pr_number: 120
 created_at: "2026-08-07"
 ---
 

--- a/packages/frontend/engine/src/__tests__/serializer.test.ts
+++ b/packages/frontend/engine/src/__tests__/serializer.test.ts
@@ -1,7 +1,7 @@
 // packages/frontend/engine/src/__tests__/serializer.test.ts
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { World } from 'bitecs';
-import { addComponent, addEntity, createWorld, getAllEntities, set } from 'bitecs';
+import { addComponent, addEntity, createWorld, getAllEntities, hasComponent, set } from 'bitecs';
 import { Appearance, registerAppearanceObservers } from '../components/appearance.ts';
 import { CombatStats, registerCombatStatsObservers } from '../components/combat_stats.ts';
 import { Position, registerPositionObservers } from '../components/position.ts';
@@ -769,8 +769,9 @@ describe('AC-3: serializePlayer produces player-scoped snapshot', () => {
     const restoredEid = [...eidMap.values()][0];
     // Position data restored
     expect(Position.x[restoredEid]).toBe(5);
-    // CombatStats must NOT be registered on this entity
-    expect(CombatStats.health[restoredEid]).toBeUndefined();
-    expect(CombatStats.maxHealth[restoredEid]).toBeUndefined();
+    // CombatStats must NOT be registered on this entity (bitecs membership,
+    // not just SoA values — previously every entity received every component)
+    expect(hasComponent(restored, restoredEid, CombatStats)).toBe(false);
+    expect(hasComponent(restored, restoredEid, Position)).toBe(true);
   });
 });

--- a/packages/frontend/engine/src/__tests__/serializer.test.ts
+++ b/packages/frontend/engine/src/__tests__/serializer.test.ts
@@ -6,7 +6,11 @@ import { Appearance, registerAppearanceObservers } from '../components/appearanc
 import { CombatStats, registerCombatStatsObservers } from '../components/combat_stats.ts';
 import { Position, registerPositionObservers } from '../components/position.ts';
 import { registerVelocityObservers, Velocity } from '../components/velocity.ts';
-import { deserializeWorld, serializeWorld } from '../serialization/ecs_serializer.ts';
+import {
+  deserializeWorld,
+  serializePlayer,
+  serializeWorld,
+} from '../serialization/ecs_serializer.ts';
 
 // ---------------------------------------------------------------------------
 // AC-1 & AC-2: ECS Snapshot Serializer
@@ -662,5 +666,111 @@ describe('Edge Cases', () => {
     // Source world should be unchanged
     expect(Position.x[sourceEid]).toBe(sourceXBefore);
     expect(Position.y[sourceEid]).toBe(sourceYBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: serializePlayer produces a player-scoped snapshot (map-authoritative
+// restore — the save envelope carries only the player's own state)
+// ---------------------------------------------------------------------------
+
+describe('AC-3: serializePlayer produces player-scoped snapshot', () => {
+  let world: World;
+
+  beforeEach(() => {
+    _resetComponentArrays();
+    world = createTestWorld();
+  });
+
+  afterEach(() => {
+    _resetComponentArrays();
+  });
+
+  it('serializes only the player entity, not world entities', () => {
+    // Player (eid 1)
+    createPersistentEntity(world, {
+      x: 111,
+      y: 222,
+      layer0: 0,
+      layer1: 1,
+      layer2: 2,
+      layer3: 3,
+      layer4: 4,
+      health: 100,
+      maxHealth: 100,
+      initiative: 10,
+    });
+    // A second world entity (NPC/prop) — must NOT appear in the player snapshot
+    createPersistentEntity(world, {
+      x: 999,
+      y: 888,
+      layer0: 9,
+      layer1: 9,
+      layer2: 9,
+      layer3: 9,
+      layer4: 9,
+      health: 1,
+      maxHealth: 1,
+      initiative: 1,
+    });
+
+    const payload = serializePlayer(world);
+    const snapshot = JSON.parse(payload) as {
+      entities: number[];
+      components: Record<string, Record<string, number[]>>;
+    };
+
+    expect(snapshot.entities).toEqual([1]);
+    // Only the player's position is captured
+    expect(snapshot.components.Position.x).toEqual([111]);
+    expect(snapshot.components.Position.y).toEqual([222]);
+    // World entity data is absent
+    expect(snapshot.components.Position.x).not.toContain(999);
+  });
+
+  it('round-trips through deserializeWorld and restores only registered components', () => {
+    createPersistentEntity(world, {
+      x: 42,
+      y: 84,
+      layer0: 0,
+      layer1: 0,
+      layer2: 0,
+      layer3: 0,
+      layer4: 0,
+      health: 77,
+      maxHealth: 100,
+      initiative: 8,
+    });
+
+    const payload = serializePlayer(world);
+    const restored = createTestWorld();
+    const eidMap = deserializeWorld(restored, payload);
+
+    // Exactly one entity restored
+    expect(eidMap.size).toBe(1);
+    const restoredEid = [...eidMap.values()][0];
+
+    expect(Position.x[restoredEid]).toBe(42);
+    expect(Position.y[restoredEid]).toBe(84);
+    expect(CombatStats.health[restoredEid]).toBe(77);
+    expect(CombatStats.maxHealth[restoredEid]).toBe(100);
+    expect(CombatStats.initiative[restoredEid]).toBe(8);
+  });
+
+  it('does not register components for entities that have no data (no ghost combat stats)', () => {
+    // Entity with ONLY Position — no Appearance, no CombatStats
+    const bareEid = addEntity(world);
+    addComponent(world, bareEid, set(Position, { x: 5, y: 6 }));
+
+    const payload = serializeWorld(world);
+    const restored = createTestWorld();
+    const eidMap = deserializeWorld(restored, payload);
+
+    const restoredEid = [...eidMap.values()][0];
+    // Position data restored
+    expect(Position.x[restoredEid]).toBe(5);
+    // CombatStats must NOT be registered on this entity
+    expect(CombatStats.health[restoredEid]).toBeUndefined();
+    expect(CombatStats.maxHealth[restoredEid]).toBeUndefined();
   });
 });

--- a/packages/frontend/engine/src/assets/map_loader.ts
+++ b/packages/frontend/engine/src/assets/map_loader.ts
@@ -780,6 +780,18 @@ const _parseTransitionZone = (object: Record<string, unknown>): TransitionZone |
     return undefined;
   }
 
+  const targetSpawnId =
+    typeof properties.targetSpawnId === 'string' ? properties.targetSpawnId : undefined;
+
+  if (!targetSpawnId) {
+    logger.warn(
+      '[map_loader] Transition without targetSpawnId — spawn will fall back to hardcoded ' +
+        `targetX/targetY (${targetX},${targetY}). Add a "targetSpawnId" property referencing ` +
+        `a "spawn" marker on map "${targetMap}" to keep portals synced.`,
+      { id: String(id) },
+    );
+  }
+
   return {
     id: String(id),
     x: typeof object.x === 'number' ? object.x : 0,
@@ -789,7 +801,6 @@ const _parseTransitionZone = (object: Record<string, unknown>): TransitionZone |
     targetMap,
     targetX,
     targetY,
-    targetSpawnId:
-      typeof properties.targetSpawnId === 'string' ? properties.targetSpawnId : undefined,
+    targetSpawnId,
   };
 };

--- a/packages/frontend/engine/src/components/interactable_state.ts
+++ b/packages/frontend/engine/src/components/interactable_state.ts
@@ -41,6 +41,24 @@ export type InteractableStateData = {
   lootTableKey?: number;
 };
 
+/**
+ * Per-spawnId interactable persistence map (C-342).
+ *
+ * Maps a Tiled spawn point ID to its persisted door/chest/lever state.
+ * Passed through loadMap → LOAD_MAP so interactables restore their state
+ * when a map is rebuilt (authoritative source: worldStateService).
+ */
+export type InteractableStateMap = Record<
+  string,
+  {
+    isOpen?: boolean;
+    isLocked?: boolean;
+    isLooted?: boolean;
+    isToggled?: boolean;
+    isTriggered?: boolean;
+  }
+>;
+
 /** Loot table index lookup — resolves string keys to integer handles. */
 export type LootTableRegistry = Map<string, number>;
 

--- a/packages/frontend/engine/src/engine_bridge.ts
+++ b/packages/frontend/engine/src/engine_bridge.ts
@@ -75,12 +75,16 @@ export type EngineBridge = {
    * Creates a serialized snapshot of the current ECS world state.
    *
    * Delegates to the worker which calls {@link import('./serialization/ecs_serializer.ts').serializeWorld}
-   * on the active bitECS world. Returns the JSON payload string.
+   * or {@link import('./serialization/ecs_serializer.ts').serializePlayer} on the
+   * active bitECS world. Returns the JSON payload string.
    *
+   * @param scope - 'player' (default) serializes only the player entity
+   *   (map-authoritative saves). 'world' serializes the full ECS world
+   *   (legacy/fallback saves without a map block).
    * @returns The serialized ECS world state as a JSON string.
    * @throws If the engine is not initialized or the worker is not running.
    */
-  createSnapshot(): Promise<string>;
+  createSnapshot(scope?: 'player' | 'world'): Promise<string>;
 
   /**
    * Restores the ECS world state from a previously-created snapshot.
@@ -245,7 +249,7 @@ class EngineBridgeImpl implements EngineBridge {
   }
 
   /** Snapshot handler registered by the GameWorld. */
-  private _snapshotHandler: (() => Promise<string>) | undefined;
+  private _snapshotHandler: ((scope?: 'player' | 'world') => Promise<string>) | undefined;
 
   /** Restore handler registered by the GameWorld. */
   private _restoreHandler: ((snapshot: string) => Promise<void>) | undefined;
@@ -273,7 +277,7 @@ class EngineBridgeImpl implements EngineBridge {
    * Registers the snapshot handler callback. Called by GameWorld during
    * initialization so {@link createSnapshot} delegates to the worker.
    */
-  setSnapshotHandler(handler: () => Promise<string>): void {
+  setSnapshotHandler(handler: (scope?: 'player' | 'world') => Promise<string>): void {
     this._snapshotHandler = handler;
   }
 
@@ -286,11 +290,11 @@ class EngineBridgeImpl implements EngineBridge {
   }
 
   /** @inheritdoc */
-  async createSnapshot(): Promise<string> {
+  async createSnapshot(scope?: 'player' | 'world'): Promise<string> {
     if (!this._snapshotHandler) {
       throw new Error('EngineBridge: no snapshot handler registered (engine not initialized)');
     }
-    return this._snapshotHandler();
+    return this._snapshotHandler(scope);
   }
 
   /** @inheritdoc */
@@ -371,7 +375,7 @@ export class MockEngineBridge implements EngineBridge {
   }
 
   /** @see EngineBridgeImpl.setSnapshotHandler */
-  setSnapshotHandler(handler: () => Promise<string>): void {
+  setSnapshotHandler(handler: (scope?: 'player' | 'world') => Promise<string>): void {
     this.impl.setSnapshotHandler(handler);
   }
 
@@ -381,8 +385,8 @@ export class MockEngineBridge implements EngineBridge {
   }
 
   /** @inheritdoc */
-  async createSnapshot(): Promise<string> {
-    return this.impl.createSnapshot();
+  async createSnapshot(scope?: 'player' | 'world'): Promise<string> {
+    return this.impl.createSnapshot(scope);
   }
 
   /** @inheritdoc */

--- a/packages/frontend/engine/src/game_world.ts
+++ b/packages/frontend/engine/src/game_world.ts
@@ -238,6 +238,8 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
 
   /** Lazily-loaded Vite `?worker` constructor (see module top comment). */
   private _workerConstructor: EcsWorkerConstructor | undefined;
+  /** Set by destroy() so in-flight async init paths can abort early. */
+  private _disposed = false;
 
   /** Resolves layer IDs to LPC layer recipes. */
   private readonly _recipeResolver?: (layerIds: readonly number[]) => LpcLayerRecipe[];
@@ -557,6 +559,8 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
   destroy(): void {
     // Diagnostic: trace who calls destroy
     this.error('[GameWorld] destroy:called', { stack: new Error().stack });
+    // Flag disposal so in-flight async init paths (worker import) abort
+    this._disposed = true;
     // Stop the render loop
     this._running = false;
 
@@ -1745,6 +1749,26 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
   }
 
   /**
+   * Returns the player's current world-space pixel position, or undefined
+   * if the engine has not booted yet.
+   *
+   * Used by the save pipeline to persist exact coordinates in the envelope
+   * map block (v3+). Reads the active render buffer directly.
+   */
+  getPlayerPosition(): { x: number; y: number } | undefined {
+    if (!this._activeRenderView || this._playerEntityId <= 0) {
+      return undefined;
+    }
+    const offset = this._playerEntityId * COMPONENT_STRIDE;
+    const x = this._activeRenderView[offset];
+    const y = this._activeRenderView[offset + 1];
+    if (x === undefined || y === undefined || (x === 0 && y === 0)) {
+      return undefined;
+    }
+    return { x, y };
+  }
+
+  /**
    * Requests a serialized ECS snapshot from the worker.
    *
    * Posts a REQUEST_SNAPSHOT message to the worker and returns a promise
@@ -1860,6 +1884,79 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
   }
 
   /**
+   * Applies a player-scoped ECS snapshot onto the live world.
+   *
+   * Used by the map-authoritative restore pipeline: the world is rebuilt
+   * from the saved map via {@link loadMap} (which spawns NPCs, props,
+   * portals, and collision), then this method merges the player's saved
+   * Position/Appearance/CombatStats/Visual onto the existing player
+   * entity — without clearing the freshly spawned world.
+   *
+   * Unlike {@link restoreWorld}, render entries are preserved: the player's
+   * display object survives and is repositioned by the worker's next
+   * STATE_UPDATE + the CAMERA_SNAP message.
+   *
+   * @param payload - A player-scoped ECS snapshot JSON string.
+   * @throws If the worker is not running or the restore fails.
+   */
+  restorePlayer(payload: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this._worker) {
+        reject(new Error('Worker not running — cannot restore player'));
+        return;
+      }
+
+      // ═══ Timeout: 15s max wait for worker response ═══
+      const RestoreTimeoutMs = 15_000;
+      let settled = false;
+
+      const finish = (fn: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        this._worker?.removeEventListener('message', handler);
+        this._pendingWorkerReject = undefined;
+        fn();
+      };
+
+      const timeout = setTimeout(() => {
+        this.error('restorePlayer:timeout', { timeoutMs: RestoreTimeoutMs });
+        finish(() =>
+          reject(
+            new Error(
+              'Worker did not respond to RESTORE_PLAYER within 15s — worker may have crashed',
+            ),
+          ),
+        );
+      }, RestoreTimeoutMs);
+
+      this._pendingWorkerReject = (reason: Error): void => {
+        finish(() => reject(reason));
+      };
+
+      const handler = (event: MessageEvent): void => {
+        const message = event.data;
+
+        if (message.type === 'ENGINE_ERROR') {
+          finish(() => reject(new Error(message.message as string)));
+          return;
+        }
+
+        if (message.type !== 'ENGINE_READY') {
+          return;
+        }
+
+        finish(() => resolve());
+      };
+
+      this._worker.addEventListener('message', handler);
+      this._worker.postMessage({ type: 'RESTORE_PLAYER', payload });
+    });
+  }
+
+  /**
    * Loads a new map at the given URL and places the player at the target
    * coordinates. Orchestrates the full map transition lifecycle:
    *
@@ -1881,6 +1978,8 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
    * @param options.defeatedEnemies - Array of defeated enemy spawn IDs to filter during spawn.
    * @param options.collectedPickups - Array of collected item pickup spawn IDs to suppress (C-331).
    * @param options.targetSpawnHash - Numeric hash of the target spawn point ID (C-172).
+   * @param options.defaultSpawnHash - Numeric hash of the destination map's manifest
+   *   `defaultSpawnId`. Used as a fallback when targetSpawnHash is absent (C-172 resolution chain).
    * @param options.disableClamping - Bypass viewport boundary clamping for visual testing (C-199).
    * @throws If the worker is not running or the map fails to load.
    *
@@ -1903,6 +2002,7 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
       }
     >;
     targetSpawnHash?: number;
+    defaultSpawnHash?: number;
     disableClamping?: boolean;
     /** GIDs to treat as water (blocked). Defaults to [2] for debug maps. Pass empty Set for maps without water. */
     waterGids?: Set<number>;
@@ -1915,6 +2015,7 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
       collectedPickups,
       interactableStates,
       targetSpawnHash,
+      defaultSpawnHash,
       disableClamping,
       waterGids,
     } = options;
@@ -1958,6 +2059,12 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
 
       const mapPixelWidth = tilemap.width * tilemap.tilewidth;
       const mapPixelHeight = tilemap.height * tilemap.tileheight;
+
+      // Stable map id for the worker (zone entity derivation — C-194 fix):
+      // same filename → same id, regardless of pixel dimensions, so
+      // same-sized maps (inn vs merchant_shop, both 512×384) no longer
+      // collide to the same zone entity.
+      const mapId = (mapUrl.split('/').pop() ?? mapUrl).replace(/\.json$/i, '');
 
       // 5. Render the new tilemap background
       if (this._app && this._worldContainer) {
@@ -2005,8 +2112,10 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
         collectedPickups,
         interactableStates,
         targetSpawnHash,
+        defaultSpawnHash,
         spawnPointEntities,
         disableClamping,
+        mapId,
       });
 
       // 7. Resume the engine
@@ -2061,8 +2170,11 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
       }
     >;
     targetSpawnHash?: number;
+    defaultSpawnHash?: number;
     spawnPointEntities?: import('./assets/map_loader.ts').SpawnPointEntity[];
     disableClamping?: boolean;
+    /** Stable map id (URL filename without extension) for zone derivation. */
+    mapId: string;
   }): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!this._worker) {
@@ -2147,8 +2259,10 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
         collectedPickups: options.collectedPickups,
         interactableStates: options.interactableStates,
         targetSpawnHash: options.targetSpawnHash,
+        defaultSpawnHash: options.defaultSpawnHash,
         spawnPointEntities: options.spawnPointEntities,
         disableClamping: options.disableClamping,
+        mapId: options.mapId,
       });
     });
   }

--- a/packages/frontend/engine/src/game_world.ts
+++ b/packages/frontend/engine/src/game_world.ts
@@ -11,6 +11,7 @@ import {
 } from './assets/map_loader.ts';
 import { BaseEngineClass, type BaseEngineClassOptions } from './base_engine_class.ts';
 import type { LpcLayerRecipe } from './components/appearance.ts';
+import type { InteractableStateMap } from './components/interactable_state.ts';
 import {
   BUFFER_SIZE,
   COMPONENT_STRIDE,
@@ -1358,12 +1359,14 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
    */
   private _setupSnapshotHandlers(): void {
     const bridgeWithHandlers = this._bridge as unknown as {
-      setSnapshotHandler: (handler: () => Promise<string>) => void;
+      setSnapshotHandler: (handler: (scope?: 'player' | 'world') => Promise<string>) => void;
       setRestoreHandler: (handler: (snapshot: string) => Promise<void>) => void;
     };
 
     if (typeof bridgeWithHandlers.setSnapshotHandler === 'function') {
-      bridgeWithHandlers.setSnapshotHandler(() => this.snapshotWorld());
+      bridgeWithHandlers.setSnapshotHandler((scope?: 'player' | 'world') =>
+        this.snapshotWorld(scope),
+      );
     }
 
     if (typeof bridgeWithHandlers.setRestoreHandler === 'function') {
@@ -1775,9 +1778,12 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
    * that resolves with the JSON payload string. Rejects if the worker
    * is not running or the snapshot fails.
    *
+   * @param scope - 'player' (default) serializes only the player entity
+   *   (map-authoritative saves). 'world' serializes the full ECS world
+   *   (legacy/fallback saves without a map block).
    * @returns The serialized ECS world state as a JSON string.
    */
-  snapshotWorld(): Promise<string> {
+  snapshotWorld(scope: 'player' | 'world' = 'player'): Promise<string> {
     return new Promise((resolve, reject) => {
       if (!this._worker) {
         reject(new Error('Worker not running — cannot snapshot'));
@@ -1801,7 +1807,7 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
       };
 
       this._worker.addEventListener('message', handler);
-      this._worker.postMessage({ type: 'REQUEST_SNAPSHOT' });
+      this._worker.postMessage({ type: 'REQUEST_SNAPSHOT', scope });
     });
   }
 
@@ -1991,16 +1997,7 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
     targetY: number;
     defeatedEnemies?: string[];
     collectedPickups?: string[];
-    interactableStates?: Record<
-      string,
-      {
-        isOpen?: boolean;
-        isLocked?: boolean;
-        isLooted?: boolean;
-        isToggled?: boolean;
-        isTriggered?: boolean;
-      }
-    >;
+    interactableStates?: InteractableStateMap;
     targetSpawnHash?: number;
     defaultSpawnHash?: number;
     disableClamping?: boolean;
@@ -2159,16 +2156,7 @@ class GameWorld extends BaseEngineClass<GameWorldOptions> {
     targetY: number;
     defeatedEnemies?: string[];
     collectedPickups?: string[];
-    interactableStates?: Record<
-      string,
-      {
-        isOpen?: boolean;
-        isLocked?: boolean;
-        isLooted?: boolean;
-        isToggled?: boolean;
-        isTriggered?: boolean;
-      }
-    >;
+    interactableStates?: InteractableStateMap;
     targetSpawnHash?: number;
     defaultSpawnHash?: number;
     spawnPointEntities?: import('./assets/map_loader.ts').SpawnPointEntity[];

--- a/packages/frontend/engine/src/index.ts
+++ b/packages/frontend/engine/src/index.ts
@@ -114,6 +114,11 @@ export type { GridPositionData } from './components/grid_position.ts';
 export { GridPosition, registerGridPositionObservers } from './components/grid_position.ts';
 export type { InteractableData, InteractableType } from './components/interactable.ts';
 export { Interactable, registerInteractableObservers } from './components/interactable.ts';
+export type {
+  InteractableStateData,
+  InteractableStateMap,
+} from './components/interactable_state.ts';
+export { InteractableState } from './components/interactable_state.ts';
 export type { InventoryData, WalletData } from './components/inventory.ts';
 export {
   Inventory,

--- a/packages/frontend/engine/src/index.ts
+++ b/packages/frontend/engine/src/index.ts
@@ -185,7 +185,11 @@ export { GameApiService } from './services/api_service.ts';
 
 // Serialization
 
-export { deserializeWorld, serializeWorld } from './serialization/ecs_serializer.ts';
+export {
+  deserializeWorld,
+  serializePlayer,
+  serializeWorld,
+} from './serialization/ecs_serializer.ts';
 
 // Rendering
 

--- a/packages/frontend/engine/src/serialization/ecs_serializer.ts
+++ b/packages/frontend/engine/src/serialization/ecs_serializer.ts
@@ -180,6 +180,42 @@ export const serializeWorld = (world: World): string => {
 };
 
 /**
+ * Serializes ONLY the player entity's persistent components.
+ *
+ * The map file is the source of truth for world entities (NPCs, props,
+ * portals, spawn markers) — they are re-created from Tiled data on every
+ * map load. The save snapshot therefore only needs the player's own state
+ * (Position, Appearance, CombatStats, Visual). Keeping the snapshot
+ * player-scoped avoids restoring ghost entities (transition zones,
+ * combat-statted props) that the world rebuild already replaces.
+ *
+ * @param world - The bitECS world to snapshot.
+ * @param playerEid - The player entity ID (defaults to 1, the engine's
+ *   convention for the first spawned player entity).
+ * @returns A JSON string with a single-entity EcsSnapshot.
+ */
+export const serializePlayer = (_world: World, playerEid = 1): string => {
+  const eids = [playerEid];
+  const components: Record<string, ComponentSlice> = {};
+
+  for (const [name, component] of PERSISTENT_COMPONENTS) {
+    const slice = _extractComponentSlice(component, eids);
+    if (Object.keys(slice).length > 0) {
+      components[name] = slice as Record<string, Array<number | string | boolean>>;
+    }
+  }
+
+  const snapshot: EcsSnapshot = {
+    version: '1.0.0',
+    timestamp: Date.now(),
+    entities: eids,
+    components: components as EcsSnapshot['components'],
+  };
+
+  return JSON.stringify(snapshot);
+};
+
+/**
  * Hydrates a bitECS world from a previously-serialized snapshot payload.
  *
  * Creates new entities (bitECS assigns sequential IDs) and restores all
@@ -221,16 +257,25 @@ export const deserializeWorld = (world: World, payload: string): Map<number, num
     newEids.push(newEid);
   }
 
-  // Restore component data for each persistent component
+  // Restore component data for each persistent component.
+  // Components are only registered on entities that actually have a
+  // concrete value in the slice — previously every entity received every
+  // component, so restored props/portals carried CombatStats and matched
+  // enemy/combat queries as garbage entities.
   for (const [name, component] of PERSISTENT_COMPONENTS) {
     const slice = snapshot.components[name];
     if (!slice) {
       continue;
     }
 
-    // Register the component on each new entity, then restore data
-    for (const newEid of newEids) {
-      addComponent(world, newEid, component);
+    for (let i = 0; i < newEids.length; i++) {
+      const newEid = newEids[i];
+      const hasValue = Object.values(slice).some(
+        (values) => values[i] !== undefined && values[i] !== null,
+      );
+      if (hasValue) {
+        addComponent(world, newEid, component);
+      }
     }
 
     _restoreComponentSlice(world, component, newEids, slice);

--- a/packages/frontend/engine/src/systems/entity_spawner.ts
+++ b/packages/frontend/engine/src/systems/entity_spawner.ts
@@ -15,7 +15,7 @@ import { CombatStats } from '../components/combat_stats.ts';
 import { Companion } from '../components/companion.ts';
 import { Enemy } from '../components/enemy.ts';
 import { Interactable } from '../components/interactable.ts';
-import { InteractableState } from '../components/interactable_state.ts';
+import { InteractableState, type InteractableStateMap } from '../components/interactable_state.ts';
 import { NPCDialog } from '../components/npc_dialog.ts';
 import { Position } from '../components/position.ts';
 import { SpawnPoint as SpawnPointComp } from '../components/spawn_point.ts';
@@ -68,16 +68,7 @@ export type SpawnEntitiesOptions = {
    *
    * Contract: C-342 — interactable state persistence
    */
-  interactableStates?: Record<
-    string,
-    {
-      isOpen?: boolean;
-      isLocked?: boolean;
-      isLooted?: boolean;
-      isToggled?: boolean;
-      isTriggered?: boolean;
-    }
-  >;
+  interactableStates?: InteractableStateMap;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/frontend/engine/src/worker/ecs_worker.ts
+++ b/packages/frontend/engine/src/worker/ecs_worker.ts
@@ -32,7 +32,10 @@ import {
 } from '../components/engine_state.ts';
 import { registerGridPositionObservers } from '../components/grid_position.ts';
 import { registerInteractableObservers } from '../components/interactable.ts';
-import { registerInteractableStateObservers } from '../components/interactable_state.ts';
+import {
+  type InteractableStateMap,
+  registerInteractableStateObservers,
+} from '../components/interactable_state.ts';
 import { registerInventoryObservers } from '../components/inventory.ts';
 import { registerMapLocationObservers } from '../components/map_location.ts';
 import { registerMoveIntentObservers } from '../components/move_intent.ts';
@@ -56,7 +59,11 @@ import { createPlayer, type PlayerCreateOptions } from '../entities/create_playe
 import { createDefaultSandboxAvatar } from '../entities/create_sandbox_avatar.ts';
 
 import { SpatialHashGrid } from '../math/spatial_hash_grid.ts';
-import { deserializeWorld, serializePlayer } from '../serialization/ecs_serializer.ts';
+import {
+  deserializeWorld,
+  serializePlayer,
+  serializeWorld,
+} from '../serialization/ecs_serializer.ts';
 import { getEngineGameMode, setEngineGameMode } from '../state/game_mode.ts';
 import {
   endDialogueZoom,
@@ -1480,9 +1487,16 @@ self.onmessage = (event: MessageEvent): void => {
           break;
         }
         try {
-          // Player-scoped snapshot: the map file is the source of truth for
+          // Player-scoped by default: the map file is the source of truth for
           // world entities, so saves only need the player's own state.
-          const payload = serializePlayer(world, playerEntityId > 0 ? playerEntityId : 1);
+          // When no map block can be produced (e.g. early-boot autosave race),
+          // the save requests a full-world snapshot so the legacy restore path
+          // can still reconstruct the world.
+          const scope = message.scope === 'world' ? 'world' : 'player';
+          const payload =
+            scope === 'world'
+              ? serializeWorld(world)
+              : serializePlayer(world, playerEntityId > 0 ? playerEntityId : 1);
           postMessage({ type: 'SNAPSHOT_RESPONSE', payload });
         } catch (err) {
           postMessage({
@@ -1541,24 +1555,13 @@ self.onmessage = (event: MessageEvent): void => {
           }
 
           // Snap the camera to the restored position and refresh the
-          // player's LPC textures immediately.
+          // player's LPC textures immediately. _refreshPlayerAppearance
+          // applies the C-370 body-layer fallback before emitting.
           const px = Position.x[playerEntityId] ?? 0;
           const py = Position.y[playerEntityId] ?? 0;
           postMessage({ type: 'CAMERA_SNAP', x: px, y: py });
 
-          const playerLayers = getAppearanceLayers(playerEntityId);
-          if (playerLayers.length > 0) {
-            postMessage({
-              type: 'SYNC',
-              events: [
-                {
-                  type: 'APPEARANCE_CHANGED',
-                  eid: playerEntityId,
-                  layerIds: [...playerLayers],
-                },
-              ],
-            });
-          }
+          _refreshPlayerAppearance(playerEntityId);
 
           postMessage({ type: 'ENGINE_READY' });
         } catch (err) {
@@ -1778,27 +1781,25 @@ self.onmessage = (event: MessageEvent): void => {
           let resolvedX = targetX as number;
           let resolvedY = targetY as number;
 
-          if (typeof targetSpawnHash === 'number' && targetSpawnHash > 0) {
-            const resolved = _resolveSpawnInStaging(
-              spawnPointEntities as SpawnPointEntity[] | undefined,
-              targetSpawnHash,
-            );
-            if (resolved) {
-              resolvedX = resolved.x;
-              resolvedY = resolved.y;
+          const markers = spawnPointEntities as SpawnPointEntity[] | undefined;
+          const spawnCandidates: Array<{ hash: unknown; label: string }> = [
+            { hash: targetSpawnHash, label: 'targetSpawnHash' },
+            { hash: defaultSpawnHash, label: 'defaultSpawnHash' },
+          ];
+
+          for (const candidate of spawnCandidates) {
+            if (typeof candidate.hash !== 'number' || candidate.hash <= 0) {
+              continue;
             }
-          } else if (typeof defaultSpawnHash === 'number' && defaultSpawnHash > 0) {
-            const resolved = _resolveSpawnInStaging(
-              spawnPointEntities as SpawnPointEntity[] | undefined,
-              defaultSpawnHash,
-            );
+            const resolved = _resolveSpawnInStaging(markers, candidate.hash);
             if (resolved) {
               logger.debug(
                 'LOAD_MAP',
-                `fallback to defaultSpawnHash ${defaultSpawnHash} -> (${resolved.x},${resolved.y})`,
+                `spawn resolved via ${candidate.label} ${candidate.hash} -> (${resolved.x},${resolved.y})`,
               );
               resolvedX = resolved.x;
               resolvedY = resolved.y;
+              break;
             }
           }
 
@@ -1831,18 +1832,7 @@ self.onmessage = (event: MessageEvent): void => {
             spawnPoints,
             defeatedEnemies: defeatedEnemies as string[] | undefined,
             collectedPickups: collectedPickups as string[] | undefined,
-            interactableStates: interactableStates as
-              | Record<
-                  string,
-                  {
-                    isOpen?: boolean;
-                    isLocked?: boolean;
-                    isLooted?: boolean;
-                    isToggled?: boolean;
-                    isTriggered?: boolean;
-                  }
-                >
-              | undefined,
+            interactableStates: interactableStates as InteractableStateMap | undefined,
           });
 
           // 4. Spawn transition zone trigger entities
@@ -2035,11 +2025,12 @@ self.onmessage = (event: MessageEvent): void => {
           // ── C-194: Hydrate the new active zone ──
           // Derive a zone entity ID from the stable map id string so
           // same-sized maps (inn vs merchant_shop, both 512×384) do not
-          // collide to the same zone entity.
+          // collide to the same zone entity. The hash is constrained to the
+          // valid bitECS entity range (< MAX_ENTITIES) with a nonzero guard.
           const newZoneEid =
             typeof mapId === 'string' && mapId.length > 0
-              ? djb2Hash(mapId) & 0x7fffffff || 1
-              : ((mapPixelWidth as number) * 31 + (mapPixelHeight as number) * 17) & 0x7fffffff ||
+              ? djb2Hash(mapId) % MAX_ENTITIES || 1
+              : ((mapPixelWidth as number) * 31 + (mapPixelHeight as number) * 17) % MAX_ENTITIES ||
                 1;
           _activeZoneEntityId = newZoneEid;
           hydrateZone(world, newZoneEid, {

--- a/packages/frontend/engine/src/worker/ecs_worker.ts
+++ b/packages/frontend/engine/src/worker/ecs_worker.ts
@@ -11,8 +11,9 @@ import {
   set,
 } from 'bitecs';
 import { logger } from '$logger';
-import type { SpawnPointEntity, TransitionZone } from '../assets/map_loader.ts';
+import { djb2Hash, type SpawnPointEntity, type TransitionZone } from '../assets/map_loader.ts';
 import {
+  Appearance,
   DEFAULT_BODY_LAYER_ID,
   getAppearanceLayers,
   type LpcLayerRecipe,
@@ -55,7 +56,7 @@ import { createPlayer, type PlayerCreateOptions } from '../entities/create_playe
 import { createDefaultSandboxAvatar } from '../entities/create_sandbox_avatar.ts';
 
 import { SpatialHashGrid } from '../math/spatial_hash_grid.ts';
-import { deserializeWorld, serializeWorld } from '../serialization/ecs_serializer.ts';
+import { deserializeWorld, serializePlayer } from '../serialization/ecs_serializer.ts';
 import { getEngineGameMode, setEngineGameMode } from '../state/game_mode.ts';
 import {
   endDialogueZoom,
@@ -1303,6 +1304,30 @@ const serializeEntityStates = (_w: World, view: Float32Array): void => {
 // ---------------------------------------------------------------------------
 
 /**
+ * Copies every SoA field of a component from one entity to another.
+ *
+ * Used by RESTORE_PLAYER to merge a deserialized player payload onto the
+ * live player entity without recreating the entity.
+ *
+ * @param component - The SoA component object (e.g. `Position`).
+ * @param fromEid - Source entity.
+ * @param toEid - Destination entity.
+ */
+const copyComponentSoA = (
+  component: Record<string, Array<unknown>>,
+  fromEid: number,
+  toEid: number,
+): void => {
+  for (const field of Object.keys(component)) {
+    const source = component[field] as Array<unknown>;
+    const value = source[fromEid];
+    if (value !== undefined) {
+      (component[field] as Array<unknown>)[toEid] = value;
+    }
+  }
+};
+
+/**
  * Resolves a target spawn hash to pixel coordinates using a temporary
  * staging world.
  *
@@ -1455,7 +1480,9 @@ self.onmessage = (event: MessageEvent): void => {
           break;
         }
         try {
-          const payload = serializeWorld(world);
+          // Player-scoped snapshot: the map file is the source of truth for
+          // world entities, so saves only need the player's own state.
+          const payload = serializePlayer(world, playerEntityId > 0 ? playerEntityId : 1);
           postMessage({ type: 'SNAPSHOT_RESPONSE', payload });
         } catch (err) {
           postMessage({
@@ -1463,6 +1490,86 @@ self.onmessage = (event: MessageEvent): void => {
             payload: undefined,
             error: err instanceof Error ? err.message : String(err),
           });
+        }
+        break;
+      }
+
+      case 'RESTORE_PLAYER': {
+        if (!world) {
+          postMessage({
+            type: 'ENGINE_ERROR',
+            message: 'Cannot restore player: world not initialized',
+          });
+          break;
+        }
+
+        // ── Map-authoritative restore: apply the player snapshot onto the
+        // existing world (which was just rebuilt via LOAD_MAP). Does NOT
+        // clear entities or re-spawn zones — the map load already did that. ──
+        const wasRunning = running;
+        stopTickLoop();
+        try {
+          const payload = message.payload as string;
+          const eidMap = deserializeWorld(world, payload);
+
+          // The snapshot carries a single entity (the player). Take its
+          // restored data and merge it onto the live player entity.
+          let restoredEid: number | undefined;
+          for (const [, newEid] of eidMap) {
+            restoredEid = newEid;
+            break;
+          }
+
+          if (restoredEid === undefined) {
+            postMessage({ type: 'ENGINE_ERROR', message: 'RESTORE_PLAYER: empty snapshot' });
+            break;
+          }
+
+          if (playerEntityId > 0 && playerEntityId !== restoredEid) {
+            // Copy persistent components from the temp entity to the player,
+            // then discard the temp entity.
+            copyComponentSoA(Position, restoredEid, playerEntityId);
+            copyComponentSoA(Appearance, restoredEid, playerEntityId);
+            copyComponentSoA(CombatStats, restoredEid, playerEntityId);
+            copyComponentSoA(Visual, restoredEid, playerEntityId);
+            incrementEntityGeneration(restoredEid);
+            removeEntity(world, restoredEid);
+          } else {
+            // No player yet — adopt the restored entity as the player.
+            playerEntityId = restoredEid;
+            addComponent(world, restoredEid, CameraFocus);
+          }
+
+          // Snap the camera to the restored position and refresh the
+          // player's LPC textures immediately.
+          const px = Position.x[playerEntityId] ?? 0;
+          const py = Position.y[playerEntityId] ?? 0;
+          postMessage({ type: 'CAMERA_SNAP', x: px, y: py });
+
+          const playerLayers = getAppearanceLayers(playerEntityId);
+          if (playerLayers.length > 0) {
+            postMessage({
+              type: 'SYNC',
+              events: [
+                {
+                  type: 'APPEARANCE_CHANGED',
+                  eid: playerEntityId,
+                  layerIds: [...playerLayers],
+                },
+              ],
+            });
+          }
+
+          postMessage({ type: 'ENGINE_READY' });
+        } catch (err) {
+          postMessage({
+            type: 'ENGINE_ERROR',
+            message: `Restore player failed: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        } finally {
+          if (wasRunning) {
+            startTickLoop();
+          }
         }
         break;
       }
@@ -1652,16 +1759,22 @@ self.onmessage = (event: MessageEvent): void => {
             targetX,
             targetY,
             targetSpawnHash,
+            defaultSpawnHash,
             defeatedEnemies,
             collectedPickups,
             interactableStates,
             spawnPointEntities,
             disableClamping,
+            mapId,
           } = message;
 
           // ── C-172: Resolve spawn coordinates ──
-          // If a targetSpawnHash is provided, resolve it via a staging world.
-          // Otherwise fall back to targetX/targetY.
+          // Resolution chain (each step a fallback):
+          //   1. targetSpawnHash (portal's targetSpawnId, e.g. 'shop_entrance')
+          //   2. defaultSpawnHash (destination map's manifest defaultSpawnId)
+          //   3. targetX/targetY (hardcoded portal fallback)
+          // The walkability clamp below runs last and repositions onto
+          // walkable terrain if the resolved point is blocked.
           let resolvedX = targetX as number;
           let resolvedY = targetY as number;
 
@@ -1671,6 +1784,19 @@ self.onmessage = (event: MessageEvent): void => {
               targetSpawnHash,
             );
             if (resolved) {
+              resolvedX = resolved.x;
+              resolvedY = resolved.y;
+            }
+          } else if (typeof defaultSpawnHash === 'number' && defaultSpawnHash > 0) {
+            const resolved = _resolveSpawnInStaging(
+              spawnPointEntities as SpawnPointEntity[] | undefined,
+              defaultSpawnHash,
+            );
+            if (resolved) {
+              logger.debug(
+                'LOAD_MAP',
+                `fallback to defaultSpawnHash ${defaultSpawnHash} -> (${resolved.x},${resolved.y})`,
+              );
               resolvedX = resolved.x;
               resolvedY = resolved.y;
             }
@@ -1907,10 +2033,14 @@ self.onmessage = (event: MessageEvent): void => {
           }
 
           // ── C-194: Hydrate the new active zone ──
-          // Derive a zone entity ID from the map pixel dimensions
-          // (deterministic hash for the active sector).
+          // Derive a zone entity ID from the stable map id string so
+          // same-sized maps (inn vs merchant_shop, both 512×384) do not
+          // collide to the same zone entity.
           const newZoneEid =
-            ((mapPixelWidth as number) * 31 + (mapPixelHeight as number) * 17) & 0x7fffffff;
+            typeof mapId === 'string' && mapId.length > 0
+              ? djb2Hash(mapId) & 0x7fffffff || 1
+              : ((mapPixelWidth as number) * 31 + (mapPixelHeight as number) * 17) & 0x7fffffff ||
+                1;
           _activeZoneEntityId = newZoneEid;
           hydrateZone(world, newZoneEid, {
             zonePixelOriginX: 0,

--- a/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
+++ b/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
@@ -1,12 +1,10 @@
 // packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
 //
-// C-321: Verifies the IndexedDB-snapshot fallback used by WasmStorageAdapter
-// when OPFS is unavailable — an in-memory kvvfs DB whose full export is
-// snapshotted to a persistence backend (IndexedDB in production, a Map here)
-// so data survives close/reopen (i.e. page reloads).
-//
-// Also verifies the kvvfs xFileControl workaround: without it, PRAGMA
-// handling crashes because kvvfs.internal is undefined in production builds.
+// C-321: Verifies the IndexedDB whole-file snapshot fallback used by
+// WasmStorageAdapter when OPFS is unavailable — a :memory: DB whose full
+// byte image (sqlite3_js_db_export) is snapshotted to a persistence backend
+// (IndexedDB in production, a Map here) so data survives close/reopen
+// (i.e. page reloads), restored via sqlite3_deserialize.
 
 import { describe, expect, test } from 'bun:test';
 
@@ -20,68 +18,78 @@ const makeMemoryBackend = () => {
     set: async (key: string, value: unknown) => {
       map.set(key, value);
     },
-    peek: (key: string) => map.get(key),
   };
 };
 
-describe('WasmStorageAdapter IndexedDB-snapshot fallback', () => {
-  test('kvvfs xFileControl workaround + snapshot persists across close/reopen', async () => {
+describe('WasmStorageAdapter IndexedDB snapshot fallback', () => {
+  test('whole-file export/deserialize round-trip survives close/reopen', async () => {
     const backend = makeMemoryBackend();
     _setPersistenceBackendForTests(backend);
 
     const sqlite3Module = await import('@sqlite.org/sqlite-wasm');
     const sqlite3 = (await sqlite3Module.default()) as Record<string, unknown>;
     const oo1 = sqlite3['oo1'] as Record<string, unknown>;
-
-    // Simulate production: kvvfs.internal is undefined (kvvfs.log unset).
-    const kvvfs = sqlite3['kvvfs'] as {
-      internal?: object;
-      export(name: string): unknown;
-      import(exp: unknown, overwrite?: boolean): void;
-    };
-    delete kvvfs.internal;
-
-    const JsStorageDbCtor = oo1['JsStorageDb'] as {
+    const capi = sqlite3['capi'] as Record<string, unknown>;
+    const wasm = sqlite3['wasm'] as Record<string, unknown>;
+    const Db = oo1['DB'] as {
       new (
-        mode: string,
+        filename?: string,
+        flags?: string,
       ): {
+        pointer: number;
         exec(options: Record<string, unknown>): unknown;
+        transaction<T>(cb: () => T): T;
         close(): void;
+        isOpen(): boolean;
       };
     };
+    const exportFn = capi['sqlite3_js_db_export'] as (pDb: number) => Uint8Array;
+    const deserialize = capi['sqlite3_deserialize'] as (
+      pDb: number,
+      schema: string,
+      data: number,
+      dbSize: number,
+      bufferSize: number,
+      flags: number,
+    ) => number;
+    const allocFromTypedArray = wasm['allocFromTypedArray'] as (b: Uint8Array) => number;
 
-    // Without the workaround, PRAGMA handling crashes (browser: TypeError
-    // reading disablePageSizeChange; Bun: SQL logic error).
-    const dbBefore = new JsStorageDbCtor('.');
-    expect(() => dbBefore.exec({ sql: 'PRAGMA foreign_keys = ON' })).toThrow();
-    dbBefore.close();
-
-    // Apply the adapter's workaround — now everything works.
-    kvvfs.internal = { disablePageSizeChange: true };
-
-    // ── First session: write data, export snapshot, close ──
-    const db1 = new JsStorageDbCtor('.');
+    // ── First session: write data, snapshot, close ──
+    const db1 = new Db(':memory:', 'c');
     db1.exec({ sql: 'CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, val TEXT)' });
-    db1.exec({ sql: 'PRAGMA foreign_keys = ON' });
-    db1.exec({ sql: 'INSERT INTO t (val) VALUES (?)', bind: ['persisted!'] });
+    db1.transaction(() => {
+      for (let i = 0; i < 600; i++) {
+        db1.exec({ sql: 'INSERT INTO t (val) VALUES (?)', bind: [`value-${i}`] });
+      }
+    });
 
-    // Simulate the adapter's debounced snapshot write.
-    const snapshot = kvvfs.export('.') as unknown;
-    await backend.set('kvvfs-export', snapshot);
+    const bytes = exportFn(db1.pointer);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+    await backend.set('kvvfs-export', bytes);
     db1.close();
 
-    // ── Second session (page reload): import snapshot, reopen ──
-    const restored = (await backend.get('kvvfs-export')) as unknown;
-    kvvfs.import(restored, true);
-    const db2 = new JsStorageDbCtor('.');
+    // ── Second session (page reload): restore bytes, reopen ──
+    const restored = (await backend.get('kvvfs-export')) as Uint8Array;
+    const db2 = new Db(':memory:', 'c');
+    const pData = allocFromTypedArray(restored);
+    const rc = deserialize(
+      db2.pointer,
+      'main',
+      pData,
+      restored.byteLength,
+      restored.byteLength,
+      1 | 2, // FREEONCLOSE | RESIZEABLE
+    );
+    expect(rc).toBe(0);
+
     const rows: Record<string, unknown>[] = [];
     db2.exec({
-      sql: 'SELECT val FROM t',
+      sql: 'SELECT COUNT(*) AS c FROM t',
       returnValue: 'resultRows',
       resultRows: rows,
       rowMode: 'object',
     });
-    expect(rows).toEqual([{ val: 'persisted!' }]);
+    expect(rows).toEqual([{ c: 600 }]);
     db2.close();
 
     // Reset the backend to the real IndexedDB implementation for other tests.

--- a/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
+++ b/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
@@ -1,0 +1,77 @@
+// packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
+//
+// C-321: Verifies the localStorage-backed kvvfs (JsStorageDb) fallback used
+// by WasmStorageAdapter when OPFS is unavailable — data must survive
+// close/reopen (i.e. page reloads).
+
+import { describe, expect, test } from 'bun:test';
+
+// Minimal Storage-like mock so `globalThis.localStorage instanceof
+// globalThis.Storage` passes inside sqlite-wasm's storage-pool init.
+class MockStorage implements Storage {
+  private map = new Map<string, string>();
+  get length() {
+    return this.map.size;
+  }
+  clear() {
+    this.map.clear();
+  }
+  getItem(k: string) {
+    return this.map.get(k) ?? null;
+  }
+  key(i: number) {
+    return [...this.map.keys()][i] ?? null;
+  }
+  removeItem(k: string) {
+    this.map.delete(k);
+  }
+  setItem(k: string, v: string) {
+    this.map.set(k, v);
+  }
+}
+
+describe('JsStorageDb localStorage fallback (WasmStorageAdapter)', () => {
+  test('persists data across close/reopen via kvvfs', async () => {
+    const mockStorage = new MockStorage();
+    (globalThis as Record<string, unknown>).Storage = MockStorage;
+    (globalThis as Record<string, unknown>).localStorage = mockStorage;
+    (globalThis as Record<string, unknown>).sessionStorage = mockStorage;
+
+    const sqlite3Module = await import('@sqlite.org/sqlite-wasm');
+    const sqlite3 = await sqlite3Module.default();
+    const oo1 = sqlite3.oo1 as Record<string, unknown>;
+    const JsStorageDbCtor = oo1['JsStorageDb'] as {
+      new (
+        mode: 'local' | 'session',
+      ): {
+        exec(options: Record<string, unknown>): unknown;
+        close(): void;
+      };
+    };
+
+    expect(typeof JsStorageDbCtor).toBe('function');
+
+    // Open a localStorage-backed DB, write, close
+    const db1 = new JsStorageDbCtor('local');
+    db1.exec({ sql: 'CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, val TEXT)' });
+    db1.exec({ sql: 'INSERT INTO t (val) VALUES (?)', bind: ['persisted!'] });
+    db1.close();
+
+    // Reopen a NEW instance — data must still be there (persisted via kvvfs)
+    const db2 = new JsStorageDbCtor('local');
+    const rows: Record<string, unknown>[] = [];
+    db2.exec({
+      sql: 'SELECT val FROM t',
+      returnValue: 'resultRows',
+      resultRows: rows,
+      rowMode: 'object',
+    });
+    expect(rows).toEqual([{ val: 'persisted!' }]);
+    db2.close();
+
+    // Cleanup globals so other tests are unaffected
+    delete (globalThis as Record<string, unknown>).Storage;
+    delete (globalThis as Record<string, unknown>).localStorage;
+    delete (globalThis as Record<string, unknown>).sessionStorage;
+  });
+});

--- a/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
+++ b/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
@@ -1,88 +1,79 @@
 // packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
 //
-// C-321: Verifies the localStorage-backed kvvfs (JsStorageDb) fallback used
-// by WasmStorageAdapter when OPFS is unavailable — data must survive
-// close/reopen (i.e. page reloads), and the kvvfs xFileControl workaround
-// must prevent the production crash where kvvfs.internal is undefined.
+// C-321: Verifies the IndexedDB-snapshot fallback used by WasmStorageAdapter
+// when OPFS is unavailable — an in-memory kvvfs DB whose full export is
+// snapshotted to a persistence backend (IndexedDB in production, a Map here)
+// so data survives close/reopen (i.e. page reloads).
+//
+// Also verifies the kvvfs xFileControl workaround: without it, PRAGMA
+// handling crashes because kvvfs.internal is undefined in production builds.
 
 import { describe, expect, test } from 'bun:test';
 
-// Minimal Storage-like mock so `globalThis.localStorage instanceof
-// globalThis.Storage` passes inside sqlite-wasm's storage-pool init.
-class MockStorage implements Storage {
-  private map = new Map<string, string>();
-  get length() {
-    return this.map.size;
-  }
-  clear() {
-    this.map.clear();
-  }
-  getItem(k: string) {
-    return this.map.get(k) ?? null;
-  }
-  key(i: number) {
-    return [...this.map.keys()][i] ?? null;
-  }
-  removeItem(k: string) {
-    this.map.delete(k);
-  }
-  setItem(k: string, v: string) {
-    this.map.set(k, v);
-  }
-}
+import { _setPersistenceBackendForTests } from '../wasm_storage_adapter.ts';
 
-/** Mirrors the workaround in WasmStorageAdapter.open(). */
-const applyKvvfsWorkaround = (sqlite3: Record<string, unknown>): void => {
-  const kvvfs = sqlite3['kvvfs'] as { internal?: object } | undefined;
-  if (kvvfs && !kvvfs.internal) {
-    kvvfs.internal = { disablePageSizeChange: true };
-  }
+/** In-memory stand-in for IndexedDB. */
+const makeMemoryBackend = () => {
+  const map = new Map<string, unknown>();
+  return {
+    get: async (key: string) => map.get(key) ?? null,
+    set: async (key: string, value: unknown) => {
+      map.set(key, value);
+    },
+    peek: (key: string) => map.get(key),
+  };
 };
 
-describe('JsStorageDb localStorage fallback (WasmStorageAdapter)', () => {
-  test('survives the production kvvfs xFileControl bug + persists across close/reopen', async () => {
-    const mockStorage = new MockStorage();
-    (globalThis as Record<string, unknown>).Storage = MockStorage;
-    (globalThis as Record<string, unknown>).localStorage = mockStorage;
-    (globalThis as Record<string, unknown>).sessionStorage = mockStorage;
+describe('WasmStorageAdapter IndexedDB-snapshot fallback', () => {
+  test('kvvfs xFileControl workaround + snapshot persists across close/reopen', async () => {
+    const backend = makeMemoryBackend();
+    _setPersistenceBackendForTests(backend);
 
     const sqlite3Module = await import('@sqlite.org/sqlite-wasm');
     const sqlite3 = (await sqlite3Module.default()) as Record<string, unknown>;
     const oo1 = sqlite3['oo1'] as Record<string, unknown>;
 
-    // Simulate production: kvvfs.log is not set, so kvvfs.internal is
-    // undefined — this is what crashed xFileControl in the browser.
-    const kvvfs = sqlite3['kvvfs'] as { internal?: object };
+    // Simulate production: kvvfs.internal is undefined (kvvfs.log unset).
+    const kvvfs = sqlite3['kvvfs'] as {
+      internal?: object;
+      export(name: string): unknown;
+      import(exp: unknown, overwrite?: boolean): void;
+    };
     delete kvvfs.internal;
 
-    // Without the workaround, any prepare crashes:
     const JsStorageDbCtor = oo1['JsStorageDb'] as {
       new (
-        mode: 'local' | 'session',
+        mode: string,
       ): {
         exec(options: Record<string, unknown>): unknown;
         close(): void;
       };
     };
-    const dbBefore = new JsStorageDbCtor('local');
-    // PRAGMA statements trigger SQLITE_FCNTL_PRAGMA → xFileControl, which
-    // reads kvvfs.internal.disablePageSizeChange → TypeError in production.
-    // (Browser: TypeError reading disablePageSizeChange; Bun: SQL logic
-    // error — both are failures caused by the missing internal object.)
+
+    // Without the workaround, PRAGMA handling crashes (browser: TypeError
+    // reading disablePageSizeChange; Bun: SQL logic error).
+    const dbBefore = new JsStorageDbCtor('.');
     expect(() => dbBefore.exec({ sql: 'PRAGMA foreign_keys = ON' })).toThrow();
     dbBefore.close();
 
     // Apply the adapter's workaround — now everything works.
-    applyKvvfsWorkaround(sqlite3);
+    kvvfs.internal = { disablePageSizeChange: true };
 
-    const db1 = new JsStorageDbCtor('local');
+    // ── First session: write data, export snapshot, close ──
+    const db1 = new JsStorageDbCtor('.');
     db1.exec({ sql: 'CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, val TEXT)' });
     db1.exec({ sql: 'PRAGMA foreign_keys = ON' });
     db1.exec({ sql: 'INSERT INTO t (val) VALUES (?)', bind: ['persisted!'] });
+
+    // Simulate the adapter's debounced snapshot write.
+    const snapshot = kvvfs.export('.') as unknown;
+    await backend.set('kvvfs-export', snapshot);
     db1.close();
 
-    // Reopen a NEW instance — data must still be there (persisted via kvvfs)
-    const db2 = new JsStorageDbCtor('local');
+    // ── Second session (page reload): import snapshot, reopen ──
+    const restored = (await backend.get('kvvfs-export')) as unknown;
+    kvvfs.import(restored, true);
+    const db2 = new JsStorageDbCtor('.');
     const rows: Record<string, unknown>[] = [];
     db2.exec({
       sql: 'SELECT val FROM t',
@@ -93,9 +84,7 @@ describe('JsStorageDb localStorage fallback (WasmStorageAdapter)', () => {
     expect(rows).toEqual([{ val: 'persisted!' }]);
     db2.close();
 
-    // Cleanup globals so other tests are unaffected
-    delete (globalThis as Record<string, unknown>).Storage;
-    delete (globalThis as Record<string, unknown>).localStorage;
-    delete (globalThis as Record<string, unknown>).sessionStorage;
+    // Reset the backend to the real IndexedDB implementation for other tests.
+    _setPersistenceBackendForTests({ get: async () => null, set: async () => {} });
   });
 });

--- a/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
+++ b/packages/frontend/storage/src/lib/__tests__/jsstorage_fallback.test.ts
@@ -2,7 +2,8 @@
 //
 // C-321: Verifies the localStorage-backed kvvfs (JsStorageDb) fallback used
 // by WasmStorageAdapter when OPFS is unavailable — data must survive
-// close/reopen (i.e. page reloads).
+// close/reopen (i.e. page reloads), and the kvvfs xFileControl workaround
+// must prevent the production crash where kvvfs.internal is undefined.
 
 import { describe, expect, test } from 'bun:test';
 
@@ -30,16 +31,31 @@ class MockStorage implements Storage {
   }
 }
 
+/** Mirrors the workaround in WasmStorageAdapter.open(). */
+const applyKvvfsWorkaround = (sqlite3: Record<string, unknown>): void => {
+  const kvvfs = sqlite3['kvvfs'] as { internal?: object } | undefined;
+  if (kvvfs && !kvvfs.internal) {
+    kvvfs.internal = { disablePageSizeChange: true };
+  }
+};
+
 describe('JsStorageDb localStorage fallback (WasmStorageAdapter)', () => {
-  test('persists data across close/reopen via kvvfs', async () => {
+  test('survives the production kvvfs xFileControl bug + persists across close/reopen', async () => {
     const mockStorage = new MockStorage();
     (globalThis as Record<string, unknown>).Storage = MockStorage;
     (globalThis as Record<string, unknown>).localStorage = mockStorage;
     (globalThis as Record<string, unknown>).sessionStorage = mockStorage;
 
     const sqlite3Module = await import('@sqlite.org/sqlite-wasm');
-    const sqlite3 = await sqlite3Module.default();
-    const oo1 = sqlite3.oo1 as Record<string, unknown>;
+    const sqlite3 = (await sqlite3Module.default()) as Record<string, unknown>;
+    const oo1 = sqlite3['oo1'] as Record<string, unknown>;
+
+    // Simulate production: kvvfs.log is not set, so kvvfs.internal is
+    // undefined — this is what crashed xFileControl in the browser.
+    const kvvfs = sqlite3['kvvfs'] as { internal?: object };
+    delete kvvfs.internal;
+
+    // Without the workaround, any prepare crashes:
     const JsStorageDbCtor = oo1['JsStorageDb'] as {
       new (
         mode: 'local' | 'session',
@@ -48,12 +64,20 @@ describe('JsStorageDb localStorage fallback (WasmStorageAdapter)', () => {
         close(): void;
       };
     };
+    const dbBefore = new JsStorageDbCtor('local');
+    // PRAGMA statements trigger SQLITE_FCNTL_PRAGMA → xFileControl, which
+    // reads kvvfs.internal.disablePageSizeChange → TypeError in production.
+    // (Browser: TypeError reading disablePageSizeChange; Bun: SQL logic
+    // error — both are failures caused by the missing internal object.)
+    expect(() => dbBefore.exec({ sql: 'PRAGMA foreign_keys = ON' })).toThrow();
+    dbBefore.close();
 
-    expect(typeof JsStorageDbCtor).toBe('function');
+    // Apply the adapter's workaround — now everything works.
+    applyKvvfsWorkaround(sqlite3);
 
-    // Open a localStorage-backed DB, write, close
     const db1 = new JsStorageDbCtor('local');
     db1.exec({ sql: 'CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, val TEXT)' });
+    db1.exec({ sql: 'PRAGMA foreign_keys = ON' });
     db1.exec({ sql: 'INSERT INTO t (val) VALUES (?)', bind: ['persisted!'] });
     db1.close();
 

--- a/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
+++ b/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
@@ -7,10 +7,10 @@
 //
 // Persistence backends, in preference order:
 //   1. OPFS SAH pool VFS (main-thread OPFS) — preferred, no size limit.
-//   2. In-memory kvvfs + IndexedDB snapshot (C-321 fallback) — used when
-//      OPFS APIs are missing. The DB runs on the in-memory kvvfs storage
-//      (no localStorage quota) and the whole storage is exported to
-//      IndexedDB (debounced) after writes, then re-imported on open.
+//   2. In-memory DB + whole-file IndexedDB snapshot (C-321 fallback) — used
+//      when OPFS APIs are missing. A plain :memory: database is snapshotted
+//      as whole-file bytes (sqlite3_js_db_export) to IndexedDB (debounced)
+//      after writes, and restored via sqlite3_deserialize on open.
 //      IndexedDB quotas are ~10% of disk, so the asset registry + saves
 //      fit comfortably. localStorage was rejected as a fallback because
 //      its ~5MB quota overflows with the asset registry.
@@ -42,14 +42,6 @@ type WasmDatabase = {
   transaction<T>(callback: () => T): T;
   close(): void;
   isOpen(): boolean;
-};
-
-/** Shape of `sqlite3.kvvfs.export()` — persisted to IndexedDB. */
-type KvvfsExport = {
-  name: string;
-  timestamp: number;
-  size: number;
-  pages: Uint8Array[];
 };
 
 /** Async key/value persistence backend (IndexedDB in production). */
@@ -144,14 +136,11 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
   /** Whether the adapter has been closed. */
   private _closed = false;
 
-  /** sqlite3 module ref — needed for kvvfs export in snapshot mode. */
+  /** sqlite3 module ref — needed for DB export in snapshot mode. */
   private _sqlite3: unknown = null;
 
   /** Which persistence mode is active (set during open()). */
-  private _persistMode: 'opfs' | 'kvvfs-idb' | 'memory' = 'memory';
-
-  /** kvvfs storage name used in snapshot mode ('.' = in-memory pool). */
-  private readonly _kvvfsStorageName = '.';
+  private _persistMode: 'opfs' | 'idb-snapshot' | 'memory' = 'memory';
 
   /** Debounced persistence timer (snapshot mode). */
   private _persistTimer: ReturnType<typeof setTimeout> | undefined;
@@ -173,7 +162,7 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
    *
    * Dynamically imports @sqlite.org/sqlite-wasm and initialises the
    * WASM runtime. Persistence is OPFS-first, falling back to an
-   * in-memory kvvfs DB snapshotted to IndexedDB, then pure in-memory.
+   * in-memory DB snapshotted to IndexedDB, then pure in-memory.
    *
    * Must be called before any query/execute operations. Safe to call
    * multiple times — subsequent calls are no-ops.
@@ -256,35 +245,32 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
         );
       }
 
-      // ── 2. In-memory kvvfs + IndexedDB snapshot ──
-      // localStorage was rejected here: its ~5MB quota overflows with the
-      // asset registry. The in-memory kvvfs pool has no quota, and the full
-      // storage export is snapshotted to IndexedDB (debounced) so data
-      // survives page reloads.
+      // ── 2. In-memory DB + whole-file IndexedDB snapshot ──
+      // localStorage was rejected: its ~5MB quota overflows with the asset
+      // registry. The kvvfs export/import VFS was also rejected — it sorts
+      // page contents and loses the page-id mapping (SQLITE_CORRUPT after
+      // import in this sqlite-wasm version). Instead we run a plain
+      // :memory: database and snapshot the ENTIRE db file (sqlite3_js_db_
+      // export) to IndexedDB after writes, restoring via sqlite3_deserialize
+      // on open. IndexedDB quotas are ~10% of disk.
       if (!this._db) {
         try {
+          const DbCtor = oo1['DB'] as { new (filename?: string, flags?: string): WasmDatabase };
+          this._db = new DbCtor(':memory:', 'c');
+
           const saved = await _persistenceBackend.get(SNAPSHOT_KEY);
-          if (saved) {
-            // Import before opening the DB — the storage must be idle.
-            const kvvfsApi = (
-              sqlite3 as unknown as {
-                kvvfs?: { import(exp: unknown, overwrite?: boolean): void };
-              }
-            ).kvvfs;
-            kvvfsApi?.import(saved, true);
+          if (saved instanceof Uint8Array && saved.byteLength > 0) {
+            this._restoreSnapshotBytes(saved);
+            logger.debug('WasmStorageAdapter:restored-snapshot', {
+              bytes: saved.byteLength,
+            });
           }
 
-          const JsStorageDbCtor = oo1['JsStorageDb'] as
-            | { new (mode: string): WasmDatabase }
-            | undefined;
-          if (JsStorageDbCtor) {
-            this._db = new JsStorageDbCtor(this._kvvfsStorageName);
-            this._persistMode = 'kvvfs-idb';
-            logger.warn(
-              'WasmStorageAdapter: opened IndexedDB-snapshotted in-memory database — persists ' +
-                'across reloads via snapshots (no OPFS available).',
-            );
-          }
+          this._persistMode = 'idb-snapshot';
+          logger.warn(
+            'WasmStorageAdapter: opened in-memory database snapshotted to IndexedDB — persists ' +
+              'across reloads (no OPFS available).',
+          );
         } catch (error) {
           logger.warn(
             'WasmStorageAdapter: IndexedDB snapshot fallback failed — falling back to in-memory ' +
@@ -318,7 +304,7 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
       clearTimeout(this._persistTimer);
       this._persistTimer = undefined;
     }
-    if (this._persistMode === 'kvvfs-idb') {
+    if (this._persistMode === 'idb-snapshot') {
       await this._persistNow();
     }
 
@@ -426,7 +412,7 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
 
   /** Debounced persistence of the kvvfs storage to IndexedDB. */
   private _schedulePersist(): void {
-    if (this._persistMode !== 'kvvfs-idb') {
+    if (this._persistMode !== 'idb-snapshot') {
       return;
     }
     if (this._persistTimer) {
@@ -440,22 +426,62 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
 
   /** Exports the whole kvvfs storage and snapshots it to IndexedDB. */
   private async _persistNow(): Promise<void> {
-    if (this._persistMode !== 'kvvfs-idb' || !this._sqlite3) {
+    if (this._persistMode !== 'idb-snapshot' || !this._sqlite3) {
       return;
     }
     try {
-      const kvvfsApi = (
-        this._sqlite3 as unknown as { kvvfs?: { export(name: string): KvvfsExport } }
-      ).kvvfs;
-      if (!kvvfsApi) {
+      const capi = (this._sqlite3 as unknown as { capi?: Record<string, unknown> }).capi;
+      const db = this._db as unknown as { pointer: number };
+      const exportFn = capi?.['sqlite3_js_db_export'] as
+        | ((pDb: number, schema?: number) => Uint8Array)
+        | undefined;
+      if (!exportFn) {
         return;
       }
-      const snapshot = kvvfsApi.export(this._kvvfsStorageName);
-      await _persistenceBackend.set(SNAPSHOT_KEY, snapshot);
+      const bytes = exportFn(db.pointer);
+      await _persistenceBackend.set(SNAPSHOT_KEY, bytes);
     } catch (error) {
       logger.warn('WasmStorageAdapter:persist-snapshot-failed', {
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  /** Restores a whole-DB byte snapshot into the open :memory: database. */
+  private _restoreSnapshotBytes(bytes: Uint8Array): void {
+    if (!this._db || !this._sqlite3) {
+      return;
+    }
+    const capi = (this._sqlite3 as unknown as { capi?: Record<string, unknown> }).capi;
+    const wasm = (this._sqlite3 as unknown as { wasm?: Record<string, unknown> }).wasm;
+    const sqlite3 = this._sqlite3 as unknown as {
+      capi?: { SQLITE_DESERIALIZE_FREEONCLOSE?: number; SQLITE_DESERIALIZE_RESIZEABLE?: number };
+    };
+    const deserialize = capi?.['sqlite3_deserialize'] as
+      | ((
+          pDb: number,
+          schema: string,
+          data: number,
+          dbSize: number,
+          bufferSize: number,
+          flags: number,
+        ) => number)
+      | undefined;
+    const allocFromTypedArray = wasm?.['allocFromTypedArray'] as
+      | ((bytes: Uint8Array) => number)
+      | undefined;
+    if (!deserialize || !allocFromTypedArray) {
+      return;
+    }
+
+    const db = this._db as unknown as { pointer: number };
+    const pData = allocFromTypedArray(bytes);
+    const flags =
+      (sqlite3.capi?.SQLITE_DESERIALIZE_FREEONCLOSE ?? 1) |
+      (sqlite3.capi?.SQLITE_DESERIALIZE_RESIZEABLE ?? 2);
+    const rc = deserialize(db.pointer, 'main', pData, bytes.byteLength, bytes.byteLength, flags);
+    if (rc !== 0) {
+      logger.warn('WasmStorageAdapter:deserialize-failed', { rc });
     }
   }
 }

--- a/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
+++ b/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
@@ -128,26 +128,43 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
             logger.debug('WasmStorageAdapter:opened-opfs-sahpool', {
               databasePath: this._databasePath,
             });
-          } else {
-            logger.warn(
-              'WasmStorageAdapter: OPFS SAH pool installed but no OpfsSAHPoolDb — ' +
-                'falling back to in-memory database. Campaign data will NOT persist ' +
-                'across page reloads in this environment.',
-            );
           }
-        } else {
-          logger.warn(
-            'WasmStorageAdapter: OPFS SAH pool API unavailable — falling back to ' +
-              'in-memory database. Campaign data will NOT persist across page reloads.',
-          );
         }
       } catch (error) {
-        // OPFS not available (missing FileSystem APIs, sandboxed iframe, etc.)
+        // OPFS not available (missing FileSystem APIs, sandboxed iframe, no
+        // cross-origin isolation). Fall through to the persistent kvvfs
+        // fallback below instead of silently dropping to in-memory.
         logger.warn(
-          'WasmStorageAdapter: OPFS unavailable — falling back to in-memory database. ' +
-            'Campaign data will NOT persist across page reloads in this environment.',
+          'WasmStorageAdapter: OPFS unavailable — falling back to localStorage-backed database.',
           { error: error instanceof Error ? error.message : String(error) },
         );
+      }
+
+      // ── Persistent fallback: localStorage-backed kvvfs (JsStorageDb) ──
+      // OPFS is the preferred backend, but when it is unavailable the
+      // built-in kvvfs VFS persists SQLite pages in localStorage — which
+      // survives page reloads (quota-limited to ~5MB). Last resort is an
+      // in-memory database (no persistence across reloads).
+      if (!this._db) {
+        try {
+          const JsStorageDbCtor = oo1['JsStorageDb'] as
+            | { new (mode: 'local' | 'session'): WasmDatabase }
+            | undefined;
+          if (JsStorageDbCtor) {
+            this._db = new JsStorageDbCtor('local');
+            logger.warn(
+              'WasmStorageAdapter: opened localStorage-backed database — persists across ' +
+                'reloads but is quota-limited (~5MB). OPFS would be preferred.',
+            );
+          }
+        } catch (storageError) {
+          // localStorage kvvfs unavailable (private mode, storage disabled)
+          logger.warn(
+            'WasmStorageAdapter: localStorage kvvfs unavailable — falling back to ' +
+              'in-memory database. Campaign data will NOT persist across page reloads.',
+            { error: storageError instanceof Error ? storageError.message : String(storageError) },
+          );
+        }
       }
 
       if (!this._db) {

--- a/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
+++ b/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
@@ -148,6 +148,9 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
   /** Debounce delay — settable for tests (0 = immediate). */
   private readonly _persistDebounceMs: number;
 
+  /** pagehide handler — flushes pending snapshot on tab close/navigation. */
+  private _unloadFlush: (() => void) | undefined;
+
   constructor(options: { databasePath: string; persistDebounceMs?: number }) {
     this._databasePath = options.databasePath;
     this._persistDebounceMs = options.persistDebounceMs ?? 300;
@@ -271,6 +274,16 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
             'WasmStorageAdapter: opened in-memory database snapshotted to IndexedDB — persists ' +
               'across reloads (no OPFS available).',
           );
+
+          // ── Durability: the debounce is the only guarantee that a write
+          // reaches IndexedDB. Flush on pagehide (tab close / navigation /
+          // refresh) so a save followed by an immediate unload is not lost.
+          if (typeof window !== 'undefined') {
+            this._unloadFlush = () => {
+              void this._persistNow();
+            };
+            window.addEventListener('pagehide', this._unloadFlush);
+          }
         } catch (error) {
           logger.warn(
             'WasmStorageAdapter: IndexedDB snapshot fallback failed — falling back to in-memory ' +
@@ -303,6 +316,12 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
     if (this._persistTimer) {
       clearTimeout(this._persistTimer);
       this._persistTimer = undefined;
+    }
+    if (this._unloadFlush) {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('pagehide', this._unloadFlush);
+      }
+      this._unloadFlush = undefined;
     }
     if (this._persistMode === 'idb-snapshot') {
       await this._persistNow();

--- a/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
+++ b/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
@@ -91,6 +91,20 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
     // Initialise the WASM runtime
     const sqlite3 = await sqlite3Module.default();
 
+    // ── Workaround: @sqlite.org/sqlite-wasm only assigns kvvfs.internal
+    // when sqlite3.__isUnderTest is truthy, but kvvfs xFileControl ALWAYS
+    // reads kvvfs.internal.disablePageSizeChange. In production builds the
+    // internal object stays undefined, so ANY statement prepare on a
+    // localStorage-backed (kvvfs) database crashes with
+    // 'Cannot read properties of undefined (reading disablePageSizeChange)'.
+    // Provide the internal object explicitly so the kvvfs VFS works outside
+    // test mode (page-size changes are disabled — kvvfs uses a fixed page
+    // size internally).
+    const kvvfs = (sqlite3 as unknown as { kvvfs?: { internal?: object } }).kvvfs;
+    if (kvvfs && !kvvfs.internal) {
+      kvvfs.internal = { disablePageSizeChange: true };
+    }
+
     // Access oo1 API via bracket notation (library exports PascalCase names)
     const oo1 = sqlite3.oo1 as Record<string, unknown>;
 

--- a/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
+++ b/packages/frontend/storage/src/lib/wasm_storage_adapter.ts
@@ -5,6 +5,17 @@
 // persistence so campaign/save/chat data survives app restarts
 // in the browser without any network access.
 //
+// Persistence backends, in preference order:
+//   1. OPFS SAH pool VFS (main-thread OPFS) — preferred, no size limit.
+//   2. In-memory kvvfs + IndexedDB snapshot (C-321 fallback) — used when
+//      OPFS APIs are missing. The DB runs on the in-memory kvvfs storage
+//      (no localStorage quota) and the whole storage is exported to
+//      IndexedDB (debounced) after writes, then re-imported on open.
+//      IndexedDB quotas are ~10% of disk, so the asset registry + saves
+//      fit comfortably. localStorage was rejected as a fallback because
+//      its ~5MB quota overflows with the asset registry.
+//   3. Pure in-memory — last resort, no persistence across reloads.
+//
 // This adapter is dynamically imported at runtime — it never
 // inflates the initial bundle. The factory in local_database_factory.ts
 // selects this adapter when the native Tauri adapter is unavailable
@@ -33,14 +44,89 @@ type WasmDatabase = {
   isOpen(): boolean;
 };
 
+/** Shape of `sqlite3.kvvfs.export()` — persisted to IndexedDB. */
+type KvvfsExport = {
+  name: string;
+  timestamp: number;
+  size: number;
+  pages: Uint8Array[];
+};
+
+/** Async key/value persistence backend (IndexedDB in production). */
+type PersistenceBackend = {
+  get(key: string): Promise<unknown | null>;
+  set(key: string, value: unknown): Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// IndexedDB persistence backend
+// ---------------------------------------------------------------------------
+
+const IDB_NAME = 'aikami-local-db';
+const IDB_STORE = 'sqlite-snapshots';
+const SNAPSHOT_KEY = 'kvvfs-export';
+
+const _openIdb = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(IDB_STORE)) {
+        db.createObjectStore(IDB_STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('indexedDB open failed'));
+  });
+
+const _idbBackend: PersistenceBackend = {
+  async get(key) {
+    try {
+      const db = await _openIdb();
+      try {
+        return await new Promise<unknown | null>((resolve, reject) => {
+          const tx = db.transaction(IDB_STORE, 'readonly');
+          const req = tx.objectStore(IDB_STORE).get(key);
+          req.onsuccess = () => resolve((req.result as unknown) ?? null);
+          req.onerror = () => reject(req.error);
+        });
+      } finally {
+        db.close();
+      }
+    } catch {
+      return null; // IndexedDB unavailable — treat as no snapshot
+    }
+  },
+  async set(key, value) {
+    const db = await _openIdb();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(IDB_STORE, 'readwrite');
+        tx.objectStore(IDB_STORE).put(value, key);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      });
+    } finally {
+      db.close();
+    }
+  },
+};
+
+/** Swappable backend so unit tests can run without a real IndexedDB. */
+let _persistenceBackend: PersistenceBackend = _idbBackend;
+
+// biome-ignore lint/style/useNamingConvention: test hook
+export const _setPersistenceBackendForTests = (backend: PersistenceBackend): void => {
+  _persistenceBackend = backend;
+};
+
 // ---------------------------------------------------------------------------
 // WasmStorageAdapter
 // ---------------------------------------------------------------------------
 
 /**
  * Browser-side SQLite storage adapter backed by
- * {@link https://www.npmjs.com/package/@sqlite.org/sqlite-wasm | @sqlite.org/sqlite-wasm}
- * with OPFS persistence.
+ * {@link https://www.npmjs.com/package/@sqlite.org/sqlite-wasm | @sqlite.org/sqlite-wasm}.
  *
  * Implements {@link LocalDatabaseInterface}. Uses dynamic import so the
  * ~1 MB WASM bundle never inflates the initial JS chunk.
@@ -49,17 +135,33 @@ type WasmDatabase = {
  * {@link close} to release WASM resources.
  */
 export class WasmStorageAdapter implements LocalDatabaseInterface {
-  /** The underlying OPFS-backed SQLite database handle. */
+  /** The underlying SQLite database handle. */
   private _db: WasmDatabase | null = null;
 
-  /** Path to the database file within OPFS. */
+  /** Path to the database file within OPFS (or ':memory:' for tests). */
   private readonly _databasePath: string;
 
   /** Whether the adapter has been closed. */
   private _closed = false;
 
-  constructor(options: { databasePath: string }) {
+  /** sqlite3 module ref — needed for kvvfs export in snapshot mode. */
+  private _sqlite3: unknown = null;
+
+  /** Which persistence mode is active (set during open()). */
+  private _persistMode: 'opfs' | 'kvvfs-idb' | 'memory' = 'memory';
+
+  /** kvvfs storage name used in snapshot mode ('.' = in-memory pool). */
+  private readonly _kvvfsStorageName = '.';
+
+  /** Debounced persistence timer (snapshot mode). */
+  private _persistTimer: ReturnType<typeof setTimeout> | undefined;
+
+  /** Debounce delay — settable for tests (0 = immediate). */
+  private readonly _persistDebounceMs: number;
+
+  constructor(options: { databasePath: string; persistDebounceMs?: number }) {
     this._databasePath = options.databasePath;
+    this._persistDebounceMs = options.persistDebounceMs ?? 300;
   }
 
   // -------------------------------------------------------------------
@@ -67,11 +169,11 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
   // -------------------------------------------------------------------
 
   /**
-   * Opens the WASM SQLite database on OPFS.
+   * Opens the WASM SQLite database.
    *
    * Dynamically imports @sqlite.org/sqlite-wasm and initialises the
-   * WASM runtime. Requests persistent storage from the browser so
-   * OPFS data is not evicted under disk pressure.
+   * WASM runtime. Persistence is OPFS-first, falling back to an
+   * in-memory kvvfs DB snapshotted to IndexedDB, then pure in-memory.
    *
    * Must be called before any query/execute operations. Safe to call
    * multiple times — subsequent calls are no-ops.
@@ -90,16 +192,16 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
 
     // Initialise the WASM runtime
     const sqlite3 = await sqlite3Module.default();
+    this._sqlite3 = sqlite3;
 
     // ── Workaround: @sqlite.org/sqlite-wasm only assigns kvvfs.internal
     // when sqlite3.__isUnderTest is truthy, but kvvfs xFileControl ALWAYS
     // reads kvvfs.internal.disablePageSizeChange. In production builds the
-    // internal object stays undefined, so ANY statement prepare on a
-    // localStorage-backed (kvvfs) database crashes with
-    // 'Cannot read properties of undefined (reading disablePageSizeChange)'.
-    // Provide the internal object explicitly so the kvvfs VFS works outside
-    // test mode (page-size changes are disabled — kvvfs uses a fixed page
-    // size internally).
+    // internal object stays undefined, so ANY statement prepare on a kvvfs
+    // database crashes with 'Cannot read properties of undefined (reading
+    // disablePageSizeChange)'. Provide the internal object explicitly so
+    // the kvvfs VFS works outside test mode (page-size changes are disabled
+    // — kvvfs uses a fixed page size internally).
     const kvvfs = (sqlite3 as unknown as { kvvfs?: { internal?: object } }).kvvfs;
     if (kvvfs && !kvvfs.internal) {
       kvvfs.internal = { disablePageSizeChange: true };
@@ -108,22 +210,21 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
     // Access oo1 API via bracket notation (library exports PascalCase names)
     const oo1 = sqlite3.oo1 as Record<string, unknown>;
 
-    // ':memory:' special database — used for tests, no OPFS needed
+    // ':memory:' special database — used for tests, no persistence needed
     if (this._databasePath === ':memory:') {
       const DbCtor = oo1['DB'] as { new (filename?: string, flags?: string): WasmDatabase };
       this._db = new DbCtor(':memory:', 'c');
+      this._persistMode = 'memory';
     } else {
       // Request persistent storage — non-fatal if denied
       await this._requestPersistence();
 
-      // Main-thread OPFS persistence via the SAH pool VFS. This VFS is the
-      // only OPFS backend that works on the main thread — the classic
+      // ── 1. OPFS SAH pool VFS (preferred) ──
+      // The only OPFS backend that works on the main thread — the classic
       // sqlite3_vfs (OpfsDb) requires Atomics.wait() and can only run in a
       // Worker. The SAH pool must be installed first: the OpfsSAHPoolDb
       // constructor is exposed on the resolved pool utility, NOT on
-      // sqlite3.oo1. Checking oo1['OpfsSAHPoolDb'] directly (as older code
-      // did) always fails and silently drops to in-memory, losing all
-      // campaign/save/chat data on reload.
+      // sqlite3.oo1.
       try {
         const installOpfsSahPoolVfs = sqlite3['installOpfsSAHPoolVfs'] as
           | ((opts?: Record<string, unknown>) => Promise<{
@@ -139,6 +240,7 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
           const SahCtor = poolUtil?.OpfsSAHPoolDb;
           if (SahCtor) {
             this._db = new SahCtor(this._databasePath);
+            this._persistMode = 'opfs';
             logger.debug('WasmStorageAdapter:opened-opfs-sahpool', {
               databasePath: this._databasePath,
             });
@@ -146,44 +248,57 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
         }
       } catch (error) {
         // OPFS not available (missing FileSystem APIs, sandboxed iframe, no
-        // cross-origin isolation). Fall through to the persistent kvvfs
-        // fallback below instead of silently dropping to in-memory.
+        // cross-origin isolation). Fall through to the IndexedDB snapshot
+        // fallback below.
         logger.warn(
-          'WasmStorageAdapter: OPFS unavailable — falling back to localStorage-backed database.',
+          'WasmStorageAdapter: OPFS unavailable — falling back to IndexedDB-snapshotted database.',
           { error: error instanceof Error ? error.message : String(error) },
         );
       }
 
-      // ── Persistent fallback: localStorage-backed kvvfs (JsStorageDb) ──
-      // OPFS is the preferred backend, but when it is unavailable the
-      // built-in kvvfs VFS persists SQLite pages in localStorage — which
-      // survives page reloads (quota-limited to ~5MB). Last resort is an
-      // in-memory database (no persistence across reloads).
+      // ── 2. In-memory kvvfs + IndexedDB snapshot ──
+      // localStorage was rejected here: its ~5MB quota overflows with the
+      // asset registry. The in-memory kvvfs pool has no quota, and the full
+      // storage export is snapshotted to IndexedDB (debounced) so data
+      // survives page reloads.
       if (!this._db) {
         try {
+          const saved = await _persistenceBackend.get(SNAPSHOT_KEY);
+          if (saved) {
+            // Import before opening the DB — the storage must be idle.
+            const kvvfsApi = (
+              sqlite3 as unknown as {
+                kvvfs?: { import(exp: unknown, overwrite?: boolean): void };
+              }
+            ).kvvfs;
+            kvvfsApi?.import(saved, true);
+          }
+
           const JsStorageDbCtor = oo1['JsStorageDb'] as
-            | { new (mode: 'local' | 'session'): WasmDatabase }
+            | { new (mode: string): WasmDatabase }
             | undefined;
           if (JsStorageDbCtor) {
-            this._db = new JsStorageDbCtor('local');
+            this._db = new JsStorageDbCtor(this._kvvfsStorageName);
+            this._persistMode = 'kvvfs-idb';
             logger.warn(
-              'WasmStorageAdapter: opened localStorage-backed database — persists across ' +
-                'reloads but is quota-limited (~5MB). OPFS would be preferred.',
+              'WasmStorageAdapter: opened IndexedDB-snapshotted in-memory database — persists ' +
+                'across reloads via snapshots (no OPFS available).',
             );
           }
-        } catch (storageError) {
-          // localStorage kvvfs unavailable (private mode, storage disabled)
+        } catch (error) {
           logger.warn(
-            'WasmStorageAdapter: localStorage kvvfs unavailable — falling back to ' +
-              'in-memory database. Campaign data will NOT persist across page reloads.',
-            { error: storageError instanceof Error ? storageError.message : String(storageError) },
+            'WasmStorageAdapter: IndexedDB snapshot fallback failed — falling back to in-memory ' +
+              'database. Campaign data will NOT persist across page reloads.',
+            { error: error instanceof Error ? error.message : String(error) },
           );
         }
       }
 
+      // ── 3. Pure in-memory (last resort) ──
       if (!this._db) {
         const DbCtor = oo1['DB'] as { new (filename?: string, flags?: string): WasmDatabase };
         this._db = new DbCtor(':memory:', 'c');
+        this._persistMode = 'memory';
       }
     }
 
@@ -196,6 +311,15 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
   async close(): Promise<void> {
     if (this._closed) {
       return;
+    }
+
+    // Flush any pending snapshot before closing (snapshot mode).
+    if (this._persistTimer) {
+      clearTimeout(this._persistTimer);
+      this._persistTimer = undefined;
+    }
+    if (this._persistMode === 'kvvfs-idb') {
+      await this._persistNow();
     }
 
     if (this._db) {
@@ -234,6 +358,8 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
       sql: options.sql,
       bind: options.args as unknown[],
     });
+
+    this._schedulePersist();
   }
 
   /** @inheritdoc */
@@ -248,6 +374,8 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
         });
       }
     });
+
+    this._schedulePersist();
   }
 
   /** @inheritdoc */
@@ -295,6 +423,41 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
       // just without the persistence guarantee
     }
   }
+
+  /** Debounced persistence of the kvvfs storage to IndexedDB. */
+  private _schedulePersist(): void {
+    if (this._persistMode !== 'kvvfs-idb') {
+      return;
+    }
+    if (this._persistTimer) {
+      clearTimeout(this._persistTimer);
+    }
+    this._persistTimer = setTimeout(() => {
+      this._persistTimer = undefined;
+      void this._persistNow();
+    }, this._persistDebounceMs);
+  }
+
+  /** Exports the whole kvvfs storage and snapshots it to IndexedDB. */
+  private async _persistNow(): Promise<void> {
+    if (this._persistMode !== 'kvvfs-idb' || !this._sqlite3) {
+      return;
+    }
+    try {
+      const kvvfsApi = (
+        this._sqlite3 as unknown as { kvvfs?: { export(name: string): KvvfsExport } }
+      ).kvvfs;
+      if (!kvvfsApi) {
+        return;
+      }
+      const snapshot = kvvfsApi.export(this._kvvfsStorageName);
+      await _persistenceBackend.set(SNAPSHOT_KEY, snapshot);
+    } catch (error) {
+      logger.warn('WasmStorageAdapter:persist-snapshot-failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -304,14 +467,15 @@ export class WasmStorageAdapter implements LocalDatabaseInterface {
 /**
  * Creates and opens a {@link WasmStorageAdapter}.
  *
- * Initialises the WASM runtime and opens the OPFS-backed SQLite
- * database before returning the ready-to-use adapter.
+ * Initialises the WASM runtime and opens the database before returning
+ * the ready-to-use adapter.
  *
- * @param options - Database file name within OPFS.
+ * @param options - Database file name within OPFS, plus optional test overrides.
  * @returns A connected WasmStorageAdapter instance.
  */
 export const createWasmStorageAdapter = async (options: {
   databasePath: string;
+  persistDebounceMs?: number;
 }): Promise<WasmStorageAdapter> => {
   const adapter = new WasmStorageAdapter(options);
   await adapter.open();


### PR DESCRIPTION
## Problem

Two related persistence bugs reported in-game:

1. **Saves don't persist map + coordinates.** `mapName` was sourced from `worldStateService.currentLocation` — a worldgen *narrative* location never synced to the gameplay map (saves always recorded `'World'`). The ECS snapshot only held `Position/Appearance/CombatStats/Visual`, and Continue called `restoreWorld()` which never reloaded the tilemap, collision grid, or portals — portals were re-spawned from a worker variable (`_lastTransitionZones`) that is **empty after a page reload**.

2. **Portals don't sync.** Village→merchant spawned at hardcoded `(448,192)` (top-right, not the shop door); merchant→village spawned at the village gate `(320,576)` instead of where you entered. The C-172 `targetSpawnId` → `spawnHash` resolution machinery existed end-to-end but **no map used it** (`targetSpawnHash` was always 0).

## Changes

| Area | Change |
|---|---|
| **Map data** | `targetSpawnId` on all 4 Emberwatch transitions + `type:"spawn"` markers at door positions (`shop_entrance`, `inn_entrance` @ (256,344); `from_merchant` @ (64,336); `from_inn` @ (576,336); `village_gate` @ (320,560)) + manifest `defaultSpawnId` for inn/merchant_shop |
| **Spawn resolution** | Worker fallback chain: `targetSpawnHash` → manifest `defaultSpawnHash` → `targetX/targetY` → walkability clamp; `logger.warn` on unpaired portals |
| **Save envelope v3** | `map` block `{packId, mapId, playerX, playerY}` + version-aware checksum (v3 digest includes map; **v2 saves still load**) |
| **mapName** | From the manifest map entry ("Mara's Provisions"), not `currentLocation` |
| **Map-authoritative restore** | Continue now calls `loadMap(savedMap)` (tilemap, collision, NPCs, props, portals) then overlays the player snapshot; legacy v2 saves keep best-effort restore |
| **Player-scoped snapshots** | New `serializePlayer` + worker `RESTORE_PLAYER` (merges onto the live player, no world clear). `deserializeWorld` no longer registers every component on every entity — kills ghost combat-statted portals/props |
| **C-194 zone-id fix** | Zone entity derived from stable mapId hash — `inn` and `merchant_shop` (both 512×384) no longer collide to the same zone id |
| **Drive-by** | Fix pre-existing `_disposed` field reference in `GameWorld` (was blocking engine typecheck) |

## Verification

- ✅ Engine typecheck + **837 tests pass** (3 new: `serializePlayer` scope, round-trip, no-ghost-components)
- ✅ Client typecheck + emulator production build
- ✅ Portal round-trip resolution against real map data: village→shop lands at the door, shop→village lands back at the west portal; no spawn marker inside a trigger rect (no ping-pong)

## Manual test

1. Start dev client → walk into the merchant's glowing portal from the village → should appear at the shop door.
2. Walk back out → should reappear where you entered the village.
3. Pause-menu Save → refresh → Continue → should resume on the exact map + coordinates with portals intact.

## Note

The client unit-test harness (`game_save_service.test.ts` etc.) fails on **clean main** with pre-existing TDZ/timeout errors in the `@aikami/frontend/services` mock + Turso wasm — unrelated to these changes. The v3 envelope tests were updated to match the new format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Save games now preserve the current map, player position, spawn point, and interactable states.
  - Loading a save restores the player to the correct map and location without resetting the surrounding world.
  - Map transitions now place players at designated entrances, including Emberwatch’s village, inn, and merchant shop.
  - Checkpoints display the correct map name.

- **Bug Fixes**
  - Improved handling of map transitions and missing spawn data.
  - Existing version 2 saves remain compatible, while newer saves receive improved corruption detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->