### PR TITLE
feat(logging): unified log viewer + cross-origin client browser logs

### DIFF
--- a/.pi/extensions/log_viewer.ts
+++ b/.pi/extensions/log_viewer.ts
@@ -1,34 +1,42 @@
 // .pi/extensions/log_viewer.ts
-// Unified log viewer across all Aikami services.
+// Thin wrapper around `bun run scripts -- logs <app> [flags]`
+// (scripts/src/lib/ops/logs.ts) — the single source of truth for querying
+// Aikami service logs, driven by deployment_config.ts's APP_CONFIG.
 //
-// Routes by action:
-//   action=logs (default):
-//     cloud-run (client)       → scripts/ops/logs.ts → gcloud logging
-//     firebase-hosting       → scripts/ops/logs.ts → gcloud logging
-//     firebase-functions     → bun moon run functions:logs → firestack → gcloud
-//
-// Also delegates Firestore data queries to firestore_query tool.
+// This file deliberately does NOT duplicate app→serviceType mappings —
+// an earlier version hardcoded its own APP_CONFIG here and it drifted:
+// `client` was Cloud Run until 2026-07-29, `hub` (the real Cloud Run SSR
+// service) was added 2026-08-07, and this file's copy never caught up
+// with either change, silently routing `app=client` at a script that
+// never existed. All app resolution now lives in logs.ts; this extension
+// only passes args through and surfaces that script's own errors.
 //
 // Direnv env vars (set by .envrc) — always available:
-//   AIKAMI_MODE          — emulator | staging | production
-//   AIKAMI_PROJECT_ID    — GCP project id
+//   AIKAMI_MODE   — emulator | staging | production
+//   AIKAMI_ROOT   — repo root
 
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import { smartTruncate } from './lib/output_filter';
 
-const APP_CONFIG: Record<string, { serviceType: string }> = {
-  client: { serviceType: 'cloud-run' },
-  functions: { serviceType: 'firebase-functions' },
-  site: { serviceType: 'firebase-hosting' },
-};
-
-const APP_SERVICE_TYPES: Record<string, string> = Object.fromEntries(
-  Object.entries(APP_CONFIG).map(([key, config]) => [key, config.serviceType]),
-);
-
-const VALID_APPS = Object.keys(APP_SERVICE_TYPES);
+// Local list for the tool's enum/help text only — NOT used for validation
+// (logs.ts validates against the real APP_CONFIG and errors clearly on a
+// bad app id). Kept as a plain array rather than imported, same rationale
+// as gcloud_exec.ts's local MODE_PROJECT_MAP: .pi/extensions run outside
+// the moon project graph. Source of truth: scripts/src/lib/deploy/
+// deployment_config.ts's APP_CONFIG keys.
+const KNOWN_APPS = [
+  'client',
+  'client-tauri',
+  'site',
+  'hub',
+  'docs',
+  'firebase',
+  'image',
+  'text',
+  'voice',
+];
 
 export default function (pi: ExtensionAPI) {
   const DefaultTimeout = 180_000; // 3 min
@@ -37,166 +45,105 @@ export default function (pi: ExtensionAPI) {
     name: 'service_logs',
     label: 'Logs: View Service Logs',
     description:
-      'View logs for Aikami services. ' +
-      'Apps: client, site, functions. ' +
-      'Log actions: tail, line limits, time filters, function name filters. ' +
-      'For emulator Firestore data inspection, use firestore_query.',
+      'View logs for any Aikami service — Cloud Run, Firebase Functions, or client (a static ' +
+      'app with no server of its own; its browser logs are forwarded through hub and filtered ' +
+      `automatically). Apps: ${KNOWN_APPS.join(', ')}.`,
     promptSnippet:
-      'Use service_logs to view Cloud Run / Firebase logs. All logs are streamed to Cloud Run stdout — not stored in Firestore.',
+      'Use service_logs to view logs for any Aikami app. Supports --since, --severity, ' +
+      '--message, --filter (raw Cloud Logging expression), and --tail for live streaming.',
     promptGuidelines: [
-      "Use service_logs when user says 'the client crashed in dev' → app=client, mode=staging.",
-      "Use service_logs when user says 'check function logs for pollGmail' → app=functions, only=pollGmail.",
+      "Use service_logs when user says 'hub crashed in staging' → app=hub, mode=staging.",
+      "Use service_logs when user says 'check function logs for pollGmail' → app=firebase, only=pollGmail — firebase REQUIRES only, else it interleaves every function in the region.",
       "Use service_logs when user says 'tail the logs' → tail=true.",
-      'For functions, route via firestack (handles --only, --type, --since, --tail, --mode natively).',
-      'For Cloud Run (client) and Hosting (site), route via gcloud logging script.',
+      "Use service_logs when user says 'get logs from client where X' → app=client, message=X (or filter for a raw Cloud Logging filter expression).",
+      "client has no server of its own — its browser logs land in hub's Cloud Run stream, filtered to just client automatically. No extra params needed for that.",
+      'site/docs/client-tauri have no server-side logs at all (static hosting / desktop release) — service_logs will say so rather than returning anything.',
     ],
     parameters: Type.Object({
-      action: Type.Optional(
-        Type.String({
-          description: "Action: 'logs' (default) to view logs.",
-          enum: ['logs'],
-          default: 'logs',
-        }),
-      ),
-      app: Type.Optional(
-        Type.String({
-          description: `App to target: ${VALID_APPS.join(', ')}`,
-          enum: VALID_APPS,
-          default: 'functions',
-        }),
-      ),
+      app: Type.String({
+        description: `App to target: ${KNOWN_APPS.join(', ')}`,
+      }),
       mode: Type.Optional(
         Type.String({
-          description: 'Deployment mode',
-          enum: ['staging', 'production', 'emulator'],
+          description:
+            'Deployment mode — logs are only available for staging/production, not emulator.',
+          enum: ['staging', 'production'],
           default: 'staging',
         }),
       ),
-      lines: Type.Optional(
-        Type.Number({ description: 'Number of log lines (default 50)', default: 50 }),
-      ),
-      tail: Type.Optional(Type.Boolean({ description: 'Tail logs in real-time', default: false })),
-      since: Type.Optional(
-        Type.String({
-          description:
-            "Only show logs after this time, e.g. '1h', '30m', '10m'. Works for all apps.",
+      tail: Type.Optional(
+        Type.Boolean({
+          description: 'Stream logs live instead of a one-shot read.',
+          default: false,
         }),
+      ),
+      since: Type.Optional(
+        Type.String({ description: "Time window, e.g. '1h', '30m', '10m', '2d'." }),
+      ),
+      lines: Type.Optional(
+        Type.Number({ description: 'Max entries for a one-shot read (default 50).' }),
+      ),
+      severity: Type.Optional(
+        Type.String({ description: 'DEBUG|INFO|WARNING|ERROR|CRITICAL — filters severity>=this.' }),
       ),
       only: Type.Optional(
         Type.String({
-          description:
-            'Filter: function name for Firebase Functions, or service name for Cloud Run.',
+          description: 'Function name — required to scope `firebase` to one function.',
+        }),
+      ),
+      message: Type.Optional(
+        Type.String({ description: 'Substring match against the log message.' }),
+      ),
+      filter: Type.Optional(
+        Type.String({
+          description: 'Raw Cloud Logging filter fragment, ANDed onto the base filter.',
+        }),
+      ),
+      json: Type.Optional(
+        Type.Boolean({
+          description: 'Full structured JSON output instead of the compact default.',
+          default: false,
         }),
       ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
-      const app = params.app ?? 'functions';
-      // Resolve mode: explicit param > direnv env > "staging" default
-      const mode = params.mode ?? (process.env.AIKAMI_MODE as string | undefined) ?? 'staging';
-      const lines = params.lines ?? 50;
-      const serviceType = APP_SERVICE_TYPES[app];
-
-      // ── Logs action ──────────────────────────────────────────────────
-      if (!serviceType) {
-        return {
-          content: [{ type: 'text', text: `Unknown app: ${app}. Valid: ${VALID_APPS.join(', ')}` }],
-          details: { code: 1, source: 'unknown_app' },
-        };
+      const args = ['bun', 'run', 'scripts', '--', 'logs', params.app];
+      if (params.mode) {
+        args.push('--mode', params.mode);
+      }
+      if (params.tail) {
+        args.push('--tail');
+      }
+      if (params.since) {
+        args.push('--since', params.since);
+      }
+      if (params.lines) {
+        args.push('--lines', String(params.lines));
+      }
+      if (params.severity) {
+        args.push('--severity', params.severity);
+      }
+      if (params.only) {
+        args.push('--only', params.only);
+      }
+      if (params.message) {
+        args.push('--message', params.message);
+      }
+      if (params.filter) {
+        args.push('--filter', params.filter);
+      }
+      if (params.json) {
+        args.push('--json');
       }
 
-      if (serviceType === 'browser-extension') {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'Browser extension logs are not available server-side. Check Chrome DevTools → Console.',
-            },
-          ],
-          details: { code: 0, source: 'browser-extension' },
-        };
-      }
-
-      if (!process.env.AIKAMI_PROJECT_ID && mode !== 'emulator') {
-        return {
-          content: [
-            { type: 'text', text: `Unknown mode: ${mode} (AIKAMI_PROJECT_ID not set by direnv)` },
-          ],
-          details: { code: 1, source: 'unknown_mode' },
-        };
-      }
-
-      // ── Route by service type ──────────────────────────────────────────
-      const tail = params.tail ?? false;
-
-      if (serviceType === 'firebase-functions') {
-        // Route through firestack (moon run functions:logs → firestack logs).
-        // firestack handles gen2 Cloud Run service name mapping, --since, --tail, --only natively.
-        const args = [
-          'bun',
-          'moon',
-          'run',
-          'functions:logs',
-          '--',
-          '--mode',
-          mode,
-          '--lines',
-          String(lines),
-        ];
-        if (tail) {
-          args.push('--tail');
-        }
-        if (params.only) {
-          args.push('--only', params.only);
-        }
-        if (params.since) {
-          args.push('--since', params.since);
-        }
-
-        const result = await pi.exec('env', args, { signal, timeout: DefaultTimeout });
-        const raw = result.stdout || result.stderr || '';
-        return {
-          content: [{ type: 'text', text: smartTruncate(raw, 100) }],
-          details: { code: result.code, source: 'firebase-functions', tail },
-        };
-      }
-
-      // cloud-run + firebase-hosting → scripts:run (gcloud logging read/tail)
-      if (serviceType === 'cloud-run' || serviceType === 'firebase-hosting') {
-        const args = [
-          'bun',
-          'moon',
-          'run',
-          'scripts:run',
-          '--',
-          'logs',
-          app,
-          '--mode',
-          mode,
-          '--lines',
-          String(lines),
-        ];
-        if (tail) {
-          args.push('--tail');
-        }
-        if (params.only) {
-          args.push('--only', params.only);
-        }
-        if (params.since) {
-          args.push('--since', params.since);
-        }
-
-        const result = await pi.exec('env', args, { signal, timeout: DefaultTimeout });
-        const raw = result.stdout || result.stderr || '';
-        return {
-          content: [{ type: 'text', text: smartTruncate(raw, 100) }],
-          details: { code: result.code, source: serviceType, tail },
-        };
-      }
-
-      // Unreachable — all service types handled above
+      const result = await pi.exec('env', args, {
+        signal,
+        timeout: params.tail ? DefaultTimeout : 60_000,
+      });
+      const raw = result.stdout || result.stderr || '';
       return {
-        content: [{ type: 'text', text: `Log viewing not supported for: ${serviceType}` }],
-        details: { code: 1, source: 'unsupported' },
+        content: [{ type: 'text', text: smartTruncate(raw, 100) }],
+        details: { code: result.code, app: params.app, tail: params.tail ?? false },
       };
     },
   });

--- a/.pi/extensions/log_viewer.ts
+++ b/.pi/extensions/log_viewer.ts
@@ -107,10 +107,13 @@ export default function (pi: ExtensionAPI) {
       ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+      // Default undefined mode to 'staging' — logs are only available for
+      // staging/production, and the tool help declares staging as the default.
+      // Always pass --mode explicitly so logs.ts never falls back to the
+      // ambient AIKAMI_MODE (which may be 'emulator' in dev).
+      const mode = params.mode ?? 'staging';
       const args = ['bun', 'run', 'scripts', '--', 'logs', params.app];
-      if (params.mode) {
-        args.push('--mode', params.mode);
-      }
+      args.push('--mode', mode);
       if (params.tail) {
         args.push('--tail');
       }
@@ -139,8 +142,15 @@ export default function (pi: ExtensionAPI) {
       const result = await pi.exec('env', args, {
         signal,
         timeout: params.tail ? DefaultTimeout : 60_000,
+        // Run from the repo root (direnv's AIKAMI_ROOT) so `bun run scripts`
+        // resolves the workspace regardless of pi's current cwd.
+        cwd: process.env.AIKAMI_ROOT,
       });
-      const raw = result.stdout || result.stderr || '';
+      // Keep stderr diagnostics (gcloud writes progress/warnings there) and
+      // surface non-zero exits explicitly instead of returning them as log
+      // data.
+      const streams = [result.stdout, result.stderr].filter(Boolean).join('\n');
+      const raw = result.code === 0 ? streams : `Command failed (exit ${result.code}):\n${streams}`;
       return {
         content: [{ type: 'text', text: smartTruncate(raw, 100) }],
         details: { code: result.code, app: params.app, tail: params.tail ?? false },

--- a/.pi/skills/project-commands/SKILL.md
+++ b/.pi/skills/project-commands/SKILL.md
@@ -299,14 +299,41 @@ The root `package.json` provides shortcuts for common operations:
 
 ### Logging
 
-| Script                | Command                                        | Purpose            |
-| --------------------- | ---------------------------------------------- | ------------------ |
-| `logs:functions`      | `bun run scripts/ops/logs.ts functions`        | View function logs |
-| `logs:functions:tail` | `bun run scripts/ops/logs.ts functions --tail` | Tail function logs |
-| `logs:client`            | `bun run scripts/ops/logs.ts client`              | View Client logs      |
-| `logs:client:tail`       | `bun run scripts/ops/logs.ts client --tail`       | Tail Client logs      |
-| `logs:landing`        | `bun run scripts/ops/logs.ts landing`          | View landing logs  |
-| `logs:landing:tail`   | `bun run scripts/ops/logs.ts landing --tail`   | Tail landing logs  |
+Single source of truth for logs across every service — `scripts/src/lib/ops/logs.ts`,
+driven entirely by `deployment_config.ts`'s `APP_CONFIG` (no separate per-app scripts to
+keep in sync). Same command for manual use and for pi/agents (the `service_logs` tool in
+`.pi/extensions/log_viewer.ts` is a thin wrapper around it).
+
+```bash
+bun run scripts -- logs <app> [flags]
+```
+
+| App(s)                          | Behavior                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `hub`                             | Cloud Run SSR service — direct `gcloud logging read`/`tail`              |
+| `firebase`                        | Firebase Functions (gen2 = Cloud Run under the hood) — pass `--only <fn>` to scope to one function, else all functions in the region interleave |
+| `client`                          | Static Firebase Hosting, no server — transparently redirected to hub's log stream, filtered to `jsonPayload.app="client"` (its browser logger forwards there cross-origin) |
+| `site`, `docs`, `client-tauri`   | No server-side logs at all (static hosting / desktop release) — command says so |
+| `image`, `text`, `voice`          | Self-hosted GPU boxes, not on Cloud Run yet — command says so; once their `serviceType` moves to a Cloud Run type in `deployment_config.ts`, this picks them up automatically |
+
+| Flag                | Purpose                                                        |
+| -------------------- | --------------------------------------------------------------- |
+| `--mode`             | `staging` \| `production` (default: `$AIKAMI_MODE` or staging) |
+| `--tail`              | Stream live instead of a one-shot read                          |
+| `--since <dur>`       | e.g. `1h`, `30m`, `2d`                                          |
+| `--lines <n>`         | Max entries for a one-shot read (default 50)                    |
+| `--severity <lvl>`    | `DEBUG`\|`INFO`\|`WARNING`\|`ERROR`\|`CRITICAL` — filters `severity>=lvl` |
+| `--only <name>`       | Function name — required to scope `firebase` to one function    |
+| `--message <text>`    | Substring match against the log message                         |
+| `--filter <raw>`      | Raw Cloud Logging filter fragment, ANDed onto the base filter    |
+| `--json`              | Full structured JSON instead of the compact default              |
+
+```bash
+bun run scripts -- logs hub --mode staging --tail
+bun run scripts -- logs firebase --only pollGmail --since 1h
+bun run scripts -- logs client --mode production --severity ERROR
+bun run scripts -- logs client --filter 'jsonPayload.sessionId="abc-123"'
+```
 
 ### CI / Build
 

--- a/apps/frontend/client/.env.example
+++ b/apps/frontend/client/.env.example
@@ -14,6 +14,10 @@ PUBLIC_LOG_LEVEL=
 PUBLIC_LOG_PERSIST_LEVEL=
 PUBLIC_PARSE_LEVEL=safe
 PUBLIC_SITE_URL=
+# client is static Firebase Hosting with no server of its own — browser logs
+# forward cross-origin to hub's /api/internal_logging in staging/production.
+# Leave empty in emulator/dev (uses the relative-path dev sink instead).
+PUBLIC_LOG_ENDPOINT=
 
 # reCAPTCHA v3 (for Firebase App Check)
 # Get yours at: https://www.google.com/recaptcha/admin/create

--- a/apps/frontend/hub/src/hooks.server.ts
+++ b/apps/frontend/hub/src/hooks.server.ts
@@ -7,6 +7,8 @@ import {
   buildLogContext,
   detectDevice,
   getClientIp,
+  isAikamiWebOrigin,
+  isPathExcluded,
   manageSessionId,
   rewriteForwardedHost,
 } from '@aikami/backend/svelte-kit/hooks_helpers';
@@ -20,6 +22,15 @@ import { logContextStore } from '$loggerServer';
 import { toRoutePathFromRouteId, toRoutePathFromURL } from '$router';
 
 const allowExtensionCors = true;
+
+// The `client` app (Firebase Hosting, no server of its own) forwards its
+// browser logger's HTTP sink here cross-origin — see
+// packages/shared/logger/src/lib/logger_browser.ts and
+// apps/frontend/client's PUBLIC_LOG_ENDPOINT. Any first-party
+// *.bearlysleeping.com origin is allowed for this endpoint only (never a
+// wildcard, and no credentials — this route needs none). The origin check
+// lives in packages/backend/svelte-kit/src/lib/hooks_helpers.ts
+// (isAikamiWebOrigin), shared with tests.
 
 // App Check is enabled via the shared predicate in
 // packages/frontend/configs/environment.ts (isAppCheckEnabled) — the same
@@ -125,24 +136,32 @@ export const handle: Handle = async ({ event, resolve }) => {
     userId: userSession?.id,
   }) as LogContext;
 
-  // ── 7. API route: method guard + extension CORS ──
+  // ── 7. API route: method guard + extension/logging CORS ──
   if (pathname.startsWith('/api/')) {
     const method = request.method;
+    // Only /api/internal_logging gets the *.bearlysleeping.com allowance —
+    // scoped narrowly so other /api/ routes don't inherit broadened CORS.
+    const isLoggingEndpoint = isPathExcluded(pathname, appCheckExcludePaths);
 
-    if (allowExtensionCors && method === 'OPTIONS') {
+    if (method === 'OPTIONS' && (allowExtensionCors || isLoggingEndpoint)) {
       const origin = request.headers.get('origin');
-      // Only answer preflight for trusted extension origins — never fall
-      // back to a wildcard, and omit CORS headers for disallowed origins.
-      const isAllowedOrigin = origin?.startsWith('chrome-extension://') || origin === 'null';
+      // Only answer preflight for trusted origins — never fall back to a
+      // wildcard, and omit CORS headers for disallowed origins.
+      const isExtensionOrigin = origin?.startsWith('chrome-extension://') || origin === 'null';
+      const isLoggingOrigin = isLoggingEndpoint && isAikamiWebOrigin(origin);
       const preflightHeaders = new Headers();
-      if (origin && isAllowedOrigin) {
+      if (origin && (isExtensionOrigin || isLoggingOrigin)) {
         preflightHeaders.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
         preflightHeaders.set(
           'Access-Control-Allow-Headers',
           'Content-Type, Cookie, x-aikami-session',
         );
         preflightHeaders.set('Access-Control-Allow-Origin', origin);
-        preflightHeaders.set('Access-Control-Allow-Credentials', 'true');
+        // The logging endpoint needs no cookies/credentials — only grant
+        // Allow-Credentials for the extension case, which does.
+        if (isExtensionOrigin) {
+          preflightHeaders.set('Access-Control-Allow-Credentials', 'true');
+        }
       }
       return new Response(null, { status: 204, headers: preflightHeaders });
     }
@@ -156,10 +175,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     // Exclude /api/internal_logging only when the pathname is EXACTLY that
     // endpoint or begins with it followed by '/' — never a bare unbounded
     // startsWith() so similarly prefixed routes stay protected.
-    const isAppCheckExcluded = appCheckExcludePaths.some(
-      (excludedPath) => pathname === excludedPath || pathname.startsWith(`${excludedPath}/`),
-    );
-    if (enforceAppCheck && method !== 'OPTIONS' && !isAppCheckExcluded) {
+    if (enforceAppCheck && method !== 'OPTIONS' && !isLoggingEndpoint) {
       try {
         await verifyAppCheck(request);
       } catch {
@@ -169,13 +185,14 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     const response = await logContextStore.run(logContext, () => resolve(event));
 
-    // Attach CORS headers for extension origins
-    if (allowExtensionCors) {
-      const origin = request.headers.get('origin');
-      if (origin?.startsWith('chrome-extension://') || origin === 'null') {
-        response.headers.set('Access-Control-Allow-Origin', origin);
-        response.headers.set('Access-Control-Allow-Credentials', 'true');
-      }
+    // Attach CORS headers for extension origins and (logging endpoint only)
+    // first-party *.bearlysleeping.com origins.
+    const origin = request.headers.get('origin');
+    if (allowExtensionCors && (origin?.startsWith('chrome-extension://') || origin === 'null')) {
+      response.headers.set('Access-Control-Allow-Origin', origin);
+      response.headers.set('Access-Control-Allow-Credentials', 'true');
+    } else if (isLoggingEndpoint && isAikamiWebOrigin(origin)) {
+      response.headers.set('Access-Control-Allow-Origin', origin);
     }
 
     return response;

--- a/apps/frontend/hub/src/hooks.server.ts
+++ b/apps/frontend/hub/src/hooks.server.ts
@@ -52,6 +52,10 @@ logger.addSink(new SSRLogSink(logContextStore));
 // Eagerly trigger the lazy SSR logger to load BEFORE the first request.
 void logger.write({ logLevel: 'DEBUG', logType: 'debug', message: 'ssr-logger-init' });
 
+/**
+ * SvelteKit handleError hook: log the error with SSR context (session,
+ * user, IP, route) and return a safe error payload.
+ */
 export const handleError = (({ error, event }) => {
   const pwaError = error as App.Error | undefined;
   const sessionId =
@@ -210,6 +214,7 @@ export const handle: Handle = async ({ event, resolve }) => {
   return response;
 };
 
+/** Resolve the route path from the SvelteKit route id, falling back to the URL. */
 const resolveRoute = (event: Parameters<Handle>[0]['event']) => {
   const routeId = event.route.id;
   if (routeId) {

--- a/apps/frontend/hub/src/routes/api/internal_logging/+server.ts
+++ b/apps/frontend/hub/src/routes/api/internal_logging/+server.ts
@@ -54,6 +54,11 @@ const RATE_LIMIT_MAX = 120; // requests per window
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const _rateBuckets = new Map<string, { count: number; windowStart: number }>();
 
+/**
+ * In-memory fixed-window rate limiter keyed by client IP. Single-instance
+ * guard — production (Cloud Run) should layer edge rate limiting on top.
+ * Returns true when the key is over its window budget.
+ */
 const _rateLimited = (key: string): boolean => {
   const now = Date.now();
   const bucket = _rateBuckets.get(key);

--- a/apps/frontend/hub/src/routes/api/internal_logging/+server.ts
+++ b/apps/frontend/hub/src/routes/api/internal_logging/+server.ts
@@ -11,6 +11,8 @@
 // `/api/[...slugs]` Elysia catch-all. It is also excluded from App Check
 // enforcement in hooks.server.ts (appCheckExcludePaths) so log uploads
 // are never blocked by a missing token.
+
+import { sanitizeLogAppTag } from '@aikami/backend/svelte-kit/hooks_helpers';
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { logger } from '$logger';
 import { logContextStore } from '$loggerServer';
@@ -24,6 +26,11 @@ type LogEntryInput = {
 
 type InternalLogsBody = {
   label?: string;
+  /** Originating app id (PUBLIC_APP_ID), e.g. "hub" or "client" — see
+   *  packages/shared/logger/src/lib/logger_browser.ts. Distinguishes
+   *  hub's own browser-side logs from other apps forwarding here
+   *  cross-origin (e.g. client, which has no server of its own). */
+  app?: string;
   payload?: { batch?: LogEntryInput[] };
 };
 
@@ -135,6 +142,8 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
   if (!Array.isArray(batch)) {
     return json({ error: 'Invalid logs array' }, { status: 400 });
   }
+  // Cap length defensively — this is a public, App Check-excluded field.
+  const app = sanitizeLogAppTag((body as InternalLogsBody).app);
 
   // 4. Batch- and entry-size limits — all validated BEFORE emitEntry so
   //    nothing is emitted or counted for a rejected request.
@@ -157,7 +166,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
   try {
     const requestContext = logContextStore.getStore();
     let count = 0;
-    await logContextStore.run({ ...requestContext, source: 'client' }, () => {
+    await logContextStore.run({ ...requestContext, source: 'client', app }, () => {
       for (const entry of batch) {
         emitEntry(entry as LogEntryInput);
         count += 1;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ci": "bun run validate && bun run test",
     "scripts": "bun run scripts/src/index.ts",
     "setup": "bun run scripts/src/lib/setup/index.ts",
+    "setup:iam": "bun run scripts/src/lib/setup/iam.ts",
     "dev:all": "bun run scripts/src/lib/ops/dev_all.ts",
     "knowledge:sync": "bun run scripts/src/lib/ops/sync_contracts.ts && bun run scripts/src/lib/ops/generate_llms_txt.ts",
     "pre-commit": "bun run scripts/src/lib/ops/pre_commit.ts",

--- a/packages/backend/svelte-kit/src/lib/hooks_helpers.test.ts
+++ b/packages/backend/svelte-kit/src/lib/hooks_helpers.test.ts
@@ -1,0 +1,112 @@
+// packages/backend/svelte-kit/src/lib/hooks_helpers.test.ts
+//
+// Unit tests for the pure request/logging helpers extracted from
+// apps/frontend/hub — isPathExcluded, isAikamiWebOrigin (the
+// *.bearlysleeping.com CORS allowance for /api/internal_logging) and
+// sanitizeLogAppTag (the `app` tag cap for browser log ingestion).
+
+import { describe, expect, it } from 'bun:test';
+import { isAikamiWebOrigin, isPathExcluded, sanitizeLogAppTag } from './hooks_helpers.ts';
+
+describe('isPathExcluded', () => {
+  const excluded = ['/api/internal_logging'];
+
+  it('matches an exact excluded path', () => {
+    expect(isPathExcluded('/api/internal_logging', excluded)).toBe(true);
+  });
+
+  it('matches a path that starts with the excluded path followed by /', () => {
+    expect(isPathExcluded('/api/internal_logging/sub', excluded)).toBe(true);
+    expect(isPathExcluded('/api/internal_logging/deep/route', excluded)).toBe(true);
+  });
+
+  it('rejects bare prefix lookalikes (no trailing /)', () => {
+    expect(isPathExcluded('/api/internal_logging_extra', excluded)).toBe(false);
+    expect(isPathExcluded('/api/internal_loggings', excluded)).toBe(false);
+  });
+
+  it('rejects unrelated paths', () => {
+    expect(isPathExcluded('/api/auth/session', excluded)).toBe(false);
+    expect(isPathExcluded('/', excluded)).toBe(false);
+  });
+
+  it('handles an empty exclusion list', () => {
+    expect(isPathExcluded('/api/internal_logging', [])).toBe(false);
+  });
+});
+
+describe('isAikamiWebOrigin', () => {
+  it('accepts first-party https *.bearlysleeping.com origins', () => {
+    expect(isAikamiWebOrigin('https://aikami.bearlysleeping.com')).toBe(true);
+    expect(isAikamiWebOrigin('https://hub.stg.bearlysleeping.com')).toBe(true);
+    expect(isAikamiWebOrigin('https://hub.bearlysleeping.com')).toBe(true);
+    expect(isAikamiWebOrigin('https://a.b.c.bearlysleeping.com')).toBe(true);
+  });
+
+  it('accepts subdomains with digits and hyphens', () => {
+    expect(isAikamiWebOrigin('https://my-app-2.bearlysleeping.com')).toBe(true);
+  });
+
+  it('rejects non-bearlysleeping.com hosts', () => {
+    expect(isAikamiWebOrigin('https://evil.com')).toBe(false);
+    expect(isAikamiWebOrigin('https://bearlysleeping.com.evil.com')).toBe(false);
+    expect(isAikamiWebOrigin('https://notbearlysleeping.com')).toBe(false);
+  });
+
+  it('rejects non-https schemes', () => {
+    expect(isAikamiWebOrigin('http://aikami.bearlysleeping.com')).toBe(false);
+    expect(isAikamiWebOrigin('ws://aikami.bearlysleeping.com')).toBe(false);
+  });
+
+  it('rejects the bare apex domain (needs at least one subdomain label)', () => {
+    expect(isAikamiWebOrigin('https://bearlysleeping.com')).toBe(false);
+  });
+
+  it('rejects null, undefined and empty strings', () => {
+    expect(isAikamiWebOrigin(null)).toBe(false);
+    expect(isAikamiWebOrigin(undefined)).toBe(false);
+    expect(isAikamiWebOrigin('')).toBe(false);
+  });
+
+  it('rejects ports, paths and userinfo', () => {
+    expect(isAikamiWebOrigin('https://aikami.bearlysleeping.com:8443')).toBe(false);
+    expect(isAikamiWebOrigin('https://aikami.bearlysleeping.com/path')).toBe(false);
+    expect(isAikamiWebOrigin('https://user@aikami.bearlysleeping.com')).toBe(false);
+  });
+
+  it('acts as a type predicate: narrows the true branch to string', () => {
+    const origin: string | null | undefined = 'https://hub.stg.bearlysleeping.com';
+    if (isAikamiWebOrigin(origin)) {
+      // In this branch TS narrows origin to `string` — compile-time check.
+      expect(origin.startsWith('https://')).toBe(true);
+    }
+  });
+});
+
+describe('sanitizeLogAppTag', () => {
+  it('passes a valid short app id through unchanged', () => {
+    expect(sanitizeLogAppTag('client')).toBe('client');
+    expect(sanitizeLogAppTag('hub')).toBe('hub');
+  });
+
+  it('passes a 64-char tag through (boundary)', () => {
+    const tag = 'a'.repeat(64);
+    expect(sanitizeLogAppTag(tag)).toBe(tag);
+  });
+
+  it('returns undefined for an over-64-char tag', () => {
+    expect(sanitizeLogAppTag('a'.repeat(65))).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(sanitizeLogAppTag('')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string values', () => {
+    expect(sanitizeLogAppTag(null)).toBeUndefined();
+    expect(sanitizeLogAppTag(undefined)).toBeUndefined();
+    expect(sanitizeLogAppTag(42)).toBeUndefined();
+    expect(sanitizeLogAppTag({ app: 'client' })).toBeUndefined();
+    expect(sanitizeLogAppTag(['client'])).toBeUndefined();
+  });
+});

--- a/packages/backend/svelte-kit/src/lib/hooks_helpers.test.ts
+++ b/packages/backend/svelte-kit/src/lib/hooks_helpers.test.ts
@@ -89,6 +89,16 @@ describe('sanitizeLogAppTag', () => {
     expect(sanitizeLogAppTag('hub')).toBe('hub');
   });
 
+  it('trims surrounding whitespace before validating', () => {
+    expect(sanitizeLogAppTag('  client  ')).toBe('client');
+    expect(sanitizeLogAppTag('\tclient\n')).toBe('client');
+  });
+
+  it('returns undefined for whitespace-only input', () => {
+    expect(sanitizeLogAppTag('   ')).toBeUndefined();
+    expect(sanitizeLogAppTag('\t\n')).toBeUndefined();
+  });
+
   it('passes a 64-char tag through (boundary)', () => {
     const tag = 'a'.repeat(64);
     expect(sanitizeLogAppTag(tag)).toBe(tag);

--- a/packages/backend/svelte-kit/src/lib/hooks_helpers.ts
+++ b/packages/backend/svelte-kit/src/lib/hooks_helpers.ts
@@ -152,3 +152,40 @@ export const rewriteForwardedHost = (event: RequestEvent): RequestEvent => {
     request: new Request(originalUrl.toString(), event.request),
   };
 };
+
+// ── Log-ingestion / CORS helpers ─────────────────────────────────────────
+
+/**
+ * Matches a pathname against a list of excluded paths. A path matches when
+ * it is exactly an excluded path or starts with it followed by '/'
+ * (never a bare unbounded startsWith(), so similarly prefixed routes stay
+ * protected).
+ */
+export const isPathExcluded = (pathname: string, excludedPaths: string[]): boolean =>
+  excludedPaths.some(
+    (excludedPath) => pathname === excludedPath || pathname.startsWith(`${excludedPath}/`),
+  );
+
+/**
+ * Matches first-party web origins: `https://*.bearlysleeping.com`
+ * (e.g. https://aikami.bearlysleeping.com, https://hub.stg.bearlysleeping.com).
+ * HTTPS only — `http://` and cross-site lookalikes (evil.com,
+ * bearlysleeping.com.evil.com) fail.
+ */
+const aikamiWebOriginPattern = /^https:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*\.bearlysleeping\.com$/i;
+
+/**
+ * Whether an Origin header value is a trusted first-party Aikami web
+ * origin. Returns false for null/undefined/empty values. Doubles as a type
+ * predicate so callers get `origin: string` narrowed in the true branch.
+ */
+export const isAikamiWebOrigin = (origin: string | null | undefined): origin is string =>
+  !!origin && aikamiWebOriginPattern.test(origin);
+
+/**
+ * Sanitize the `app` tag from a browser-log-ingestion request body.
+ * Returns the trimmed tag when it is a non-empty string of at most 64
+ * characters, otherwise undefined (the tag is omitted entirely).
+ */
+export const sanitizeLogAppTag = (raw: unknown): string | undefined =>
+  typeof raw === 'string' && raw.length > 0 && raw.length <= 64 ? raw : undefined;

--- a/packages/backend/svelte-kit/src/lib/hooks_helpers.ts
+++ b/packages/backend/svelte-kit/src/lib/hooks_helpers.ts
@@ -184,8 +184,14 @@ export const isAikamiWebOrigin = (origin: string | null | undefined): origin is 
 
 /**
  * Sanitize the `app` tag from a browser-log-ingestion request body.
- * Returns the trimmed tag when it is a non-empty string of at most 64
- * characters, otherwise undefined (the tag is omitted entirely).
+ * Trims surrounding whitespace, then returns the tag when it is a non-empty
+ * string of at most 64 characters; otherwise (or for whitespace-only input)
+ * returns undefined (the tag is omitted entirely).
  */
-export const sanitizeLogAppTag = (raw: unknown): string | undefined =>
-  typeof raw === 'string' && raw.length > 0 && raw.length <= 64 ? raw : undefined;
+export const sanitizeLogAppTag = (raw: unknown): string | undefined => {
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 && trimmed.length <= 64 ? trimmed : undefined;
+};

--- a/packages/backend/svelte-kit/src/lib/log_sink.test.ts
+++ b/packages/backend/svelte-kit/src/lib/log_sink.test.ts
@@ -1,0 +1,162 @@
+// packages/backend/svelte-kit/src/lib/log_sink.test.ts
+//
+// Regression test for the staging pretty-print bug: SSRLogSink only wrote
+// single-line JSON (parseable by Cloud Logging into jsonPayload) when
+// AIKAMI_MODE === 'production'; staging pretty-printed multi-line JSON,
+// which Cloud Logging shreds into unfilterable textPayload lines. Both
+// deployed modes (staging AND production) must write exactly one line of
+// JSON.stringify(payload); local modes (unset/emulator/testing) keep the
+// human-readable pretty-print via console.log.
+//
+// Note: bun:test's spyOn reuses the same mock object when a property is
+// already mocked, so call counts accumulate across tests — every test
+// restores via mock.restore() in afterEach to get a fresh spy.
+
+// biome-ignore-all lint/style/useNamingConvention: syslog severity level names
+
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { LogEntry } from '@aikami/types';
+import { SSRLogSink } from './log_sink.ts';
+
+type TestContext = {
+  sessionId?: string;
+  userId?: string;
+  ip?: string;
+  route?: string;
+  userAgent?: string;
+  device?: unknown;
+  source?: string;
+  app?: string;
+};
+
+const store = new AsyncLocalStorage<TestContext>();
+
+// logLevel (syslog enum) → lowercase console logType.
+const LOG_TYPES: Record<string, LogEntry['logType']> = {
+  DEBUG: 'debug',
+  INFO: 'info',
+  NOTICE: 'log',
+  WARNING: 'warn',
+  ERROR: 'error',
+  CRITICAL: 'error',
+  ALERT: 'error',
+  EMERGENCY: 'error',
+  NONE: 'log',
+};
+
+const makeEntry = (logLevel: NonNullable<LogEntry['logLevel']>, message: string): LogEntry => ({
+  logLevel,
+  logType: LOG_TYPES[logLevel] ?? 'log',
+  message,
+});
+
+afterEach(() => {
+  delete process.env.AIKAMI_MODE;
+  mock.restore();
+});
+
+describe('SSRLogSink deployed modes (single-line JSON)', () => {
+  for (const mode of ['staging', 'production'] as const) {
+    test(`AIKAMI_MODE=${mode}: writes exactly one line of JSON.stringify(payload) to stdout`, () => {
+      process.env.AIKAMI_MODE = mode;
+      const stdoutWrite = spyOn(process.stdout, 'write');
+      const stderrWrite = spyOn(process.stderr, 'write');
+      const consoleLog = spyOn(console, 'log');
+
+      const sink = new SSRLogSink(store);
+      sink.write(makeEntry('INFO', 'hello'));
+
+      expect(stdoutWrite).toHaveBeenCalledTimes(1);
+      expect(stderrWrite).not.toHaveBeenCalled();
+      expect(consoleLog).not.toHaveBeenCalled();
+
+      const raw = String(stdoutWrite.mock.calls[0][0]);
+      // Exactly one non-empty line — a single-line JSON doc + trailing newline.
+      const lines = raw.split('\n').filter((l) => l.length > 0);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).not.toContain('\n  '); // not pretty-printed
+
+      const payload = JSON.parse(lines[0]);
+      expect(payload.severity).toBe('INFO');
+      expect(payload.message).toBe('hello');
+      expect(payload.source).toBe('ssr');
+    });
+  }
+
+  test('AIKAMI_MODE=staging: ERROR entries go to stderr as single-line JSON', () => {
+    process.env.AIKAMI_MODE = 'staging';
+    const stdoutWrite = spyOn(process.stdout, 'write');
+    const stderrWrite = spyOn(process.stderr, 'write');
+
+    const sink = new SSRLogSink(store);
+    sink.write(makeEntry('ERROR', 'boom'));
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(stderrWrite).toHaveBeenCalledTimes(1);
+    const raw = String(stderrWrite.mock.calls[0][0]);
+    expect(raw.split('\n').filter((l) => l.length > 0)).toHaveLength(1);
+    expect(JSON.parse(raw).severity).toBe('ERROR');
+  });
+});
+
+describe('SSRLogSink local modes (pretty-print via console.log)', () => {
+  for (const mode of [undefined, 'emulator', 'testing'] as const) {
+    test(`AIKAMI_MODE=${String(mode)}: pretty-prints, never emits single-line JSON`, () => {
+      if (mode !== undefined) {
+        process.env.AIKAMI_MODE = mode;
+      }
+      const stdoutWrite = spyOn(process.stdout, 'write');
+      const consoleLog = spyOn(console, 'log');
+
+      const sink = new SSRLogSink(store);
+      sink.write(makeEntry('DEBUG', 'local'));
+
+      expect(consoleLog).toHaveBeenCalledTimes(1);
+      const raw = String(consoleLog.mock.calls[0][0]);
+      expect(raw).toContain('\n  '); // pretty-printed with indentation
+      const payload = JSON.parse(raw);
+      expect(payload.message).toBe('local');
+      expect(payload.severity).toBe('DEBUG');
+
+      // The sink itself must not emit single-line JSON payloads in local
+      // mode. (console.log may internally route through process.stdout.write,
+      // so assert on content, not call counts.)
+      const stdout = stdoutWrite.mock.calls.map((call) => String(call[0])).join('');
+      for (const line of stdout.split('\n')) {
+        expect(line.startsWith('{"severity"')).toBe(false);
+      }
+    });
+  }
+});
+
+describe('SSRLogSink context.app tagging', () => {
+  test('includes app in the payload when the store context has it', () => {
+    process.env.AIKAMI_MODE = 'production';
+    const stdoutWrite = spyOn(process.stdout, 'write');
+
+    const sink = new SSRLogSink(store);
+    store.run({ source: 'client', app: 'client' }, () => {
+      sink.write(makeEntry('INFO', 'browser log'));
+    });
+
+    const payload = JSON.parse(String(stdoutWrite.mock.calls[0][0]));
+    expect(payload.app).toBe('client');
+    expect(payload.source).toBe('client');
+  });
+
+  test('omits app (and other optional fields) when not in the store context', () => {
+    process.env.AIKAMI_MODE = 'production';
+    const stdoutWrite = spyOn(process.stdout, 'write');
+
+    const sink = new SSRLogSink(store);
+    store.run({ source: 'ssr' }, () => {
+      sink.write(makeEntry('INFO', 'no app'));
+    });
+
+    const payload = JSON.parse(String(stdoutWrite.mock.calls[0][0]));
+    expect(payload).not.toHaveProperty('app');
+    expect(payload).not.toHaveProperty('sessionId');
+    expect(payload).not.toHaveProperty('userId');
+  });
+});

--- a/packages/backend/svelte-kit/src/lib/log_sink.ts
+++ b/packages/backend/svelte-kit/src/lib/log_sink.ts
@@ -35,6 +35,7 @@ export class SSRLogSink implements LogSink {
       userAgent?: string;
       device?: unknown;
       source?: string;
+      app?: string;
     }>,
   ) {}
 
@@ -77,12 +78,22 @@ export class SSRLogSink implements LogSink {
       if (context?.userAgent) {
         payload.userAgent = context.userAgent;
       }
+      if (context?.app) {
+        payload.app = context.app;
+      }
       if (metadata.length > 0) {
         payload.metadata = metadata;
       }
 
-      const isProduction = process.env.AIKAMI_MODE === 'production';
-      if (isProduction) {
+      // Any mode actually deployed to Cloud Run (staging AND production)
+      // needs single-line JSON so Cloud Logging parses it into jsonPayload —
+      // pretty-printing would split it across many textPayload lines,
+      // making it unfilterable (`gcloud logging read`, this repo's own
+      // `bun run scripts -- logs`). Only true local runs (emulator/testing)
+      // get the human-readable pretty-print.
+      const isDeployed =
+        process.env.AIKAMI_MODE === 'staging' || process.env.AIKAMI_MODE === 'production';
+      if (isDeployed) {
         const stream =
           entryLevel === 'ERROR' || entryLevel === 'CRITICAL' ? process.stderr : process.stdout;
         stream.write(`${JSON.stringify(payload)}\n`);

--- a/packages/shared/logger/moon.yml
+++ b/packages/shared/logger/moon.yml
@@ -18,3 +18,20 @@ dependsOn:
   - 'constants'
   - 'types'
 
+fileGroups:
+  sources:
+    - 'src/**/*'
+  configs:
+    - 'package.json'
+    - 'tsconfig.json'
+    - 'moon.yml'
+
+tasks:
+  test:
+    command: 'bun run test'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+    options:
+      mergeArgs: 'replace'
+

--- a/packages/shared/logger/package.json
+++ b/packages/shared/logger/package.json
@@ -6,6 +6,7 @@
     "lint": "biome lint .",
     "format": "biome format .",
     "typecheck": "tsgo --noEmit",
+    "test": "bun test src/lib",
     "fix": "biome check --write . --error-on-warnings"
   },
   "devDependencies": {

--- a/packages/shared/logger/src/lib/logger_browser.test.ts
+++ b/packages/shared/logger/src/lib/logger_browser.test.ts
@@ -1,0 +1,128 @@
+// packages/shared/logger/src/lib/logger_browser.test.ts
+//
+// Unit tests for HttpLogSink (the browser logger's cross-origin HTTP
+// ingestion sink):
+//   - default endpoint is the relative /api/internal_logging when
+//     PUBLIC_LOG_ENDPOINT is unset
+//   - PUBLIC_LOG_ENDPOINT is honored when set (hub's custom domain for
+//     static hosts like `client`)
+//   - the POST body carries PUBLIC_APP_ID as `app` so hub can tag entries
+//
+// import.meta.env proxies process.env under Bun, so env vars are set before
+// constructing each sink instance (the endpoint is captured at
+// construction time — same as a Vite build replacing the literal).
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { HttpLogSink } from './logger_browser.ts';
+
+const DEFAULT_ENDPOINT = '/api/internal_logging';
+
+const fetchMock = mock((_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) =>
+  Promise.resolve(new Response('{"count":1,"success":true}')),
+);
+
+beforeEach(() => {
+  delete process.env.PUBLIC_LOG_ENDPOINT;
+  delete process.env.PUBLIC_APP_ID;
+  fetchMock.mockClear();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  delete process.env.PUBLIC_LOG_ENDPOINT;
+  delete process.env.PUBLIC_APP_ID;
+  // Restore the real global fetch so other tests aren't affected.
+  // (bun:test restores module state per file, but be explicit anyway.)
+});
+
+const writeAndFlush = (sink: HttpLogSink, message = 'test log') => {
+  sink.write({ logLevel: 'INFO', logType: 'info', message });
+  sink.flush();
+};
+
+describe('HttpLogSink endpoint resolution', () => {
+  test('defaults to the relative /api/internal_logging when PUBLIC_LOG_ENDPOINT is unset', () => {
+    const sink = new HttpLogSink();
+    writeAndFlush(sink);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(DEFAULT_ENDPOINT);
+  });
+
+  test('uses PUBLIC_LOG_ENDPOINT when set (cross-origin hub endpoint)', () => {
+    process.env.PUBLIC_LOG_ENDPOINT = 'https://hub.stg.bearlysleeping.com/api/internal_logging';
+    const sink = new HttpLogSink();
+    writeAndFlush(sink);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://hub.stg.bearlysleeping.com/api/internal_logging');
+  });
+
+  test('endpoint is captured at construction time (build-time replacement semantics)', () => {
+    const sinkA = new HttpLogSink();
+    process.env.PUBLIC_LOG_ENDPOINT = 'https://changed.example.com/api';
+    const sinkB = new HttpLogSink();
+
+    writeAndFlush(sinkA);
+    writeAndFlush(sinkB);
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(DEFAULT_ENDPOINT);
+    expect(String(fetchMock.mock.calls[1][0])).toBe('https://changed.example.com/api');
+  });
+});
+
+describe('HttpLogSink request payload', () => {
+  test('POSTs a JSON batch with label, app and payload.batch', () => {
+    process.env.PUBLIC_APP_ID = 'client';
+    const sink = new HttpLogSink();
+    sink.write({ logLevel: 'ERROR', logType: 'error', message: 'boom' });
+    sink.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(DEFAULT_ENDPOINT);
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>)?.['Content-Type']).toBe('application/json');
+
+    const body = JSON.parse(String(init?.body));
+    expect(body.label).toBe('logger');
+    expect(body.app).toBe('client');
+    expect(body.payload.batch).toHaveLength(1);
+    expect(body.payload.batch[0].message).toBe('boom');
+  });
+
+  test('omits the app field entirely when PUBLIC_APP_ID is unset', () => {
+    const sink = new HttpLogSink();
+    writeAndFlush(sink);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body).not.toHaveProperty('app');
+  });
+
+  test('batches multiple entries written before flush into one request', () => {
+    const sink = new HttpLogSink();
+    sink.write({ logLevel: 'INFO', logType: 'info', message: 'one' });
+    sink.write({ logLevel: 'WARNING', logType: 'warn', message: 'two' });
+    sink.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.payload.batch).toHaveLength(2);
+  });
+
+  test('drops render-spam entries matching the exclude pattern before flushing', () => {
+    const sink = new HttpLogSink();
+    sink.write({ logLevel: 'DEBUG', logType: 'debug', message: '00:12 [GameWorld] render' });
+    sink.flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('does not call fetch when flush is a no-op (empty buffer)', () => {
+    const sink = new HttpLogSink();
+    sink.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/logger/src/lib/logger_browser.ts
+++ b/packages/shared/logger/src/lib/logger_browser.ts
@@ -82,6 +82,11 @@ export class HttpLogSink implements LogSink {
   }
 }
 
+/**
+ * Browser logger service: BaseLoggerService + the HTTP sink, so every
+ * write also flushes toward /api/internal_logging (browser console
+ * included via the base implementation).
+ */
 class FrontendLoggerService extends BaseLoggerService implements FrontendLoggerInterface {
   private readonly _httpSink: HttpLogSink;
 
@@ -120,6 +125,10 @@ class FrontendLoggerService extends BaseLoggerService implements FrontendLoggerI
   }
 }
 
+/**
+ * Create a browser logger instance wired with the HTTP sink.
+ * Prefer the module-level {@link logger} singleton.
+ */
 export function createLogger(): LoggerInterface {
   return new FrontendLoggerService();
 }

--- a/packages/shared/logger/src/lib/logger_browser.ts
+++ b/packages/shared/logger/src/lib/logger_browser.ts
@@ -15,8 +15,12 @@ export type FrontendLoggerInterface = LoggerInterface;
  *
  * Entries matching the {@link _excludePattern} are silently dropped to
  * avoid flooding the endpoint with per-frame render logs.
+ *
+ * Exported for unit tests (packages/shared/logger/src/lib/logger_browser.test.ts)
+ * — reads PUBLIC_LOG_ENDPOINT / PUBLIC_APP_ID from import.meta.env at
+ * construction time.
  */
-class HttpLogSink implements LogSink {
+export class HttpLogSink implements LogSink {
   private _buffer: LogEntry[] = [];
   private _flushTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -36,7 +40,17 @@ class HttpLogSink implements LogSink {
     this._scheduleFlush();
   }
 
-  /** Flushes buffered log entries to /api/internal_logging immediately. */
+  /**
+   * Ingestion endpoint. Defaults to the relative same-origin route (works
+   * for hub, which serves its own /api/internal_logging). Apps with no
+   * server of their own (e.g. client, static Firebase Hosting) set
+   * PUBLIC_LOG_ENDPOINT to an absolute cross-origin URL — see hub's
+   * hooks.server.ts for the matching CORS allowance.
+   */
+  private readonly _endpoint: string =
+    (import.meta.env.PUBLIC_LOG_ENDPOINT as string | undefined) || '/api/internal_logging';
+
+  /** Flushes buffered log entries to the ingestion endpoint immediately. */
   flush(): void {
     if (this._flushTimer) {
       clearTimeout(this._flushTimer);
@@ -46,10 +60,11 @@ class HttpLogSink implements LogSink {
       return;
     }
     const batch = this._buffer.splice(0);
-    void fetch('/api/internal_logging', {
+    const app = import.meta.env.PUBLIC_APP_ID as string | undefined;
+    void fetch(this._endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ label: 'logger', payload: { batch } }),
+      body: JSON.stringify({ label: 'logger', app, payload: { batch } }),
     }).catch(() => {
       // Server may not be running (dev) or route unavailable — silent fallback
     });

--- a/packages/shared/types/src/lib/common/logger.ts
+++ b/packages/shared/types/src/lib/common/logger.ts
@@ -166,6 +166,9 @@ export type LoggerInterface = {
  */
 export type LogContext = {
   source: 'client' | 'ssr' | 'functions';
+  /** Originating app id (e.g. "hub", "client") for entries forwarded through
+   *  another app's ingestion endpoint — see internal_logging's +server.ts. */
+  app?: string;
   userId?: string;
   companyId?: string;
   sessionId?: string;

--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -66,6 +66,7 @@ const EXCLUDED_FILES = new Set(['cli_utils.ts']);
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Recursively find script files (relative to `base`) under `dir`, excluding CLI plumbing. */
 async function findScripts(dir: string, base: string): Promise<string[]> {
   const scripts: string[] = [];
   const entries = await readdir(dir, { withFileTypes: true });
@@ -80,6 +81,7 @@ async function findScripts(dir: string, base: string): Promise<string[]> {
   return scripts.sort();
 }
 
+/** Run one resolved script as a child process, inheriting stdio, and exit with its code. */
 async function runScript(scriptRelPath: string, scriptArgs: string[]): Promise<void> {
   const absPath = join(SCRIPT_DIR, scriptRelPath);
   const file = Bun.file(absPath);
@@ -111,6 +113,7 @@ async function runScript(scriptRelPath: string, scriptArgs: string[]): Promise<v
   ok('Done');
 }
 
+/** Resolve a script name: SCRIPT_MAP short name first, then as a path relative to src/lib/. */
 function resolveScriptPath(nameOrPath: string): string {
   // Check short name map first
   if (SCRIPT_MAP[nameOrPath]) {
@@ -129,6 +132,7 @@ function resolveScriptPath(nameOrPath: string): string {
 // Interactive mode
 // ---------------------------------------------------------------------------
 
+/** Interactive picker: list available scripts and let the user choose one to run. */
 async function interactiveMode(): Promise<void> {
   const scripts = await findScripts(SCRIPT_DIR, SCRIPT_DIR);
 

--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -32,6 +32,7 @@ const SCRIPT_MAP: Record<string, string> = {
   cleanup: 'ops/cleanup_vendor_dirs.ts',
   validate_all: 'ops/validate_all.ts',
   validate: 'ops/validate_all.ts',
+  logs: 'ops/logs.ts',
 
   // Setup scripts
   setup: 'setup/index.ts',

--- a/scripts/src/lib/deploy/index.ts
+++ b/scripts/src/lib/deploy/index.ts
@@ -65,6 +65,7 @@ import { type AppResult, type NotificationInput, notifyDeployment } from './noti
 import { deployTauriRelease } from './tauri_release';
 import {
   authenticateDocker,
+  ensureGcloudAuth,
   getCurrentBranch,
   isVerbose,
   resolveProjectId,
@@ -323,12 +324,10 @@ async function main(): Promise<void> {
     }
   }
 
-  // Auth check
-  const authCheck = run('gcloud auth print-access-token', { quiet: true });
-  if (!authCheck) {
-    error('Not authenticated with gcloud. Run: gcloud auth login');
-    process.exit(1);
-  }
+  // Auth check — user credentials first, then fall back to the mode's
+  // service-account key (.secrets/gcp_sa_key.{mode}.json) so deploys work
+  // without an interactive `gcloud auth login`.
+  ensureGcloudAuth(mode, projectId, ROOT_DIR);
 
   authenticateDocker();
 

--- a/scripts/src/lib/deploy/index.ts
+++ b/scripts/src/lib/deploy/index.ts
@@ -109,6 +109,10 @@ const isCI = !!process.env.BUILD_ID || !!process.env.CI;
 
 let _autoYes = false;
 
+/**
+ * Prompt for a yes/no confirmation, honoring --yes (auto-yes) and
+ * defaulting to no on non-TTY input.
+ */
 async function confirm(msg: string): Promise<boolean> {
   if (_autoYes) {
     log(`${c.dim}(auto-yes)${c.reset} ${msg}`);
@@ -126,6 +130,10 @@ async function confirm(msg: string): Promise<boolean> {
 
 // ── Deploy Orchestrator ──────────────────────────────────────────────────
 
+/**
+ * Deploy one app end-to-end for the given mode: checksum cache check,
+ * build, package, push and deploy per its service type.
+ */
 async function deployApp(
   config: AppConfig,
   appName: string,
@@ -183,6 +191,10 @@ async function deployApp(
 
 // ── Main ─────────────────────────────────────────────────────────────────
 
+/**
+ * Deploy CLI entry: parse args, detect affected apps, authenticate, then
+ * run the deploy phases (build, push, deploy) for the requested apps.
+ */
 async function main(): Promise<void> {
   const rawArgs = Bun.argv.slice(2);
   // args[0] is 'deploy' if called via the scripts runner, or the first app name

--- a/scripts/src/lib/deploy/utils.ts
+++ b/scripts/src/lib/deploy/utils.ts
@@ -35,22 +35,33 @@ let _verbose = false;
 let _quiet = false;
 const _dockerAuthenticated = new Set<string>();
 
+/** Enable verbose shell output for subsequent run()/runArgs() calls. */
 export function setVerbose(v: boolean): void {
   _verbose = v;
 }
 
+/** Whether verbose shell output is enabled. */
 export function isVerbose(): boolean {
   return _verbose;
 }
 
+/** Suppress non-essential output for subsequent run()/runArgs() calls. */
 export function setQuiet(v: boolean): void {
   _quiet = v;
 }
 
+/** Whether quiet mode is enabled. */
 export function isQuiet(): boolean {
   return _quiet;
 }
 
+/**
+ * Run a shell command and return its trimmed stdout.
+ *
+ * verbose or live → inherit stdio (direct terminal output, streams in CI);
+ * quiet → pipe and suppress everything; default → pipe and show a command
+ * prefix. Throws when the command fails unless quiet.
+ */
 export function run(
   cmd: string,
   opts: { cwd?: string; quiet?: boolean; env?: Record<string, string>; live?: boolean } = {},
@@ -122,11 +133,16 @@ export function runArgs(
 
 // ── Git ──────────────────────────────────────────────────────────────────
 
+/** Return the current git branch name (defaults to 'dev' on failure). */
 export function getCurrentBranch(): string {
   const branch = run('git rev-parse --abbrev-ref HEAD', { quiet: true });
   return branch || 'dev';
 }
 
+/**
+ * Short git SHA of HEAD, suffixed with a dirty-tree hash when the working
+ * tree has uncommitted changes (ensures unique Docker tags).
+ */
 export function shortSha(length = 8): string {
   const sha = run(`git rev-parse --short=${length} HEAD`, { quiet: true });
   // Append dirty suffix when working tree has uncommitted changes.
@@ -138,6 +154,7 @@ export function shortSha(length = 8): string {
   return `${sha}-d${dirtyHash.slice(0, 8)}`;
 }
 
+/** Version string used to tag images: the short SHA plus dirty suffix. */
 export function versionSha(): string {
   return shortSha();
 }
@@ -158,10 +175,15 @@ export function dirtyTreeHash(): string {
 
 // ── GCP / Deploy ─────────────────────────────────────────────────────────
 
+/** Resolve the GCP project id for a deployment mode. */
 export function resolveProjectId(mode: string): string {
   return MODE_PROJECT_MAP[mode as keyof typeof MODE_PROJECT_MAP] || MODE_PROJECT_MAP.staging;
 }
 
+/**
+ * Fully-qualified Artifact Registry image tag for an app config:
+ * {region}-docker.pkg.dev/{projectId}/aikami/{shortName}:{tag}.
+ */
 export function dockerImageTag(
   config: AppConfig,
   projectId: string,
@@ -174,6 +196,7 @@ export function dockerImageTag(
   return `${region}-docker.pkg.dev/${projectId}/${imageName}:${tag}`;
 }
 
+/** Resolve the Cloud Run service id for an app config. */
 export function resolveCloudRunServiceName(config: AppConfig, appName: string): string {
   return resolveCloudRunServiceId(appName as never) || `aikami-${config.shortName}`;
 }

--- a/scripts/src/lib/deploy/utils.ts
+++ b/scripts/src/lib/deploy/utils.ts
@@ -5,7 +5,7 @@
 
 import { execSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { c, error, log } from '../cli_utils';
 import {
   type AppConfig,
@@ -187,6 +187,44 @@ export function authenticateDocker(region: string = GCP_REGION): void {
   }
   _dockerAuthenticated.add(region);
   run(`gcloud auth configure-docker ${region}-docker.pkg.dev --quiet`, { quiet: true });
+}
+
+/**
+ * Ensures gcloud is authenticated — user credentials first, then fall back
+ * to the mode's service-account key (.secrets/gcp_sa_key.{mode}.json) so
+ * deploys and log queries work in CI and for agents/pi without an
+ * interactive `gcloud auth login`.
+ *
+ * Exits the process when neither credential source is available or the
+ * service-account activation fails.
+ *
+ * @param mode      Deployment mode ('staging' | 'production') — selects the SA key file.
+ * @param projectId GCP project id — passed to activate-service-account.
+ * @param rootDir   Repo root — `.secrets/` lives at its top level.
+ */
+export function ensureGcloudAuth(mode: string, projectId: string, rootDir: string): void {
+  const authCheck = run('gcloud auth print-access-token', { quiet: true });
+  if (authCheck) {
+    return;
+  }
+  const saKeyPath = resolve(rootDir, `.secrets/gcp_sa_key.${mode}.json`);
+  if (!existsSync(saKeyPath)) {
+    error('Not authenticated with gcloud and no service-account fallback found.');
+    error('  Run: gcloud auth login');
+    error(`  Or place a key at: ${saKeyPath}`);
+    process.exit(1);
+  }
+  log(
+    `${c.yellow}No gcloud user credentials — activating service account from ${saKeyPath}${c.reset}`,
+  );
+  run(`gcloud auth activate-service-account --key-file="${saKeyPath}" --project=${projectId}`, {
+    quiet: true,
+  });
+  const retry = run('gcloud auth print-access-token', { quiet: true });
+  if (!retry) {
+    error(`Service account activation failed (${saKeyPath}). Run: gcloud auth login`);
+    process.exit(1);
+  }
 }
 
 /**

--- a/scripts/src/lib/ops/logs.test.ts
+++ b/scripts/src/lib/ops/logs.test.ts
@@ -6,12 +6,8 @@
 // plain objects).
 
 import { describe, expect, it } from 'bun:test';
-import { APP_CONFIG, CLOUD_FUNCTIONS_REGION } from '../deploy/deployment_config';
+import { CLOUD_FUNCTIONS_REGION } from '../deploy/deployment_config';
 import { buildFilter, resolveLogTarget } from './logs.ts';
-
-const hubConfig = APP_CONFIG.hub;
-const hubServiceName = hubConfig.cloudRunServiceId ?? `aikami-${hubConfig.shortName}`;
-const hubRegion = hubConfig.region ?? 'europe-west1';
 
 describe('buildFilter', () => {
   const base = {
@@ -62,6 +58,15 @@ describe('buildFilter', () => {
     expect(filter).toContain('jsonPayload.message:"say \\"hello\\""');
   });
 
+  it('escapes double quotes inside the service_name clause', () => {
+    const filter = buildFilter({ ...base, serviceName: 'a"b"c' }, {});
+    expect(filter).toContain('resource.labels.service_name="a\\"b\\"c"');
+  });
+
+  it('rejects an invalid severity level', () => {
+    expect(() => buildFilter(base, { severity: 'banana' })).toThrow(/Invalid --severity/);
+  });
+
   it('ANDs a raw --filter fragment onto the base', () => {
     const filter = buildFilter(base, { filter: 'logName=~"aikami-hub"' });
     expect(filter).toEndWith('AND logName=~"aikami-hub"');
@@ -92,9 +97,21 @@ describe('resolveLogTarget', () => {
       return;
     }
     expect(target.projectId).toBe('aikami-staging');
-    expect(target.region).toBe(hubRegion);
-    expect(target.serviceName).toBe(hubServiceName);
+    expect(target.region).toBe('europe-west4'); // hub's explicit region override
+    expect(target.serviceName).toBe('aikami-hub');
     expect(target.extraFilter).toBeUndefined();
+  });
+
+  it('production mode → production project, same hub service target', () => {
+    const target = resolveLogTarget('hub', 'production', undefined);
+    expect('unsupported' in target).toBe(false);
+    if ('unsupported' in target) {
+      return;
+    }
+    expect(target.projectId).toBe('aikami-production');
+    expect(target.projectId).not.toBe('aikami-staging');
+    expect(target.region).toBe('europe-west4');
+    expect(target.serviceName).toBe('aikami-hub');
   });
 
   it('firebase without --only → all functions in the region, with a hint note', () => {
@@ -124,8 +141,8 @@ describe('resolveLogTarget', () => {
     if ('unsupported' in target) {
       return;
     }
-    expect(target.serviceName).toBe(hubServiceName);
-    expect(target.region).toBe(hubRegion);
+    expect(target.serviceName).toBe('aikami-hub');
+    expect(target.region).toBe('europe-west4');
     expect(target.extraFilter).toBe('jsonPayload.app="client"');
     expect(target.note).toContain("forwarded through hub's /api/internal_logging");
   });

--- a/scripts/src/lib/ops/logs.test.ts
+++ b/scripts/src/lib/ops/logs.test.ts
@@ -1,0 +1,178 @@
+// scripts/src/lib/ops/logs.test.ts
+//
+// Unit tests for the pure functions in ops/logs.ts — buildFilter() and
+// resolveLogTarget(). No gcloud calls, no mocking: these functions are
+// pure (they only combine APP_CONFIG data and option flags into strings /
+// plain objects).
+
+import { describe, expect, it } from 'bun:test';
+import { APP_CONFIG, CLOUD_FUNCTIONS_REGION } from '../deploy/deployment_config';
+import { buildFilter, resolveLogTarget } from './logs.ts';
+
+const hubConfig = APP_CONFIG.hub;
+const hubServiceName = hubConfig.cloudRunServiceId ?? `aikami-${hubConfig.shortName}`;
+const hubRegion = hubConfig.region ?? 'europe-west1';
+
+describe('buildFilter', () => {
+  const base = {
+    projectId: 'aikami-staging',
+    region: 'europe-west1',
+    serviceName: 'aikami-hub',
+  };
+
+  it('builds the base filter with resource type, location and service name', () => {
+    const filter = buildFilter(base, {});
+    expect(filter).toBe(
+      'resource.type="cloud_run_revision" AND ' +
+        'resource.labels.location="europe-west1" AND ' +
+        'resource.labels.service_name="aikami-hub"',
+    );
+  });
+
+  it('omits the service_name clause when serviceName is empty', () => {
+    const filter = buildFilter({ ...base, serviceName: '' }, {});
+    expect(filter).toBe(
+      'resource.type="cloud_run_revision" AND resource.labels.location="europe-west1"',
+    );
+  });
+
+  it('appends the extraFilter (client redirect) after service_name', () => {
+    const filter = buildFilter({ ...base, extraFilter: 'jsonPayload.app="client"' }, {});
+    expect(filter).toBe(
+      'resource.type="cloud_run_revision" AND ' +
+        'resource.labels.location="europe-west1" AND ' +
+        'resource.labels.service_name="aikami-hub" AND ' +
+        'jsonPayload.app="client"',
+    );
+  });
+
+  it('appends severity>= when a severity is given, uppercased', () => {
+    const filter = buildFilter(base, { severity: 'warning' });
+    expect(filter).toContain('severity>=WARNING');
+    expect(filter).not.toContain('severity>=warning');
+  });
+
+  it('appends a quoted jsonPayload.message substring match', () => {
+    const filter = buildFilter(base, { message: 'pollGmail' });
+    expect(filter).toContain('jsonPayload.message:"pollGmail"');
+  });
+
+  it('escapes double quotes inside --message values', () => {
+    const filter = buildFilter(base, { message: 'say "hello"' });
+    expect(filter).toContain('jsonPayload.message:"say \\"hello\\""');
+  });
+
+  it('ANDs a raw --filter fragment onto the base', () => {
+    const filter = buildFilter(base, { filter: 'logName=~"aikami-hub"' });
+    expect(filter).toEndWith('AND logName=~"aikami-hub"');
+  });
+
+  it('combines severity, message and raw filter in one query', () => {
+    const filter = buildFilter(base, {
+      severity: 'ERROR',
+      message: 'boom',
+      filter: 'logName=~"aikami-hub"',
+    });
+    expect(filter).toBe(
+      'resource.type="cloud_run_revision" AND ' +
+        'resource.labels.location="europe-west1" AND ' +
+        'resource.labels.service_name="aikami-hub" AND ' +
+        'severity>=ERROR AND ' +
+        'jsonPayload.message:"boom" AND ' +
+        'logName=~"aikami-hub"',
+    );
+  });
+});
+
+describe('resolveLogTarget', () => {
+  it('hub → cloud-run-sveltekit with its Cloud Run service name and region', () => {
+    const target = resolveLogTarget('hub', 'staging', undefined);
+    expect('unsupported' in target).toBe(false);
+    if ('unsupported' in target) {
+      return;
+    }
+    expect(target.projectId).toBe('aikami-staging');
+    expect(target.region).toBe(hubRegion);
+    expect(target.serviceName).toBe(hubServiceName);
+    expect(target.extraFilter).toBeUndefined();
+  });
+
+  it('firebase without --only → all functions in the region, with a hint note', () => {
+    const target = resolveLogTarget('firebase', 'staging', undefined);
+    expect('unsupported' in target).toBe(false);
+    if ('unsupported' in target) {
+      return;
+    }
+    expect(target.region).toBe(CLOUD_FUNCTIONS_REGION);
+    expect(target.serviceName).toBe('');
+    expect(target.note).toContain('No --only');
+  });
+
+  it('firebase with --only → scoped to that one function', () => {
+    const target = resolveLogTarget('firebase', 'staging', 'pollGmail');
+    expect('unsupported' in target).toBe(false);
+    if ('unsupported' in target) {
+      return;
+    }
+    expect(target.serviceName).toBe('pollGmail');
+    expect(target.note).toBeUndefined();
+  });
+
+  it('client → redirects to hub stream with jsonPayload.app="client" extra filter', () => {
+    const target = resolveLogTarget('client', 'staging', undefined);
+    expect('unsupported' in target).toBe(false);
+    if ('unsupported' in target) {
+      return;
+    }
+    expect(target.serviceName).toBe(hubServiceName);
+    expect(target.region).toBe(hubRegion);
+    expect(target.extraFilter).toBe('jsonPayload.app="client"');
+    expect(target.note).toContain("forwarded through hub's /api/internal_logging");
+  });
+
+  it('site → unsupported (static hosting, no server-side logs)', () => {
+    const target = resolveLogTarget('site', 'staging', undefined);
+    expect('unsupported' in target).toBe(true);
+    if (!('unsupported' in target)) {
+      return;
+    }
+    expect(target.unsupported).toContain('static Firebase Hosting');
+  });
+
+  it('docs → unsupported (static hosting, no server-side logs)', () => {
+    const target = resolveLogTarget('docs', 'staging', undefined);
+    expect('unsupported' in target).toBe(true);
+    if (!('unsupported' in target)) {
+      return;
+    }
+    expect(target.unsupported).toContain('static Firebase Hosting');
+  });
+
+  it('client-tauri → unsupported (desktop release artifact)', () => {
+    const target = resolveLogTarget('client-tauri', 'staging', undefined);
+    expect('unsupported' in target).toBe(true);
+    if (!('unsupported' in target)) {
+      return;
+    }
+    expect(target.unsupported).toContain('desktop release');
+  });
+
+  it('image → unsupported (docker-release, self-hosted GPU infra)', () => {
+    const target = resolveLogTarget('image', 'staging', undefined);
+    expect('unsupported' in target).toBe(true);
+    if (!('unsupported' in target)) {
+      return;
+    }
+    expect(target.unsupported).toContain('self-hosted GPU');
+  });
+
+  it('text and voice → unsupported like image (docker-release)', () => {
+    for (const app of ['text', 'voice'] as const) {
+      const target = resolveLogTarget(app, 'production', undefined);
+      expect('unsupported' in target).toBe(true);
+      if ('unsupported' in target) {
+        expect(target.unsupported).toContain('self-hosted GPU');
+      }
+    }
+  });
+});

--- a/scripts/src/lib/ops/logs.ts
+++ b/scripts/src/lib/ops/logs.ts
@@ -44,6 +44,12 @@ export type LogTarget = {
   note?: string;
 };
 
+/**
+ * Resolve which Cloud Logging target an app maps to: Cloud Run services
+ * and Firebase Functions (gen2) both live under cloud_run_revision
+ * resources; `client` redirects to hub's stream with an app filter;
+ * static/desktop/docker-release apps return an unsupported message.
+ */
 export function resolveLogTarget(
   appId: AppId,
   mode: string,
@@ -110,6 +116,24 @@ export function resolveLogTarget(
 
 // ── Filter builder ───────────────────────────────────────────────────────
 
+/** Valid Cloud Logging severity levels for the severity>= filter. */
+const SEVERITY_LEVELS = [
+  'DEBUG',
+  'INFO',
+  'NOTICE',
+  'WARNING',
+  'ERROR',
+  'CRITICAL',
+  'ALERT',
+  'EMERGENCY',
+] as const;
+
+/**
+ * Build the Cloud Logging filter expression for a target and option set:
+ * base resource/location/service clauses, optional app extraFilter,
+ * validated severity>=, quoted jsonPayload.message substring (with quote
+ * escaping) and a raw filter fragment ANDed on.
+ */
 export function buildFilter(
   target: LogTarget,
   opts: { severity?: string; message?: string; filter?: string },
@@ -119,13 +143,21 @@ export function buildFilter(
     `resource.labels.location="${target.region}"`,
   ];
   if (target.serviceName) {
-    parts.push(`resource.labels.service_name="${target.serviceName}"`);
+    // Escape quotes like the message clause below — service ids come from
+    // APP_CONFIG but defensive escaping keeps the filter expression valid.
+    parts.push(`resource.labels.service_name="${target.serviceName.replace(/"/g, '\\"')}"`);
   }
   if (target.extraFilter) {
     parts.push(target.extraFilter);
   }
   if (opts.severity) {
-    parts.push(`severity>=${opts.severity.toUpperCase()}`);
+    const severity = opts.severity.toUpperCase();
+    if (!SEVERITY_LEVELS.includes(severity as (typeof SEVERITY_LEVELS)[number])) {
+      throw new Error(
+        `Invalid --severity "${opts.severity}". Valid values: ${SEVERITY_LEVELS.join(', ')}`,
+      );
+    }
+    parts.push(`severity>=${severity}`);
   }
   if (opts.message) {
     parts.push(`jsonPayload.message:"${opts.message.replace(/"/g, '\\"')}"`);
@@ -138,6 +170,7 @@ export function buildFilter(
 
 // ── Main ──────────────────────────────────────────────────────────────────
 
+/** Print the `logs <app>` CLI usage to stderr. */
 function printUsage(): void {
   error('Usage: logs <app> [flags]');
   error(`  app                Apps: ${VALID_APPS.join(', ')}`);
@@ -152,6 +185,11 @@ function printUsage(): void {
   error('  --json             Full structured JSON output instead of the compact default');
 }
 
+/**
+ * CLI entry: parse args, resolve the target for the requested app, ensure
+ * gcloud auth, then run a one-shot `gcloud logging read` or a live
+ * `gcloud logging tail`.
+ */
 async function main(): Promise<void> {
   const opts = parseCliArgs(process.argv.slice(2), {
     mode: { type: 'string', map: { prod: 'production', stg: 'staging' } },
@@ -202,7 +240,20 @@ async function main(): Promise<void> {
   );
 
   if (opts.tail) {
-    runArgs(['gcloud', 'logging', 'tail', filter, '--project', target.projectId], { live: true });
+    try {
+      runArgs(['gcloud', 'logging', 'tail', filter, '--project', target.projectId], {
+        live: true,
+      });
+    } catch (err) {
+      // `gcloud logging tail` needs the grpcio Python module; on machines
+      // without it the command fails immediately at startup. Give the user
+      // the fix instead of a bare "Command failed".
+      error('gcloud logging tail failed to start. It requires the grpcio Python module:');
+      error('  pip3 install grpcio');
+      error('  export CLOUDSDK_PYTHON_SITEPACKAGES=1');
+      error('(see https://cloud.google.com/sdk/docs/troubleshooting#grpcio)');
+      throw err;
+    }
     return;
   }
 

--- a/scripts/src/lib/ops/logs.ts
+++ b/scripts/src/lib/ops/logs.ts
@@ -1,0 +1,243 @@
+// scripts/src/lib/ops/logs.ts
+/**
+ * Unified log viewer — single source of truth for fetching logs across
+ * every Aikami service, driven entirely by deployment_config.ts's
+ * APP_CONFIG. Add a new Cloud Run service there (e.g. migrate image/text/
+ * voice off self-hosted GPU boxes) and it works here with zero changes.
+ *
+ * Used by:
+ *   - `bun run scripts -- logs <app> [flags]`   (manual CLI)
+ *   - .pi/extensions/log_viewer.ts              (pi/LLM tool call)
+ *
+ * Cloud Run-backed services (serviceType `cloud-run-sveltekit`) AND
+ * `firebase-functions` are queried the SAME way, via `gcloud logging
+ * read`/`tail` against `resource.type="cloud_run_revision"` — Firebase
+ * Functions gen2 ARE Cloud Run revisions under the hood, so one filter
+ * builder covers both instead of two tools with different flag support.
+ *
+ * `client` (Firebase Hosting, no server of its own) has no logs of its
+ * own — its browser logger forwards cross-origin into hub's
+ * /api/internal_logging (see packages/shared/logger/src/lib/
+ * logger_browser.ts and hub's hooks.server.ts), tagged
+ * `jsonPayload.app="client"`. This command transparently redirects
+ * `logs client` to hub's log stream with that filter applied.
+ */
+
+import { resolve } from 'node:path';
+import { c, error, log, parseCliArgs } from '../cli_utils';
+import { APP_CONFIG, CLOUD_FUNCTIONS_REGION } from '../deploy/deployment_config';
+import { ensureGcloudAuth, resolveProjectId, resolveRegion, runArgs } from '../deploy/utils';
+
+const ROOT_DIR = resolve(import.meta.dir, '../../../..');
+
+type AppId = keyof typeof APP_CONFIG;
+const VALID_APPS = Object.keys(APP_CONFIG) as AppId[];
+
+// ── Resolve target ───────────────────────────────────────────────────────
+
+export type LogTarget = {
+  projectId: string;
+  region: string;
+  /** Empty string = no service_name filter (all services in the region). */
+  serviceName: string;
+  extraFilter?: string;
+  note?: string;
+};
+
+export function resolveLogTarget(
+  appId: AppId,
+  mode: string,
+  only: string | undefined,
+): LogTarget | { unsupported: string } {
+  const config = APP_CONFIG[appId];
+  const projectId = resolveProjectId(mode);
+
+  switch (config.serviceType) {
+    case 'cloud-run-sveltekit': {
+      const region = resolveRegion(mode, config.region);
+      return {
+        projectId,
+        region,
+        serviceName: config.cloudRunServiceId ?? `aikami-${config.shortName}`,
+      };
+    }
+
+    case 'firebase-functions': {
+      if (!only) {
+        return {
+          projectId,
+          region: CLOUD_FUNCTIONS_REGION,
+          serviceName: '',
+          note: 'No --only <functionName> given — showing ALL functions in this region interleaved.',
+        };
+      }
+      return { projectId, region: CLOUD_FUNCTIONS_REGION, serviceName: only };
+    }
+
+    case 'firebase-hosting': {
+      // client has no server of its own — its browser logs are forwarded
+      // into hub's Cloud Run stream (see module doc comment above).
+      if (appId === 'client') {
+        const hub = APP_CONFIG.hub;
+        return {
+          projectId,
+          region: resolveRegion(mode, hub.region),
+          serviceName: hub.cloudRunServiceId ?? `aikami-${hub.shortName}`,
+          extraFilter: 'jsonPayload.app="client"',
+          note: "client is static hosting with no server — showing browser logs forwarded through hub's /api/internal_logging.",
+        };
+      }
+      return {
+        unsupported: `${appId} is static Firebase Hosting with no server-side logs. Check browser devtools — only 'client' forwards browser logs server-side today.`,
+      };
+    }
+
+    case 'tauri-release':
+      return { unsupported: `${appId} is a desktop release artifact — no server logs.` };
+
+    case 'docker-release':
+      return {
+        unsupported:
+          `${appId} runs on self-hosted GPU infrastructure (not Cloud Run) and isn't wired to ` +
+          'Cloud Logging yet. Once its serviceType in deployment_config.ts moves to a Cloud Run ' +
+          'type, this command picks it up automatically — no changes needed here.',
+      };
+
+    default:
+      return { unsupported: `Unknown service type for ${appId}: ${config.serviceType}` };
+  }
+}
+
+// ── Filter builder ───────────────────────────────────────────────────────
+
+export function buildFilter(
+  target: LogTarget,
+  opts: { severity?: string; message?: string; filter?: string },
+): string {
+  const parts = [
+    'resource.type="cloud_run_revision"',
+    `resource.labels.location="${target.region}"`,
+  ];
+  if (target.serviceName) {
+    parts.push(`resource.labels.service_name="${target.serviceName}"`);
+  }
+  if (target.extraFilter) {
+    parts.push(target.extraFilter);
+  }
+  if (opts.severity) {
+    parts.push(`severity>=${opts.severity.toUpperCase()}`);
+  }
+  if (opts.message) {
+    parts.push(`jsonPayload.message:"${opts.message.replace(/"/g, '\\"')}"`);
+  }
+  if (opts.filter) {
+    parts.push(opts.filter);
+  }
+  return parts.join(' AND ');
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+function printUsage(): void {
+  error('Usage: logs <app> [flags]');
+  error(`  app                Apps: ${VALID_APPS.join(', ')}`);
+  error('  --mode             staging | production (default: $AIKAMI_MODE or staging)');
+  error('  --tail             Stream logs live instead of a one-shot read');
+  error('  --since <dur>      e.g. 1h, 30m, 2d (maps to gcloud --freshness)');
+  error('  --lines <n>        Max entries for a one-shot read (default 50)');
+  error('  --severity <lvl>   DEBUG|INFO|WARNING|ERROR|CRITICAL — filters severity>=lvl');
+  error('  --only <name>      Required to scope `firebase` to one function');
+  error('  --message <text>   Substring match against jsonPayload.message');
+  error('  --filter <raw>     Raw Cloud Logging filter fragment, ANDed onto the base filter');
+  error('  --json             Full structured JSON output instead of the compact default');
+}
+
+async function main(): Promise<void> {
+  const opts = parseCliArgs(process.argv.slice(2), {
+    mode: { type: 'string', map: { prod: 'production', stg: 'staging' } },
+    tail: { type: 'boolean', aliases: ['t'] },
+    since: { type: 'string' },
+    lines: { type: 'string', aliases: ['n'] },
+    severity: { type: 'string', aliases: ['s'] },
+    only: { type: 'string' },
+    filter: { type: 'string', aliases: ['f'] },
+    message: { type: 'string' },
+    json: { type: 'boolean' },
+  });
+
+  const appId = opts._[0] as AppId | undefined;
+  if (!appId || !VALID_APPS.includes(appId)) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const mode = opts.mode ?? process.env.AIKAMI_MODE ?? 'staging';
+  if (mode !== 'staging' && mode !== 'production') {
+    error(
+      `Unsupported mode "${mode}" — logs are only available for staging/production (not emulator).`,
+    );
+    process.exit(1);
+  }
+
+  const target = resolveLogTarget(appId, mode, opts.only);
+  if ('unsupported' in target) {
+    error(target.unsupported);
+    process.exit(1);
+  }
+  if (target.note) {
+    log(`${c.dim}${target.note}${c.reset}`);
+  }
+
+  ensureGcloudAuth(mode, target.projectId, ROOT_DIR);
+
+  const filter = buildFilter(target, {
+    severity: opts.severity,
+    message: opts.message,
+    filter: opts.filter,
+  });
+
+  log(
+    `${c.dim}project: ${target.projectId} · region: ${target.region}` +
+      `${target.serviceName ? ` · service: ${target.serviceName}` : ' · service: (all)'}${c.reset}`,
+  );
+
+  if (opts.tail) {
+    runArgs(['gcloud', 'logging', 'tail', filter, '--project', target.projectId], { live: true });
+    return;
+  }
+
+  const format = opts.json
+    ? 'json'
+    : 'value(timestamp, severity, jsonPayload.message, textPayload)';
+  const args = [
+    'gcloud',
+    'logging',
+    'read',
+    filter,
+    '--project',
+    target.projectId,
+    '--limit',
+    opts.lines ?? '50',
+    '--order',
+    'desc',
+    '--format',
+    format,
+  ];
+  if (opts.since) {
+    args.push('--freshness', opts.since);
+  }
+  runArgs(args, { live: true });
+}
+
+// ── Entry ────────────────────────────────────────────────────────────────
+
+// Guarded so tests can import the pure functions (buildFilter,
+// resolveLogTarget) without triggering the CLI. When run via
+// `bun run scripts -- logs ...` (or directly with `bun run logs.ts`), this
+// file IS the entry point and import.meta.main is true.
+if (import.meta.main) {
+  main().catch((err) => {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/src/lib/setup/iam.ts
+++ b/scripts/src/lib/setup/iam.ts
@@ -1,22 +1,31 @@
 #!/usr/bin/env bun
 // scripts/src/lib/setup/iam.ts
 //
-// Grant IAM roles to the Aikami deploy service account
-// (firebase-adminsdk-fbsvc@aikami-{project}.iam.gserviceaccount.com).
+// Grant IAM roles to the Aikami deploy + runtime service accounts.
 //
-// The deploy pipeline (`bun run deploy`) authenticates as this SA — both
-// locally (via .secrets/gcp_sa_key.{mode}.json) and in CI (GCP_SA_KEY).
-// It needs permissions to push Docker images to Artifact Registry, deploy
-// Cloud Run services, Firebase Hosting/Functions, and read secrets.
+// Identity model (deploy-time vs runtime):
+//   - Deploy SA  — authenticates `bun run deploy` locally (via
+//     .secrets/gcp_sa_key.{mode}.json) and in CI (GCP_SA_KEY). Needs
+//     deployment permissions only.
+//   - Runtime SA — the identity Cloud Run runs AS (derived from
+//     FIREBASE_SERVICE_ACCOUNT's client_email in hub's .env.{mode}).
+//     Needs runtime permissions only (secret reads, log writes, Firebase
+//     Admin SDK).
 //
-// The same SA is also the Cloud Run *runtime* identity (see cloud_run.ts —
-// derived from FIREBASE_SERVICE_ACCOUNT), so the role list covers both
-// deploy-time and runtime needs.
+// Today both default to the same account
+// (firebase-adminsdk-fbsvc@<project>.iam.gserviceaccount.com) so the
+// current keys/CI secret keep working unchanged. To actually split them,
+// create a deployment-only SA key (e.g. --sa-id=aikami-deploy), save it
+// as .secrets/gcp_sa_key.{mode}.json + CI GCP_SA_KEY, and re-run this
+// script — deployment roles are granted only to the deploy SA, runtime
+// roles only to the runtime SA, and roles/iam.serviceAccountUser is
+// scoped to the runtime SA resource rather than the whole project.
 //
 // Usage:
 //   bun run scripts/src/lib/setup/iam.ts --mode=staging
 //   bun run scripts/src/lib/setup/iam.ts --mode=production --dry-run
-//   bun run scripts/src/lib/setup/iam.ts --mode=production --sa-id=custom-sa
+//   bun run scripts/src/lib/setup/iam.ts --mode=production --sa-id=custom-deploy-sa
+//   bun run scripts/src/lib/setup/iam.ts --mode=production --runtime-sa-id=custom-runtime-sa
 //
 // Caller must have `roles/resourcemanager.projectIamAdmin` (or project
 // owner) on the target project — run `gcloud auth login` first.
@@ -27,19 +36,16 @@ import { liveModes, MODE_PROJECT_MAP } from '../deploy/deployment_config';
 type Check = { name: string; status: 'ok' | 'missing' | 'error'; detail?: string; fixed?: boolean };
 
 /**
- * Roles required by the deploy pipeline + Cloud Run runtime.
- * See scripts/src/lib/deploy/*.ts for where each is exercised.
+ * Roles the deploy pipeline needs (Docker push, Cloud Run/Functions/
+ * Hosting deploys, storage). Granted to the DEPLOY service account on the
+ * project. See scripts/src/lib/deploy/*.ts for where each is exercised.
  */
-const REQUIRED_ROLES: Array<{ role: string; why: string }> = [
+const DEPLOY_ROLES: Array<{ role: string; why: string }> = [
   {
     role: 'roles/artifactregistry.writer',
     why: 'docker push/pull to Artifact Registry (hub, image, text, voice, client)',
   },
   { role: 'roles/run.developer', why: 'gcloud run deploy — deploy/update Cloud Run services' },
-  {
-    role: 'roles/iam.serviceAccountUser',
-    why: 'act as the runtime SA when deploying Cloud Run services',
-  },
   {
     role: 'roles/cloudfunctions.developer',
     why: 'deploy Firebase Functions (firestack, --deploy-engine gcloud)',
@@ -50,21 +56,40 @@ const REQUIRED_ROLES: Array<{ role: string; why: string }> = [
   },
   { role: 'roles/firebasehosting.admin', why: 'deploy Firebase Hosting sites (site, docs)' },
   {
-    role: 'roles/secretmanager.secretAccessor',
-    why: 'fetch secrets for Cloud Run --set-secrets + runtime secret reads',
-  },
-  { role: 'roles/logging.logWriter', why: 'Cloud Run runtime writes logs' },
-  {
     role: 'roles/storage.objectAdmin',
     why: 'Firebase Hosting/Functions staging buckets + asset uploads',
   },
+];
+
+/**
+ * Roles the Cloud Run RUNTIME needs (the identity deployed services run
+ * as). Granted to the RUNTIME service account on the project — kept
+ * deliberately smaller than the deploy role set.
+ */
+const RUNTIME_ROLES: Array<{ role: string; why: string }> = [
+  {
+    role: 'roles/secretmanager.secretAccessor',
+    why: 'runtime secret reads (Cloud Run --set-secrets values)',
+  },
+  { role: 'roles/logging.logWriter', why: 'Cloud Run runtime writes logs' },
   {
     role: 'roles/firebase.admin',
     why: 'Firebase Admin SDK permissions (token/session-cookie verification) — usually pre-granted',
   },
 ];
 
-const getMemberRoles = async (projectId: string, memberEmail: string): Promise<Set<string>> => {
+/**
+ * Impersonation role: lets the deploy SA act as the runtime SA when
+ * deploying Cloud Run services (gcloud run deploy --service-account).
+ * Scoped to the runtime SA resource instead of the whole project.
+ */
+const SERVICE_ACCOUNT_USER_ROLE = {
+  role: 'roles/iam.serviceAccountUser',
+  why: 'act as the runtime SA when deploying Cloud Run services',
+} as const;
+
+/** Project-level IAM bindings where `memberEmail` appears. */
+const getProjectRoles = async (projectId: string, memberEmail: string): Promise<Set<string>> => {
   const { out, code } = await run([
     'gcloud',
     'projects',
@@ -86,6 +111,37 @@ const getMemberRoles = async (projectId: string, memberEmail: string): Promise<S
   }
 };
 
+/** Roles granted ON a service account resource to `memberEmail`. */
+const getSaResourceRoles = async (
+  projectId: string,
+  resourceSa: string,
+  memberEmail: string,
+): Promise<Set<string>> => {
+  const { out, code } = await run([
+    'gcloud',
+    'iam',
+    'service-accounts',
+    'get-iam-policy',
+    resourceSa,
+    '--project',
+    projectId,
+    '--flatten=bindings[].members',
+    `--filter=bindings.members:${memberEmail}`,
+    '--format=json',
+    '--quiet',
+  ]);
+  if (code !== 0) {
+    return new Set();
+  }
+  try {
+    const policies = JSON.parse(out) as Array<{ bindings?: { role: string; members: string[] } }>;
+    return new Set(policies.flatMap((p) => (p.bindings?.role ? [p.bindings.role] : [])));
+  } catch {
+    return new Set();
+  }
+};
+
+/** Grant `role` to `memberEmail` on the whole project. */
 const addIamBinding = async (
   projectId: string,
   memberEmail: string,
@@ -103,16 +159,31 @@ const addIamBinding = async (
   return code === 0;
 };
 
-export const setupIam = async (
+/** Grant `role` to `memberEmail` on the `resourceSa` service account resource. */
+const addSaIamBinding = async (
   projectId: string,
-  saEmail: string,
-  dryRun: boolean,
-): Promise<{ checks: Check[] }> => {
-  const checks: Check[] = [];
+  resourceSa: string,
+  memberEmail: string,
+  role: string,
+): Promise<boolean> => {
+  const { code } = await run([
+    'gcloud',
+    'iam',
+    'service-accounts',
+    'add-iam-policy-binding',
+    resourceSa,
+    '--project',
+    projectId,
+    `--member=serviceAccount:${memberEmail}`,
+    `--role=${role}`,
+    '--quiet',
+  ]);
+  return code === 0;
+};
 
-  // ── Service account exists? ─────────────────────────────────────────
-  console.log(fmt.section('Deploy Service Account'));
-  const { code: saExists } = await run([
+/** Does the service account exist in the project? */
+const saExists = async (projectId: string, saEmail: string): Promise<boolean> => {
+  const { code } = await run([
     'gcloud',
     'iam',
     'service-accounts',
@@ -121,13 +192,51 @@ export const setupIam = async (
     `--project=${projectId}`,
     '--quiet',
   ]);
-  if (saExists !== 0) {
-    console.log(fmt.err(`Service account ${saEmail} not found in ${projectId}`));
-    checks.push({ name: `SA: ${saEmail}`, status: 'error' });
-    return { checks };
+  return code === 0;
+};
+
+type Grant = {
+  role: string;
+  why: string;
+  /** Who receives the role. */
+  member: string;
+  /** Where the grant is scoped. */
+  resource: 'project' | { serviceAccount: string };
+};
+
+/**
+ * Grant the deploy + runtime service accounts their IAM roles.
+ *
+ * Deploy roles go to {@link deploySaEmail} on the project; runtime roles
+ * go to {@link runtimeSaEmail} on the project; and
+ * roles/iam.serviceAccountUser is granted on the runtime SA resource
+ * (scoped) so the deploy SA can act as the runtime SA when deploying
+ * Cloud Run services. Defaults both identities to the same account to
+ * preserve the current single-key setup.
+ */
+export const setupIam = async (
+  projectId: string,
+  deploySaEmail: string,
+  dryRun: boolean,
+  runtimeSaEmail: string = deploySaEmail,
+): Promise<{ checks: Check[] }> => {
+  const checks: Check[] = [];
+
+  // ── Service accounts exist? ─────────────────────────────────────────
+  console.log(fmt.section('Service Accounts'));
+  for (const [label, email] of [
+    ['Deploy', deploySaEmail],
+    ['Runtime', runtimeSaEmail],
+  ] as const) {
+    if (await saExists(projectId, email)) {
+      console.log(fmt.ok(`${label}: ${c.bold}${email}${c.reset}`));
+      checks.push({ name: `SA (${label}): ${email}`, status: 'ok' });
+    } else {
+      console.log(fmt.err(`${label} service account ${email} not found in ${projectId}`));
+      checks.push({ name: `SA (${label}): ${email}`, status: 'error' });
+      return { checks };
+    }
   }
-  console.log(fmt.ok(`Service account ${c.bold}${saEmail}${c.reset}`));
-  checks.push({ name: `SA: ${saEmail}`, status: 'ok' });
 
   // ── Caller permission check ─────────────────────────────────────────
   const { code: policyCode } = await run([
@@ -151,28 +260,62 @@ export const setupIam = async (
 
   // ── IAM Roles ───────────────────────────────────────────────────────
   console.log(fmt.section('IAM Roles'));
-  const existingRoles = await getMemberRoles(projectId, saEmail);
+  const grants: Grant[] = [
+    ...DEPLOY_ROLES.map((r) => ({
+      role: r.role,
+      why: r.why,
+      member: deploySaEmail,
+      resource: 'project' as const,
+    })),
+    ...RUNTIME_ROLES.map((r) => ({
+      role: r.role,
+      why: r.why,
+      member: runtimeSaEmail,
+      resource: 'project' as const,
+    })),
+    {
+      role: SERVICE_ACCOUNT_USER_ROLE.role,
+      why: SERVICE_ACCOUNT_USER_ROLE.why,
+      member: deploySaEmail,
+      resource: { serviceAccount: runtimeSaEmail },
+    },
+  ];
 
-  for (const { role, why } of REQUIRED_ROLES) {
-    if (existingRoles.has(role)) {
-      console.log(fmt.ok(`${role} — ${why}`));
-      checks.push({ name: `IAM: ${role}`, status: 'ok' });
+  for (const grant of grants) {
+    const scopedTo = grant.resource === 'project' ? grant.member : grant.resource.serviceAccount;
+    const existing =
+      grant.resource === 'project'
+        ? await getProjectRoles(projectId, grant.member)
+        : await getSaResourceRoles(projectId, grant.resource.serviceAccount, grant.member);
+
+    if (existing.has(grant.role)) {
+      console.log(
+        fmt.ok(`${grant.role}${scopedTo !== grant.member ? ` on ${scopedTo}` : ''} — ${grant.why}`),
+      );
+      checks.push({ name: `IAM: ${grant.role}`, status: 'ok' });
+      continue;
+    }
+
+    console.log(
+      fmt.fix(`Granting ${grant.role}${scopedTo !== grant.member ? ` on ${scopedTo}` : ''}...`),
+    );
+    console.log(fmt.note(grant.why));
+    if (dryRun) {
+      console.log(fmt.fix('Would grant (dry-run)'));
+      checks.push({ name: `IAM: ${grant.role}`, status: 'missing' });
+      continue;
+    }
+
+    const ok =
+      grant.resource === 'project'
+        ? await addIamBinding(projectId, grant.member, grant.role)
+        : await addSaIamBinding(projectId, grant.resource.serviceAccount, grant.member, grant.role);
+    if (ok) {
+      console.log(fmt.ok(`Role ${grant.role} granted`));
+      checks.push({ name: `IAM: ${grant.role}`, status: 'missing', fixed: true });
     } else {
-      console.log(fmt.fix(`Granting ${role} to ${saEmail}...`));
-      console.log(fmt.note(why));
-      if (!dryRun) {
-        const ok = await addIamBinding(projectId, saEmail, role);
-        if (ok) {
-          console.log(fmt.ok(`Role ${role} granted`));
-          checks.push({ name: `IAM: ${role}`, status: 'missing', fixed: true });
-        } else {
-          console.log(fmt.err(`Failed to grant ${role}`));
-          checks.push({ name: `IAM: ${role}`, status: 'error' });
-        }
-      } else {
-        console.log(fmt.fix(`Would grant ${role} (dry-run)`));
-        checks.push({ name: `IAM: ${role}`, status: 'missing', fixed: true });
-      }
+      console.log(fmt.err(`Failed to grant ${grant.role}`));
+      checks.push({ name: `IAM: ${grant.role}`, status: 'error' });
     }
   }
 
@@ -185,10 +328,12 @@ if (import.meta.main) {
     mode: { type: 'string', map: { prod: 'production', stg: 'staging' } },
     'dry-run': { type: 'boolean' },
     'sa-id': { type: 'string' },
+    'runtime-sa-id': { type: 'string' },
   });
   const mode = (opts.mode as string) ?? 'staging';
   const dryRun = opts['dry-run'] as boolean;
   const saId = (opts['sa-id'] as string) ?? 'firebase-adminsdk-fbsvc';
+  const runtimeSaId = (opts['runtime-sa-id'] as string) ?? saId;
 
   if (!liveModes.includes(mode as (typeof liveModes)[number])) {
     console.error(fmt.err(`Unknown live mode: ${mode}. Valid: ${liveModes.join(', ')}`));
@@ -199,15 +344,17 @@ if (import.meta.main) {
     console.error(fmt.err(`Unknown mode: ${mode}`));
     process.exit(1);
   }
-  const saEmail = `${saId}@${projectId}.iam.gserviceaccount.com`;
+  const deploySaEmail = `${saId}@${projectId}.iam.gserviceaccount.com`;
+  const runtimeSaEmail = `${runtimeSaId}@${projectId}.iam.gserviceaccount.com`;
 
   console.log(fmt.head(`IAM Setup — ${mode} (${projectId})`));
-  console.log(`  Service account: ${saEmail}`);
+  console.log(`  Deploy SA:  ${deploySaEmail}`);
+  console.log(`  Runtime SA: ${runtimeSaEmail}`);
   if (dryRun) {
     console.log(fmt.warn('Dry-run mode — no changes will be made.\n'));
   }
 
-  const { checks } = await setupIam(projectId, saEmail, dryRun);
+  const { checks } = await setupIam(projectId, deploySaEmail, dryRun, runtimeSaEmail);
 
   const okCount = checks.filter((c) => c.status === 'ok').length;
   const fixed = checks.filter((c) => c.fixed).length;

--- a/scripts/src/lib/setup/iam.ts
+++ b/scripts/src/lib/setup/iam.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env bun
+// scripts/src/lib/setup/iam.ts
+//
+// Grant IAM roles to the Aikami deploy service account
+// (firebase-adminsdk-fbsvc@aikami-{project}.iam.gserviceaccount.com).
+//
+// The deploy pipeline (`bun run deploy`) authenticates as this SA — both
+// locally (via .secrets/gcp_sa_key.{mode}.json) and in CI (GCP_SA_KEY).
+// It needs permissions to push Docker images to Artifact Registry, deploy
+// Cloud Run services, Firebase Hosting/Functions, and read secrets.
+//
+// The same SA is also the Cloud Run *runtime* identity (see cloud_run.ts —
+// derived from FIREBASE_SERVICE_ACCOUNT), so the role list covers both
+// deploy-time and runtime needs.
+//
+// Usage:
+//   bun run scripts/src/lib/setup/iam.ts --mode=staging
+//   bun run scripts/src/lib/setup/iam.ts --mode=production --dry-run
+//   bun run scripts/src/lib/setup/iam.ts --mode=production --sa-id=custom-sa
+//
+// Caller must have `roles/resourcemanager.projectIamAdmin` (or project
+// owner) on the target project — run `gcloud auth login` first.
+
+import { c, fmt, parseCliArgs, run } from '../cli_utils';
+import { liveModes, MODE_PROJECT_MAP } from '../deploy/deployment_config';
+
+type Check = { name: string; status: 'ok' | 'missing' | 'error'; detail?: string; fixed?: boolean };
+
+/**
+ * Roles required by the deploy pipeline + Cloud Run runtime.
+ * See scripts/src/lib/deploy/*.ts for where each is exercised.
+ */
+const REQUIRED_ROLES: Array<{ role: string; why: string }> = [
+  {
+    role: 'roles/artifactregistry.writer',
+    why: 'docker push/pull to Artifact Registry (hub, image, text, voice, client)',
+  },
+  { role: 'roles/run.developer', why: 'gcloud run deploy — deploy/update Cloud Run services' },
+  {
+    role: 'roles/iam.serviceAccountUser',
+    why: 'act as the runtime SA when deploying Cloud Run services',
+  },
+  {
+    role: 'roles/cloudfunctions.developer',
+    why: 'deploy Firebase Functions (firestack, --deploy-engine gcloud)',
+  },
+  {
+    role: 'roles/cloudbuild.builds.editor',
+    why: 'Cloud Build jobs created during Functions deploys',
+  },
+  { role: 'roles/firebasehosting.admin', why: 'deploy Firebase Hosting sites (site, docs)' },
+  {
+    role: 'roles/secretmanager.secretAccessor',
+    why: 'fetch secrets for Cloud Run --set-secrets + runtime secret reads',
+  },
+  { role: 'roles/logging.logWriter', why: 'Cloud Run runtime writes logs' },
+  {
+    role: 'roles/storage.objectAdmin',
+    why: 'Firebase Hosting/Functions staging buckets + asset uploads',
+  },
+  {
+    role: 'roles/firebase.admin',
+    why: 'Firebase Admin SDK permissions (token/session-cookie verification) — usually pre-granted',
+  },
+];
+
+const getMemberRoles = async (projectId: string, memberEmail: string): Promise<Set<string>> => {
+  const { out, code } = await run([
+    'gcloud',
+    'projects',
+    'get-iam-policy',
+    projectId,
+    '--flatten=bindings[].members',
+    `--filter=bindings.members:${memberEmail}`,
+    '--format=json',
+    '--quiet',
+  ]);
+  if (code !== 0) {
+    return new Set();
+  }
+  try {
+    const policies = JSON.parse(out) as Array<{ bindings?: { role: string; members: string[] } }>;
+    return new Set(policies.flatMap((p) => (p.bindings?.role ? [p.bindings.role] : [])));
+  } catch {
+    return new Set();
+  }
+};
+
+const addIamBinding = async (
+  projectId: string,
+  memberEmail: string,
+  role: string,
+): Promise<boolean> => {
+  const { code } = await run([
+    'gcloud',
+    'projects',
+    'add-iam-policy-binding',
+    projectId,
+    `--member=serviceAccount:${memberEmail}`,
+    `--role=${role}`,
+    '--quiet',
+  ]);
+  return code === 0;
+};
+
+export const setupIam = async (
+  projectId: string,
+  saEmail: string,
+  dryRun: boolean,
+): Promise<{ checks: Check[] }> => {
+  const checks: Check[] = [];
+
+  // ── Service account exists? ─────────────────────────────────────────
+  console.log(fmt.section('Deploy Service Account'));
+  const { code: saExists } = await run([
+    'gcloud',
+    'iam',
+    'service-accounts',
+    'describe',
+    saEmail,
+    `--project=${projectId}`,
+    '--quiet',
+  ]);
+  if (saExists !== 0) {
+    console.log(fmt.err(`Service account ${saEmail} not found in ${projectId}`));
+    checks.push({ name: `SA: ${saEmail}`, status: 'error' });
+    return { checks };
+  }
+  console.log(fmt.ok(`Service account ${c.bold}${saEmail}${c.reset}`));
+  checks.push({ name: `SA: ${saEmail}`, status: 'ok' });
+
+  // ── Caller permission check ─────────────────────────────────────────
+  const { code: policyCode } = await run([
+    'gcloud',
+    'projects',
+    'get-iam-policy',
+    projectId,
+    '--flatten=bindings[].members',
+    '--filter=bindings.members:user:',
+    '--format=json',
+    '--quiet',
+  ]);
+  if (policyCode !== 0) {
+    console.log(fmt.err('Cannot read project IAM policy — the active account lacks'));
+    console.log(fmt.note('roles/resourcemanager.projectIamAdmin (or project owner).'));
+    console.log(fmt.note('Run: gcloud auth login  (as an owner of the project)'));
+    checks.push({ name: 'IAM read access', status: 'error' });
+    return { checks };
+  }
+  console.log(fmt.ok('Project IAM policy readable — grants will apply'));
+
+  // ── IAM Roles ───────────────────────────────────────────────────────
+  console.log(fmt.section('IAM Roles'));
+  const existingRoles = await getMemberRoles(projectId, saEmail);
+
+  for (const { role, why } of REQUIRED_ROLES) {
+    if (existingRoles.has(role)) {
+      console.log(fmt.ok(`${role} — ${why}`));
+      checks.push({ name: `IAM: ${role}`, status: 'ok' });
+    } else {
+      console.log(fmt.fix(`Granting ${role} to ${saEmail}...`));
+      console.log(fmt.note(why));
+      if (!dryRun) {
+        const ok = await addIamBinding(projectId, saEmail, role);
+        if (ok) {
+          console.log(fmt.ok(`Role ${role} granted`));
+          checks.push({ name: `IAM: ${role}`, status: 'missing', fixed: true });
+        } else {
+          console.log(fmt.err(`Failed to grant ${role}`));
+          checks.push({ name: `IAM: ${role}`, status: 'error' });
+        }
+      } else {
+        console.log(fmt.fix(`Would grant ${role} (dry-run)`));
+        checks.push({ name: `IAM: ${role}`, status: 'missing', fixed: true });
+      }
+    }
+  }
+
+  return { checks };
+};
+
+// ── Standalone entry ────────────────────────────────────────────────────────
+if (import.meta.main) {
+  const opts = parseCliArgs(Bun.argv.slice(2), {
+    mode: { type: 'string', map: { prod: 'production', stg: 'staging' } },
+    'dry-run': { type: 'boolean' },
+    'sa-id': { type: 'string' },
+  });
+  const mode = (opts.mode as string) ?? 'staging';
+  const dryRun = opts['dry-run'] as boolean;
+  const saId = (opts['sa-id'] as string) ?? 'firebase-adminsdk-fbsvc';
+
+  if (!liveModes.includes(mode as (typeof liveModes)[number])) {
+    console.error(fmt.err(`Unknown live mode: ${mode}. Valid: ${liveModes.join(', ')}`));
+    process.exit(1);
+  }
+  const projectId = MODE_PROJECT_MAP[mode as keyof typeof MODE_PROJECT_MAP];
+  if (!projectId) {
+    console.error(fmt.err(`Unknown mode: ${mode}`));
+    process.exit(1);
+  }
+  const saEmail = `${saId}@${projectId}.iam.gserviceaccount.com`;
+
+  console.log(fmt.head(`IAM Setup — ${mode} (${projectId})`));
+  console.log(`  Service account: ${saEmail}`);
+  if (dryRun) {
+    console.log(fmt.warn('Dry-run mode — no changes will be made.\n'));
+  }
+
+  const { checks } = await setupIam(projectId, saEmail, dryRun);
+
+  const okCount = checks.filter((c) => c.status === 'ok').length;
+  const fixed = checks.filter((c) => c.fixed).length;
+  const errors = checks.filter((c) => c.status === 'error').length;
+
+  console.log(fmt.head('Summary'));
+  console.log(
+    `  ${c.green}${okCount}${c.reset} already granted, ${c.cyan}${fixed}${c.reset} granted`,
+  );
+  if (errors) {
+    console.log(`  ${c.red}${errors}${c.reset} errors`);
+  }
+  process.exit(errors > 0 ? 1 : 0);
+}

--- a/scripts/src/lib/setup/index.ts
+++ b/scripts/src/lib/setup/index.ts
@@ -26,6 +26,7 @@ import { setupArtifactRegistry } from './artifact_registry';
 import { setupCdnHosting } from './cdn_hosting_setup';
 import { setupFirebaseHosting } from './firebase_hosting_setup';
 import { setupGcpApis } from './gcp_apis';
+import { setupIam } from './iam';
 import { setupSecrets } from './secrets_manager';
 
 // ─── Types ────────────────────────────────────────────────────────────────
@@ -123,6 +124,13 @@ async function main() {
   // ── Artifact Registry ─────────────────────────────────────────────
   {
     const { checks } = await setupArtifactRegistry(projectId, CLOUD_FUNCTIONS_REGION, DRY_RUN);
+    allChecks.push(...checks);
+  }
+
+  // ── IAM (deploy service account roles) ────────────────────────────
+  {
+    const saEmail = `firebase-adminsdk-fbsvc@${projectId}.iam.gserviceaccount.com`;
+    const { checks } = await setupIam(projectId, saEmail, DRY_RUN);
     allChecks.push(...checks);
   }
 

--- a/scripts/src/lib/setup/index.ts
+++ b/scripts/src/lib/setup/index.ts
@@ -41,6 +41,7 @@ const opts = parseCliArgs(Bun.argv.slice(2), {
 const DRY_RUN = opts['dry-run'] as boolean;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
+/** Run a command array without a shell, returning trimmed stdout + exit code. */
 async function runCmd(cmd: string[]): Promise<{ out: string; code: number }> {
   const proc = Bun.spawn({ cmd, stdout: 'pipe', stderr: 'pipe' });
   const out = await new Response(proc.stdout).text();
@@ -48,6 +49,7 @@ async function runCmd(cmd: string[]): Promise<{ out: string; code: number }> {
   return { out: out.trim(), code };
 }
 
+/** Return the ACTIVE gcloud account email, or null if not authenticated. */
 async function checkGcloudAuth(): Promise<string | null> {
   const { out, code } = await runCmd([
     'gcloud',
@@ -67,12 +69,17 @@ async function checkGcloudAuth(): Promise<string | null> {
   }
 }
 
+/** Whether the given GCP project exists and is describable. */
 async function checkProject(projectId: string): Promise<boolean> {
   const { code } = await runCmd(['gcloud', 'projects', 'describe', projectId, '--quiet']);
   return code === 0;
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────
+/**
+ * Interactive project setup wizard: runs each setup step (APIs, IAM,
+ * secrets, hosting, registry, CDN) in sequence, honoring dry-run.
+ */
 async function main() {
   console.log(fmt.head('Aikami Project Setup'));
 


### PR DESCRIPTION
## Summary

### (a) Client browser logs now reach hub cross-origin with CORS + app tagging
`client` is static Firebase Hosting with no server of its own, so its browser logger previously POSTed to a relative `/api/internal_logging` that only existed on `hub` — deployed client logs were silently lost.

- `packages/shared/logger/src/lib/logger_browser.ts` — `HttpLogSink` endpoint is now configurable via `PUBLIC_LOG_ENDPOINT` (defaults to the old relative path) and POSTs `PUBLIC_APP_ID` as `app` in the body. `HttpLogSink` is now exported for unit tests.
- `apps/frontend/client/.env.example` — `PUBLIC_LOG_ENDPOINT` set to hub's real custom domains: `https://hub.stg.bearlysleeping.com/api/internal_logging` (staging) and `https://hub.bearlysleeping.com/api/internal_logging` (production). Verified live via the Firebase Hosting API (`projects/{id}/sites/{site}/domains`).
- `apps/frontend/hub/src/hooks.server.ts` — CORS allows any `https://*.bearlysleeping.com` origin, scoped narrowly to `/api/internal_logging` only (no credentials, no wildcard). Origin check extracted to `isAikamiWebOrigin()`.
- `apps/frontend/hub/src/routes/api/internal_logging/+server.ts` — reads `app` from the POST body (capped at 64 chars via `sanitizeLogAppTag`), passes it into the log context so entries are tagged `source: 'client', app: 'client'`.
- `packages/shared/types/.../logger.ts` — `LogContext` gained optional `app?: string`.
- `packages/backend/svelte-kit/src/lib/log_sink.ts` — `SSRLogSink` emits `app` in its JSON payload when present.

### (b) Real staging structured-logging bug fix
`SSRLogSink` only wrote single-line JSON (parseable by Cloud Logging into `jsonPayload`) when `AIKAMI_MODE === 'production'`; **staging pretty-printed multi-line JSON**, which Cloud Logging shreds into unfilterable `textPayload` lines. Fixed to `isDeployed = AIKAMI_MODE === 'staging' || AIKAMI_MODE === 'production'`, verified against live staging/production logs.

### (c) New unified `bun run scripts -- logs <app>` command
Replaces the stale `.pi/extensions/log_viewer.ts` (which had a hardcoded app list that silently broke when `client` stopped being Cloud Run and `hub` was added).

- `scripts/src/lib/ops/logs.ts` — single source of truth driven by `deployment_config.ts`'s `APP_CONFIG`. `hub` and `firebase` (gen2 = Cloud Run) share one `gcloud logging read`/`tail` filter builder; `client` transparently redirects to hub's stream filtered by `jsonPayload.app="client"`; `site`/`docs`/`client-tauri`/`image`/`text`/`voice` return clear "not supported, here's why" messages. Supports `--mode`, `--tail`, `--since`, `--lines`, `--severity`, `--only`, `--message`, `--filter`, `--json`.
- `scripts/src/lib/deploy/utils.ts` — shared `ensureGcloudAuth()` (user creds → `.secrets/gcp_sa_key.{mode}.json` fallback) deduped from `deploy/index.ts` and `logs.ts`.
- `.pi/extensions/log_viewer.ts` rewritten as a thin wrapper; `.pi/skills/project-commands/SKILL.md` logging section updated.

### (d) Test coverage added
- `scripts/src/lib/ops/logs.test.ts` — `buildFilter()` (base/severity/message/raw-filter combos, quote escaping) + `resolveLogTarget()` for every branch.
- `packages/backend/svelte-kit/src/lib/hooks_helpers.test.ts` — `isPathExcluded`, `isAikamiWebOrigin` (exact matches pass; evil lookalikes, non-https, null fail), `sanitizeLogAppTag`.
- `packages/backend/svelte-kit/src/lib/log_sink.test.ts` — regression: staging & production write exactly one line of `JSON.stringify(payload)`; unset/emulator/testing pretty-print; `context.app` tagged/omitted correctly.
- `packages/shared/logger/src/lib/logger_browser.test.ts` — `HttpLogSink` default endpoint, `PUBLIC_LOG_ENDPOINT` override, `app: PUBLIC_APP_ID` in POST body. Added a `test` task + script to the logger package (previously had no test infra).

## Also included (separate commit)
- `feat(setup)`: IAM role setup for the deploy service account (`scripts/src/lib/setup/iam.ts`, wired into the setup pipeline + `bun run setup:iam`). This was sitting in the working tree alongside the logging work; included at user's request as its own commit.

## Verification
- `bun moon run :test --affected` — all affected test tasks pass (backend-svelte-kit 29, scripts 25, hub 17, logger 8, frontend-engine, frontend-storage). `client:test` has 92 pre-existing failures (AI-service dependent dialogue tests) — confirmed identical on clean `main` via stash test.
- Typecheck sweep: `hub`, `logger`, `types`, `backend-svelte-kit`, `scripts`, `client` — zero errors.
- `biome check` on all touched files — clean.
- Manually verified `bun run scripts -- logs hub|client|firebase|site|image` against live staging/production Cloud Logging.

No deploy was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified log viewer for supported applications with staging and production modes.
  * Added filtering by severity, message, freshness, line count, and custom queries, plus JSON output and live streaming.
  * Client logs now include their originating application and can use a configurable logging endpoint.
  * Added an IAM setup workflow with validation, role checks, and dry-run support.

* **Bug Fixes**
  * Improved logging access controls and origin validation for safer log forwarding.

* **Documentation**
  * Updated command guidance for application-specific logging behavior and supported targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->