### PR TITLE
fix(herdr): Windows console-window hiding and pane-shell-aware commands

### DIFF
--- a/.pi/autofix/system_prompt.md
+++ b/.pi/autofix/system_prompt.md
@@ -11,29 +11,25 @@ git diff --name-only --cached
 Current git-scoped files: .pi/bun.lock, .pi/extensions/chrome_devtools.ts, .pi/extensions/firebase_tools.ts, .pi/extensions/lib/process_runner.ts, .pi/runners/convention_gate.ts, .pi/runners/test_healer.ts, docs/contracts/C-400-unify-lpc-appearance-resolution.md, scripts/src/lib/agents/contract_pipeline.ts, scripts/src/lib/agents/contract_pipeline/contract_sync.ts, scripts/src/lib/agents/contract_pipeline/git_state.ts, scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts, scripts/src/lib/agents/contract_pipeline/orchestrator.ts, scripts/src/lib/agents/git_worktree.ts, scripts/src/lib/deploy/utils.ts, scripts/src/lib/env/check.ts, scripts/src/lib/env/direnv_detect.ts, scripts/src/lib/env/scripts_env.ts, scripts/src/lib/env/secrets.ts, scripts/src/lib/herdr/cli.ts, scripts/src/lib/herdr/join.ts, scripts/src/lib/herdr/session.test.ts, scripts/src/lib/herdr/session.ts, scripts/src/lib/herdr/start_autofix.ts, scripts/src/lib/herdr/start_pi.ts, scripts/src/lib/herdr/task.ts, scripts/src/lib/herdr/worktree.ts, scripts/src/lib/ops/dev_all.ts, scripts/src/lib/ops/preview_hub.ts, scripts/src/lib/ops/preview_site.ts, scripts/src/lib/test_blackbox/run.ts, scripts/src/lib/env/mode.ts
 
 # WORKFLOW
-## STEP 1: `bun run fix`
-1. Run `bun run fix` on **git-scoped files only**.
+## STEP 1: `bun run fix` (git-scoped)
+1. Run: `bunx biome check --write <the git-scoped files listed above> --error-on-warnings --no-errors-on-unmatched` — the command receives ONLY the git-scoped files, so biome cannot process anything outside that set. Files biome ignores (e.g. docs/*.md) are skipped, not lint targets.
 2. Fix errors and warnings at the source. Prefer minimal, mechanical edits.
 3. 🔴 **CIRCUIT BREAKER**: If you cannot fix an error after **5 attempts**, use an escape hatch (see rules below).
-4. Do not proceed until `bun run fix` outputs zero errors.
+4. Do not proceed until the fix command outputs zero errors AND zero warnings.
 
-## STEP 2: `bun run typecheck`
-1. Run `bun run typecheck` on **git-scoped files only**.
+## STEP 2: `bun run typecheck` (affected projects)
+1. Run: `(git diff --name-only; git diff --name-only --cached) | bunx moon run :typecheck --affected --stdin` — the git-scoped file list is piped into moon, so ONLY projects touched by those files are type-checked.
 2. Fix every type error by adjusting interfaces or adding imports.
 3. 🔴 **CIRCUIT BREAKER**: If you cannot fix a type error after **5 attempts**, use an escape hatch (see rules below).
-4. Do not proceed until `bun run typecheck` passes cleanly.
+4. Do not proceed until the typecheck command passes cleanly.
 
-## STEP 3: Commit and push
-1. Run `git status --porcelain=v1 --untracked-files=all -- biome.json biome.jsonc '**/tsconfig*.json' moon.yml '.pi/**' lint_rules.json`. If this prints ANY line, STOP and report the protected file + status code. Fix the underlying issue in source instead. Do not proceed until it prints nothing.
-2. Run `git add -A`.
-3. Run `git diff --cached --stat` to review.
-4. Run `git commit --no-verify -m "<conventional commit message>"`.
-5. 🔴 **HOOK FAILURES**: The pre-commit hook is skipped. Ensure all checks passed before committing.
-5a. 🔴 **VALIDATION GATE**: Before committing, you MUST run `bun moon run :validate` on all affected projects. The commit must not proceed until validation passes cleanly.
-6. Run `git push origin HEAD`. 🔴 **NEVER `git push` alone** — it may push to the wrong branch if upstream tracking differs from the current branch. Always use `git push origin HEAD` to push to the CURRENT branch.
+## STEP 3: Validate and stop
+1. 🔴 **VALIDATION GATE**: Run `bun moon run :validate` on all affected projects. Do not proceed until it passes cleanly.
+2. Run `git status --porcelain=v1 --untracked-files=all` and confirm every modified path is in the git-scoped set above (plus this prompt file). If any out-of-scope or protected file changed, STOP and report it — do NOT revert it (destructive git is forbidden); fix the underlying issue in source instead.
+3. 🔴 **STOP**: Do NOT stage, commit, or push. Repository mutations require explicit caller authorization (`bun autofix --only commit`, or `commit` in `--only`). Report a final diff summary instead.
 
 # STRICT RULES
-- **🔴 DESTRUCTIVE GIT IS FORBIDDEN**: NEVER run `git checkout --`, `git checkout .`, `git restore`, `git clean`, `git reset --hard`, or `git stash drop`. These destroy uncommitted work. The ONLY git mutations allowed are `git add`, `git commit`, and `git push origin HEAD` (commit step only).
+- **🔴 DESTRUCTIVE GIT IS FORBIDDEN**: NEVER run `git checkout --`, `git checkout .`, `git restore`, `git clean`, `git reset --hard`, or `git stash drop`. These destroy uncommitted work. Git mutations (`git add`, `git commit`, `git push origin HEAD`) are ONLY allowed inside an explicitly authorized commit step (commit-only runs).
 - **🔴 WINDOWS CRLF CHURN — IGNORE IT**: On Windows (`core.autocrlf=true`), `bun run fix` (biome --write) rewrites files as LF while git expects CRLF, so `git status` will list MANY 'modified' files with ZERO content change. NEVER 'clean up' or revert them. To see real changes use `git diff --numstat HEAD` — entries like `0	0` are pure line-ending churn and must be left untouched.
 - **🔴 PROTECT PRE-EXISTING WORK**: The working tree may contain uncommitted changes from before your run. If you ever lose or accidentally revert work, STOP and restore from the baseline snapshot (`bun run autofix:restore <timestamp>`) instead of improvising.
 - **Load Conventions First**: Before writing ANY code, load the `aikami-conventions` skill. Read `.context/CONTEXT.md` and `.context/index.md` before making structural changes (file moves, new packages, boundary changes).
@@ -41,9 +37,9 @@ Current git-scoped files: .pi/bun.lock, .pi/extensions/chrome_devtools.ts, .pi/e
 - **Step-by-Step**: Re-run the verification command (`bun run fix`, `typecheck`, etc.) after EVERY file edit to confirm your fix worked.
 - **Never Skip**: A step must pass cleanly before you move to the next.
 - **No Human Intervention**: Do NOT ask questions. If you are entirely blocked, explain why and stop.
-- **Forbidden Paths**: Do NOT modify .pi/, node_modules/, config files (moon.yml, biome.json, biome.jsonc, tsconfig*.json, lint_rules.json), or examples/.
+- **Forbidden Paths**: Do NOT modify node_modules/, config files (moon.yml, biome.json, biome.jsonc, tsconfig*.json, lint_rules.json), or examples/. Within .pi/, ONLY the git-scoped .pi files listed above and this prompt file (`.pi/autofix/system_prompt.md`) may be modified — every other .pi/ path is protected.
 - **🔴 BRANCH SAFETY — NEVER `git push` alone**: Always use `git push origin HEAD`. Plain `git push` may target the wrong branch if the local branch tracks a different remote branch (e.g. `origin/main` instead of the current feature branch). `git push origin HEAD` ALWAYS pushes to the current branch. If you see an upstream mismatch error, do NOT fall back to `git push origin HEAD:main` — push to the CURRENT branch.
-- **Baseline snapshot**: The pre-run working tree is saved at `C:\Users\snorr\.herdr\autofix-snapshots\2026-08-16T02-34-44-474Z`. It contains tracked.patch (all modifications vs HEAD) plus copies of untracked files. If you think you destroyed something, tell the user to run `bun run autofix:restore <timestamp>`.
+- **Baseline snapshot**: The pre-run working tree is saved at a per-run snapshot directory under `~/.herdr/autofix-snapshots/<timestamp>/` — `start_autofix.ts` injects the exact path at runtime. It contains tracked.patch (all modifications vs HEAD) plus copies of untracked files. If you think you destroyed something, tell the user to run `bun run autofix:restore <timestamp>`.
 - **NO `as`, `any`, or `unknown`**: Never use type assertions or `any`/`unknown`.
 
 ## LINTER & ERROR RESOLUTION — FIX, NEVER SUPPRESS

--- a/.pi/autofix/system_prompt.md
+++ b/.pi/autofix/system_prompt.md
@@ -1,38 +1,29 @@
 # MISSION
-You are a **full-project** autofix agent. Fix/typecheck/test the entire project.
+You are a **git-scoped** autofix agent. Only modify files in `git diff` or `git diff --cached`.
 
+## GIT SCOPE
+You **MUST ONLY** modify files that appear in `git diff` or `git diff --cached`.
+Run these commands at the start to identify the files:
+```bash
+git diff --name-only
+git diff --name-only --cached
+```
+Current git-scoped files: .pi/bun.lock, .pi/extensions/chrome_devtools.ts, .pi/extensions/firebase_tools.ts, .pi/extensions/lib/process_runner.ts, .pi/runners/convention_gate.ts, .pi/runners/test_healer.ts, docs/contracts/C-400-unify-lpc-appearance-resolution.md, scripts/src/lib/agents/contract_pipeline.ts, scripts/src/lib/agents/contract_pipeline/contract_sync.ts, scripts/src/lib/agents/contract_pipeline/git_state.ts, scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts, scripts/src/lib/agents/contract_pipeline/orchestrator.ts, scripts/src/lib/agents/git_worktree.ts, scripts/src/lib/deploy/utils.ts, scripts/src/lib/env/check.ts, scripts/src/lib/env/direnv_detect.ts, scripts/src/lib/env/scripts_env.ts, scripts/src/lib/env/secrets.ts, scripts/src/lib/herdr/cli.ts, scripts/src/lib/herdr/join.ts, scripts/src/lib/herdr/session.test.ts, scripts/src/lib/herdr/session.ts, scripts/src/lib/herdr/start_autofix.ts, scripts/src/lib/herdr/start_pi.ts, scripts/src/lib/herdr/task.ts, scripts/src/lib/herdr/worktree.ts, scripts/src/lib/ops/dev_all.ts, scripts/src/lib/ops/preview_hub.ts, scripts/src/lib/ops/preview_site.ts, scripts/src/lib/test_blackbox/run.ts, scripts/src/lib/env/mode.ts
 
 # WORKFLOW
 ## STEP 1: `bun run fix`
-1. Run `bun run fix` on the entire project.
+1. Run `bun run fix` on **git-scoped files only**.
 2. Fix errors and warnings at the source. Prefer minimal, mechanical edits.
 3. 🔴 **CIRCUIT BREAKER**: If you cannot fix an error after **5 attempts**, use an escape hatch (see rules below).
 4. Do not proceed until `bun run fix` outputs zero errors.
 
 ## STEP 2: `bun run typecheck`
-1. Run `bun run typecheck` on the entire project.
+1. Run `bun run typecheck` on **git-scoped files only**.
 2. Fix every type error by adjusting interfaces or adding imports.
 3. 🔴 **CIRCUIT BREAKER**: If you cannot fix a type error after **5 attempts**, use an escape hatch (see rules below).
 4. Do not proceed until `bun run typecheck` passes cleanly.
 
-## STEP 3: `bun run test`
-Run the tests using: `bun run test`.
-**Service Verification:**
-The script pre-started the client dev server. Verify they are accessible:
-```bash
-curl -s http://localhost:5274/ | wc -c    # should show >10000
-```
-If connection is refused, wait 10s and retry (max 3 times). If still refused, run `herdr_session start <service>`.
-🔴 **CRITICAL TEST RULES:**
-1. **First**, assume your `fix` or `typecheck` edits broke the source code.
-   - Run `git diff` to see what changed.
-   - Revert or fix the **source code** (not the test).
-2. **Only if the test is provably wrong**, edit it:
-   - Example: The test expects an old API response format.
-   - **Justify every test edit** with a comment (e.g., `// Updated mock for new API`).
-3. **Never** edit a test just to "make it pass" without understanding why.
-4. Do not proceed until tests pass.
-## STEP 4: Commit and push
+## STEP 3: Commit and push
 1. Run `git status --porcelain=v1 --untracked-files=all -- biome.json biome.jsonc '**/tsconfig*.json' moon.yml '.pi/**' lint_rules.json`. If this prints ANY line, STOP and report the protected file + status code. Fix the underlying issue in source instead. Do not proceed until it prints nothing.
 2. Run `git add -A`.
 3. Run `git diff --cached --stat` to review.
@@ -42,6 +33,9 @@ If connection is refused, wait 10s and retry (max 3 times). If still refused, ru
 6. Run `git push origin HEAD`. 🔴 **NEVER `git push` alone** — it may push to the wrong branch if upstream tracking differs from the current branch. Always use `git push origin HEAD` to push to the CURRENT branch.
 
 # STRICT RULES
+- **🔴 DESTRUCTIVE GIT IS FORBIDDEN**: NEVER run `git checkout --`, `git checkout .`, `git restore`, `git clean`, `git reset --hard`, or `git stash drop`. These destroy uncommitted work. The ONLY git mutations allowed are `git add`, `git commit`, and `git push origin HEAD` (commit step only).
+- **🔴 WINDOWS CRLF CHURN — IGNORE IT**: On Windows (`core.autocrlf=true`), `bun run fix` (biome --write) rewrites files as LF while git expects CRLF, so `git status` will list MANY 'modified' files with ZERO content change. NEVER 'clean up' or revert them. To see real changes use `git diff --numstat HEAD` — entries like `0	0` are pure line-ending churn and must be left untouched.
+- **🔴 PROTECT PRE-EXISTING WORK**: The working tree may contain uncommitted changes from before your run. If you ever lose or accidentally revert work, STOP and restore from the baseline snapshot (`bun run autofix:restore <timestamp>`) instead of improvising.
 - **Load Conventions First**: Before writing ANY code, load the `aikami-conventions` skill. Read `.context/CONTEXT.md` and `.context/index.md` before making structural changes (file moves, new packages, boundary changes).
 - **No Hallucinations**: Read error messages carefully. Fix only what is broken.
 - **Step-by-Step**: Re-run the verification command (`bun run fix`, `typecheck`, etc.) after EVERY file edit to confirm your fix worked.
@@ -49,6 +43,7 @@ If connection is refused, wait 10s and retry (max 3 times). If still refused, ru
 - **No Human Intervention**: Do NOT ask questions. If you are entirely blocked, explain why and stop.
 - **Forbidden Paths**: Do NOT modify .pi/, node_modules/, config files (moon.yml, biome.json, biome.jsonc, tsconfig*.json, lint_rules.json), or examples/.
 - **🔴 BRANCH SAFETY — NEVER `git push` alone**: Always use `git push origin HEAD`. Plain `git push` may target the wrong branch if the local branch tracks a different remote branch (e.g. `origin/main` instead of the current feature branch). `git push origin HEAD` ALWAYS pushes to the current branch. If you see an upstream mismatch error, do NOT fall back to `git push origin HEAD:main` — push to the CURRENT branch.
+- **Baseline snapshot**: The pre-run working tree is saved at `C:\Users\snorr\.herdr\autofix-snapshots\2026-08-16T02-34-44-474Z`. It contains tracked.patch (all modifications vs HEAD) plus copies of untracked files. If you think you destroyed something, tell the user to run `bun run autofix:restore <timestamp>`.
 - **NO `as`, `any`, or `unknown`**: Never use type assertions or `any`/`unknown`.
 
 ## LINTER & ERROR RESOLUTION — FIX, NEVER SUPPRESS

--- a/.pi/bun.lock
+++ b/.pi/bun.lock
@@ -5,13 +5,13 @@
     "": {
       "name": "pi",
       "dependencies": {
-        "@hypabolic/hypa": "latest",
-        "@modelcontextprotocol/sdk": "latest",
-        "zod": "latest",
+        "@hypabolic/hypa": "^0.1.14",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "latest",
-        "@types/bun": "latest",
+        "@earendil-works/pi-coding-agent": "^0.84.2",
+        "@types/bun": "^1.3.14",
       },
     },
   },

--- a/.pi/extensions/chrome_devtools.ts
+++ b/.pi/extensions/chrome_devtools.ts
@@ -25,6 +25,7 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { PORTS } from '../../packages/shared/constants/src/lib/development_ports';
 import { optimizeImage } from '../../scripts/src/lib/ai/image_optimizer';
+import { resolveAikamiMode } from '../../scripts/src/lib/env/mode';
 import { which } from '../../scripts/src/lib/env/which';
 import { defineAction, registerNamespace } from './lib/tool_namespace.ts';
 
@@ -39,7 +40,7 @@ let spawnedChromePid: number | null = null;
 // ── Helpers ───────────────────────────────────────────────────────────
 
 function getMode(): string {
-  return process.env.AIKAMI_MODE || 'emulator';
+  return resolveAikamiMode();
 }
 
 function getRoot(): string {

--- a/.pi/extensions/firebase_tools.ts
+++ b/.pi/extensions/firebase_tools.ts
@@ -1,6 +1,10 @@
 // .pi/extensions/firebase_tools.ts
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
+// Direnv env vars (set by .envrc / scripts/direnv/) — always available:
+//   AIKAMI_MODE          — emulator | staging | production
+//   AIKAMI_PROJECT_ID    — GCP project id (demo-aikami-emulator | aikami-dev | aikami-prod)
+import { isAikamiMode, resolveAikamiMode } from '../../scripts/src/lib/env/mode';
 import {
   type AikamiMode,
   isPortReady,
@@ -8,9 +12,6 @@ import {
   startServices,
   stopServices,
 } from '../../scripts/src/lib/herdr/session';
-// Direnv env vars (set by .envrc / scripts/direnv/) — always available:
-//   AIKAMI_MODE          — emulator | staging | production
-//   AIKAMI_PROJECT_ID    — GCP project id (demo-aikami-emulator | aikami-dev | aikami-prod)
 import { smartTruncate } from './lib/output_filter';
 import { runCommand } from './lib/process_runner.ts';
 import { defineAction, registerNamespace } from './lib/tool_namespace.ts';
@@ -54,7 +55,7 @@ export default function (pi: ExtensionAPI) {
         }),
         async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
           // Resolve mode: explicit param > direnv env > "emulator" default
-          const mode = params.env ?? (process.env.AIKAMI_MODE as Mode | undefined) ?? 'emulator';
+          const mode: AikamiMode = isAikamiMode(params.env) ? params.env : resolveAikamiMode();
           if (mode === 'emulator') {
             const result = await runCommand(
               'bun',

--- a/.pi/extensions/lib/process_runner.test.ts
+++ b/.pi/extensions/lib/process_runner.test.ts
@@ -132,7 +132,17 @@ describe('startCommand', () => {
     // The child backgrounds a grandchild and exits-by-signal; killing the
     // group must reap both. If only the direct child died, the grandchild
     // would hold the pipe open and completion would hang until timeout.
-    const handle = startCommand('sh', ['-c', 'sleep 30 & sleep 30'], { timeoutMs: 2000 });
+    //
+    // 🔴 MSYS2's `sh` (Git Bash) spawns backgrounded `sleep` OUTSIDE the
+    // parent-child tree that Windows `taskkill /T` walks, so the sh-based
+    // tree is not reapable on Windows. cmd's `start /b` creates a real
+    // Windows parent-child tree that taskkill /T can walk.
+    const isWin = process.platform === 'win32';
+    const handle = startCommand(
+      isWin ? 'cmd' : 'sh',
+      isWin ? ['/c', 'start /b sleep 30 & sleep 30'] : ['-c', 'sleep 30 & sleep 30'],
+      { timeoutMs: 2000 },
+    );
     const result = await handle.completion;
     expect(result.killed).toBe(true);
     expect(result.durationMs).toBeLessThan(6000);

--- a/.pi/extensions/lib/process_runner.ts
+++ b/.pi/extensions/lib/process_runner.ts
@@ -54,8 +54,34 @@ const SIGTERM_GRACE_MS = 3000; // wait 3 s after SIGTERM before SIGKILL
 
 // ── Helpers ────────────────────────────────────────────────────────
 
+/**
+ * Terminate a process and its whole tree.
+ *
+ * POSIX: kill the process group (`-pid`) so grandchildren die too — a child
+ * that survives with the stdout pipe open would otherwise hold `completion`
+ * open forever.
+ *
+ * Windows: there are no POSIX signals or process groups, and Node's
+ * `process.kill(-pid, …)` is unsupported (throws), so killing only the direct
+ * pid strands its descendants holding the pipes open. `taskkill /T /F` is the
+ * canonical whole-tree termination; `/F` is required because console apps
+ * (sh, sleep) do not respond to the graceful WM_CLOSE path. There is no
+ * graceful variant on Windows — Node maps SIGTERM to TerminateProcess anyway,
+ * and the callers' grace-period escalation re-runs this harmlessly.
+ */
 function killProcessTree(pid: number | undefined): void {
   if (pid === undefined) {
+    return;
+  }
+  if (process.platform === 'win32') {
+    try {
+      spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+    } catch {
+      // Already dead
+    }
     return;
   }
   try {
@@ -71,6 +97,17 @@ function killProcessTree(pid: number | undefined): void {
 
 function killProcessTreeForce(pid: number | undefined): void {
   if (pid === undefined) {
+    return;
+  }
+  if (process.platform === 'win32') {
+    try {
+      spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+    } catch {
+      // Already dead
+    }
     return;
   }
   try {
@@ -251,7 +288,11 @@ export function startCommand(
     return {
       stdout: stdout.trim(),
       stderr: stderr.trim(),
-      code,
+      // 🔴 Windows has no signals: a tree terminated via taskkill exits with a
+      // numeric code (1), not null like a POSIX signal death. The POSIX
+      // contract — "code is null when we killed it" — is restored by reporting
+      // null whenever this handle performed the termination.
+      code: killed ? null : code,
       killed,
       durationMs: Date.now() - startTime,
     };
@@ -266,7 +307,14 @@ export function startCommand(
     running: () => !finished,
     exitCode: () => exitCode,
     kill: (force = false) => {
+      if (finished) {
+        return;
+      }
       if (force) {
+        // 🔴 Mark killed BEFORE killing: on Windows taskkill reaps the tree
+        // with a numeric exit code (1), not a signal-null like POSIX — the
+        // completion must report code null for a handle-performed kill.
+        killed = true;
         killProcessTreeForce(child.pid);
         return;
       }

--- a/.pi/extensions/lib/process_runner.ts
+++ b/.pi/extensions/lib/process_runner.ts
@@ -182,6 +182,10 @@ export function startCommand(
     stdio: ['pipe', 'pipe', 'pipe'],
     // Own process group (via setsid) so the whole tree can be killed by -pid.
     detached: true,
+    // Windows: without this, spawning console apps (herdr, bun, node) opens a
+    // visible console window per call — a flash-popup storm under polling.
+    // No-op on POSIX.
+    windowsHide: true,
   });
 
   // Close stdin immediately — prevents CLI tools from hanging on prompts.
@@ -324,6 +328,8 @@ export function runSync(
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     encoding: 'utf8',
+    // Windows: hide the console window this spawn would otherwise flash.
+    windowsHide: true,
   });
 
   const stdout = (result.stdout ?? '').toString().trim();

--- a/.pi/runners/convention_gate.ts
+++ b/.pi/runners/convention_gate.ts
@@ -148,6 +148,8 @@ const _getChangedFiles = async (baseRef: string): Promise<string[]> => {
     const proc = spawn('git', ['diff', '--name-only', baseRef, 'HEAD'], {
       cwd: PROJECT_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the console window this spawn would otherwise flash.
+      windowsHide: true,
     });
 
     let out = '';
@@ -321,6 +323,8 @@ const _runBiomeCheck = async (files: string[]): Promise<GateViolation[]> => {
     const proc = spawn('bun', ['biome', 'check', ...files, '--error-on-warnings'], {
       cwd: PROJECT_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the console window this spawn would otherwise flash.
+      windowsHide: true,
     });
 
     let stderr = '';

--- a/.pi/runners/test_healer.ts
+++ b/.pi/runners/test_healer.ts
@@ -257,6 +257,8 @@ const _dispatchHerdrAlert = async (message: string): Promise<void> => {
   try {
     const proc = spawn('herdr', ['notify', message], {
       stdio: 'ignore',
+      // Windows: hide the console window this spawn would otherwise flash.
+      windowsHide: true,
     });
     await new Promise<void>((resolveA) => {
       proc.on('close', () => resolveA());
@@ -278,6 +280,8 @@ const _runMoonTask = async (
     const proc = spawn('bun', ['moon', 'run', target], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env },
+      // Windows: hide the console window this spawn would otherwise flash.
+      windowsHide: true,
     });
 
     let stdout = '';

--- a/.pi/skills/testing/SKILL.md
+++ b/.pi/skills/testing/SKILL.md
@@ -217,11 +217,11 @@ apps/e2e/
 ├── playwright.config.ts    # setup, client projects
 ├── src/
 │   ├── auth.setup.ts       # Per-worker auth state generation
-│   ├── config.ts           # EMULATOR_PORTS, getWorkerProjectId()
-│   ├── emulator_helper.ts  # clearAllWorkerProjects()
+│   ├── config.ts           # EMULATOR_PORTS, EMULATOR_PROJECT_ID
+│   ├── emulator_helper.ts  # clearAllEmulatorData()
 │   ├── fixtures.ts         # Shared fixtures (guestUser, etc.)
-│   ├── global_setup.ts     # Pre-suite emulator purge (all workers)
-│   ├── global_teardown.ts  # Post-suite emulator purge (all workers)
+│   ├── global_setup.ts     # Pre-suite emulator purge (single project)
+│   ├── global_teardown.ts  # Post-suite emulator purge (single project)
 │   └── pom/                # Page Object Models
 │       ├── combat_page.ts
 │       ├── inventory_page.ts
@@ -303,10 +303,14 @@ Then add to `apps/e2e/src/pom/index.ts` barrel export.
 
 ### Worker Isolation
 
-- Each worker uses a distinct Firebase project ID: `demo-aikami-worker-{0..N}`
+- All workers run against the **single emulator project** `demo-aikami-emulator`
+- Parallel workers isolate state via separate browser contexts
 - Auth states are per-worker: `.auth/user-worker-{0..N}.json`
-- Global setup/teardown purges ALL worker projects via emulator REST API
-- `MAX_WORKERS = 8` — increase if running more parallel workers
+- Global setup/teardown purges the emulator project via REST API
+
+> Per-worker emulator project IDs (`demo-aikami-worker-{0..N}`) were removed —
+> nothing ever wrote to those projects, and their Auth purges tripped the
+> emulator's single-project-mode warnings.
 
 ### Path Aliases
 

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -95,11 +95,11 @@ Behavioral tests for PWA client and game engine.
 playwright.config.ts      # setup, client, game projects
 src/
 ├── auth.setup.ts         # Per-worker auth state generation
-├── config.ts             # EMULATOR_PORTS, getWorkerProjectId()
+├── config.ts             # EMULATOR_PORTS, EMULATOR_PROJECT_ID
 ├── emulator_helper.ts    # Emulator purge utilities
 ├── fixtures.ts           # Shared fixtures (guestUser, etc.)
-├── global_setup.ts       # Pre-suite purge (all workers)
-├── global_teardown.ts    # Post-suite purge (all workers)
+├── global_setup.ts       # Pre-suite purge (single project)
+├── global_teardown.ts    # Post-suite purge (single project)
 └── pom/                  # Page Object Models
     ├── combat_page.ts
     ├── inventory_page.ts
@@ -141,7 +141,9 @@ test.describe('My Test', () => {
 
 ### Worker Isolation
 
-Each worker uses a distinct Firebase project ID (`demo-aikami-worker-{N}`) for data isolation. Auth states are per-worker. Setup/teardown purges all worker projects. Max 4 parallel workers.
+All Playwright workers run against the **single emulator project** (`demo-aikami-emulator`). Parallel workers isolate test state via separate browser contexts and per-worker auth state files (`.auth/user-worker-{N}.json`). Global setup/teardown purges the emulator project before and after each run.
+
+> Per-worker emulator project IDs (`demo-aikami-worker-{N}`) were removed — nothing ever wrote to those projects, and their Auth purges tripped the emulator's single-project-mode warnings.
 
 ### Auth Setup
 

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -38,14 +38,6 @@ const CLIENT_PORT = 5274 + EMULATOR_PORT_OFFSET;
 const SITE_PORT = 5280 + EMULATOR_PORT_OFFSET;
 const HUB_PORT = 5276 + EMULATOR_PORT_OFFSET;
 
-/**
- * Worker-specific project ID for emulator data isolation.
- * Playwright sets TEST_WORKER_INDEX per worker process.
- * Each worker uses a distinct project namespace in the emulator
- * so parallel tests don't mutate each other's data.
- */
-const PROJECT_ID = `demo-aikami-worker-${process.env.TEST_WORKER_INDEX || '0'}`;
-
 // ── Environment binding for Firebase Admin SDK ─────────────────
 
 // Protocol-free host strings (no http:// prefix — Firebase Admin SDK requires this)
@@ -53,7 +45,6 @@ process.env.FIRESTORE_EMULATOR_HOST = `127.0.0.1:${FIRESTORE_PORT}`;
 process.env.FIREBASE_AUTH_EMULATOR_HOST = `127.0.0.1:${AUTH_PORT}`;
 process.env.FIREBASE_STORAGE_EMULATOR_HOST = `127.0.0.1:${STORAGE_PORT}`;
 process.env.PUBSUB_EMULATOR_HOST = `127.0.0.1:${PUBSUB_PORT}`;
-process.env.GCLOUD_PROJECT = PROJECT_ID;
 
 // ── Dev server base URLs ──────────────────────────────────────
 

--- a/apps/e2e/src/config.ts
+++ b/apps/e2e/src/config.ts
@@ -30,23 +30,8 @@ export const EMULATOR_PORTS = {
   voice: 8089,
 } as const;
 
-/** Emulator GCP project ID (base, worker-agnostic). */
+/** Emulator GCP project ID. The suite runs against one shared project. */
 export const EMULATOR_PROJECT_ID = 'demo-aikami-emulator' as const;
 
 /** Test API key for the Firebase Auth emulator (fake, emulator-only). */
 export const FIREBASE_API_KEY = 'fake-api-key' as const;
-
-/** Number of max parallel workers for multi-project teardown. */
-export const MAX_WORKERS = 8;
-
-/**
- * Returns a worker-specific emulator project ID for data isolation.
- *
- * Playwright sets `TEST_WORKER_INDEX` per worker (0, 1, 2, ...).
- * Using different project IDs ensures parallel workers don't mutate
- * each other's Firestore/Auth emulator state.
- */
-export const getWorkerProjectId = (workerIndex?: string | number): string => {
-  const idx = workerIndex ?? process.env.TEST_WORKER_INDEX ?? '0';
-  return `demo-aikami-worker-${idx}`;
-};

--- a/apps/e2e/src/emulator_helper.ts
+++ b/apps/e2e/src/emulator_helper.ts
@@ -4,7 +4,7 @@
 //
 // C-054 AC-3: Extracted from global_setup.ts / global_teardown.ts.
 
-import { EMULATOR_PORTS, EMULATOR_PROJECT_ID, getWorkerProjectId, MAX_WORKERS } from './config';
+import { EMULATOR_PORTS, EMULATOR_PROJECT_ID } from './config';
 
 /** Firestore emulator host without protocol prefix (for Admin SDK). */
 export const FIRESTORE_EMULATOR_HOST = `127.0.0.1:${EMULATOR_PORTS.firestore}` as const;
@@ -60,7 +60,11 @@ export const clearAuthEmulatorData = async (projectId: string): Promise<void> =>
 };
 
 /**
- * Clear ALL emulator data (Firestore + Auth) for a single project.
+ * Clear ALL emulator data (Firestore + Auth) for the emulator project.
+ *
+ * The suite uses a single shared emulator project (demo-aikami-emulator);
+ * parallel Playwright workers isolate state via separate browser contexts
+ * and per-worker auth state files, not separate emulator projects.
  */
 export const clearAllEmulatorData = async (projectId?: string): Promise<void> => {
   const pid = projectId ?? EMULATOR_PROJECT_ID;
@@ -80,21 +84,4 @@ export const clearAllEmulatorData = async (projectId?: string): Promise<void> =>
   } else {
     console.log(`[e2e:lifecycle] Project ${pid} emulator data purged successfully`);
   }
-};
-
-/**
- * Purge emulator data for ALL worker projects.
- *
- * Iterates through MAX_WORKERS project IDs (demo-aikami-worker-0 through
- * demo-aikami-worker-N) and purges each. Called from global setup/teardown
- * to ensure no stale data from previous runs interferes with the current run.
- */
-export const clearAllWorkerProjects = async (): Promise<void> => {
-  console.log('[e2e:lifecycle] Purging all worker emulator projects');
-
-  for (let i = 0; i < MAX_WORKERS; i++) {
-    const pid = getWorkerProjectId(i);
-    await clearAllEmulatorData(pid);
-  }
-  console.log('[e2e:lifecycle] All worker projects purged successfully');
 };

--- a/apps/e2e/src/global_setup.ts
+++ b/apps/e2e/src/global_setup.ts
@@ -4,16 +4,16 @@
 //
 // C-054 AC-3: Uses shared emulator_helper for REST API purging.
 
-import { clearAllWorkerProjects } from './emulator_helper';
+import { clearAllEmulatorData } from './emulator_helper';
 
 /**
  * Playwright global setup hook.
- * Purges emulator state for ALL worker projects so tests start
- * with deterministic, empty databases for every worker.
+ * Purges emulator state so tests start with a deterministic, empty
+ * database for every worker.
  */
 const globalSetup = async (): Promise<void> => {
-  console.log('\n🧹 Global Setup: Purging all worker emulator projects...');
-  await clearAllWorkerProjects();
+  console.log('\n🧹 Global Setup: Purging emulator data...');
+  await clearAllEmulatorData();
   console.log('✓ Global setup complete\n');
 };
 

--- a/apps/e2e/src/global_teardown.ts
+++ b/apps/e2e/src/global_teardown.ts
@@ -4,15 +4,15 @@
 //
 // C-054 AC-3: Uses shared emulator_helper for REST API purging.
 
-import { clearAllWorkerProjects } from './emulator_helper';
+import { clearAllEmulatorData } from './emulator_helper';
 
 /**
  * Playwright global teardown hook.
- * Resets emulator state for ALL worker projects after all suites finish.
+ * Resets emulator state after all suites finish, so the next run starts clean.
  */
 const globalTeardown = async (): Promise<void> => {
-  console.log('\n🧹 Global Teardown: Purging all worker emulator projects...');
-  await clearAllWorkerProjects();
+  console.log('\n🧹 Global Teardown: Purging emulator data...');
+  await clearAllEmulatorData();
   console.log('✓ Global teardown complete\n');
 };
 

--- a/docs/contracts/C-400-unify-lpc-appearance-resolution.md
+++ b/docs/contracts/C-400-unify-lpc-appearance-resolution.md
@@ -43,7 +43,7 @@ created_at: "2026-08-16"
 
 - **Root causes** (all four confirmed by inspection):
 
-  **RC-1 — Two divergent recipe resolvers for the same data.**
+  **RC-1 — Three divergent recipe resolvers for the same data.**
   `packages/frontend/engine/src/worker/ecs_worker.ts:628` (`workerRecipeResolver`)
   emits the raw numeric index stringified:
 
@@ -56,9 +56,16 @@ created_at: "2026-08-16"
   ```
 
   `apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts:921`
-  resolves the same index against `generatedLpcSlots` into a real asset id
-  (e.g. `torso/clothes/chainmail_male`). Two code paths, same input, different
-  output. Nothing asserts they agree.
+  and a near-identical copy in
+  `apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts:1202`
+  resolve the same index against `generatedLpcSlots` into a real asset id
+  (e.g. `torso/clothes/chainmail_male`). Three code paths, same input,
+  different output. Nothing asserts they agree. **The `game_boot_service` copy
+  is the one the production `/game` route actually uses** —
+  `game_canvas_view_model.svelte.ts` calls `gameBootService.boot()`, which
+  builds `GameWorld` with its own `_buildLpcPipeline` (line 855). Replacing the
+  worker and `game_engine_service` copies alone leaves the production path
+  running the old resolver.
 
   **RC-2 — Silent slot drops.** In the main-thread resolver, when
   `slotDef?.variants[effectiveIdx]` is `undefined` the loop `continue`s with no
@@ -80,9 +87,18 @@ created_at: "2026-08-16"
   }
   ```
 
-  `village_elder` declares head index 97 → `effectiveIdx` 96 → fails the prefix
-  test → 94. Every NPC therefore renders `heads/human_male`. This is the
-  observed uniform bald head, and it is why RC-2 is invisible in logs.
+  The override is a real masking hazard — any out-of-range or non-head index
+  silently becomes `head/heads/human_male`. **Fact check (see OQ-1):** the
+  claim that `village_elder`'s head index 97 hits this path is *wrong* for the
+  committed catalog — 97 (1-indexed) → `effectiveIdx` 96 →
+  `head/heads/human/female_elderly`, which **passes** the prefix check. The
+  catalog was last committed 2026-07-14 (unchanged at the 2026-08-16
+  playthrough), so the uniform-head symptom cannot be attributed to RC-3 via
+  the elder's index. The observed symptom more likely comes from the worker's
+  numeric-string assetIds (RC-1) or the Tiled-property default fallback
+  (RC-4) — confirmed at implementation time via OQ-3 logging. The override
+  must still be removed: it is a latent silent-corruption path, and its
+  presence is why RC-2 failures stay invisible in logs.
 
   **RC-4 — Two sources of truth for NPC appearance.** The content pack manifest
   declares `appearanceLayers` per NPC
@@ -98,8 +114,11 @@ created_at: "2026-08-16"
 
 - **Existing implementation to reuse**:
   - `apps/frontend/client/src/lib/services/game/game_engine_service.svelte.ts:905-978`
-    (`_buildLpcPipeline`) — the more correct of the two resolvers; the unified
-    implementation should be extracted from this.
+    (`_buildLpcPipeline`) and the near-identical copy in
+    `apps/frontend/client/src/lib/services/game/game_boot_service.svelte.ts:1182-1260`
+    — both contain the same more-correct index→asset resolution; the unified
+    implementation should be extracted from one and **both client copies
+    replaced** (the `game_boot_service` copy is the production `/game` path).
   - `packages/frontend/engine/src/rendering/prop_texture_resolver.ts` and its
     test — the pattern for a resolver that lives in the engine with unit
     coverage.
@@ -139,7 +158,7 @@ declares for them.
 
 | Capability | Existing source | Reuse / modify / replace |
 |---|---|---|
-| Index → asset id resolution | `game_engine_service.svelte.ts:921` | **modify** — extract to engine as the single implementation |
+| Index → asset id resolution | `game_engine_service.svelte.ts:921` **and** `game_boot_service.svelte.ts:1202` | **modify** — extract both to engine as the single implementation |
 | Worker-side recipe building | `ecs_worker.ts:628` | **replace** — call the shared resolver |
 | NPC appearance lookup at spawn | `entity_spawner.ts:174` | **modify** — read from content pack, not Tiled properties |
 | Default layer constant | `entity_spawner.ts:164` | **modify** — becomes a per-slot fallback table, not a whole-stack default |
@@ -149,8 +168,10 @@ declares for them.
 
 ## Overview
 
-LPC appearance resolution currently exists twice, disagrees between the two
-copies, and fails silently. This contract collapses it to one implementation
+LPC appearance resolution currently exists **three times** (worker resolver,
+`game_engine_service` `_buildLpcPipeline`, and the production-path
+`game_boot_service` `_buildLpcPipeline`), disagrees between the copies, and
+fails silently. This contract collapses it to one implementation
 that lives in the engine, gives every slot a declared fallback with a logged
 warning, removes the hard-coded head override that was masking the failure, and
 makes the content pack manifest the single source of NPC appearance. A
@@ -216,9 +237,10 @@ type LpcSlotResolution =
       readonly assetId: string;
       readonly requestedIndex: number;
       readonly catalogSize: number;
-    };
+    }
+  | { readonly kind: 'empty' };
 
-/** The resolver result: always six recipes, never fewer. */
+/** The resolver result: always six entries, never fewer. */
 type LpcAppearanceResult = {
   readonly recipes: readonly {
     readonly slot: LpcSlotName;
@@ -228,6 +250,14 @@ type LpcAppearanceResult = {
   readonly resolutions: Readonly<Record<LpcSlotName, LpcSlotResolution>>;
 };
 ```
+
+Index **0 means *intentionally empty*** (used by `_buildPlayerData` for
+`appearanceLayers[2]`/`[4]` — torso, feet): it resolves to an `empty` recipe
+entry (slot present, `assetId: ''`, zero-filled palette, `active = 0` in the
+UBO packer) and **must not** log a fallback warning. A non-zero index that is
+out of range or missing from the catalog resolves to `fallback` and logs a
+`warn`. Distinguishing the two is what prevents warning spam for every player
+entity (see Edge Cases).
 
 NPC appearance in the content pack manifest is already declared as
 `appearanceLayers: number[]` on each NPC entry — **no schema change is
@@ -315,18 +345,26 @@ feet, head) and no NPC renders as a head alone
 | AC-1 | Visual | `apps/e2e/src/visual/suites/emberwatch.visual.ts` | `/game` | Filled during verification |
 
 **Test Hooks**:
-- Moon Task: `moon run e2e:visual -- emberwatch`
+- Moon Task: `bun moon run e2e:run-visual-tests -- --suite=emberwatch`
+  (runner: `apps/e2e/src/visual/runner.ts`, filter flag is `--suite=<id>`;
+  there is no `e2e:visual` moon target)
 - Integration: load each of the three maps in the browser and confirm visually.
 - E2E / Visual:
-    - **Functional**: `tests/client/game_boot.spec.ts` — assert the spawned NPC
-      entity count equals the manifest NPC count for the map.
+    - **Functional**: `tests/client/game_boot.spec.ts` — extend with an
+      assertion that the spawned NPC entity count for the loaded map equals the
+      manifest NPC count for that map (current spec only checks boot completion;
+      note village/inn/merchant_shop each declare exactly one NPC — the
+      playthrough's 2/3/1 heads include emergent entities per OQ-3, so assert
+      authored NPCs, not total character count).
     - **Visual**: extend `emberwatch.visual.ts` with a case
       `npcs-render-complete-bodies` on `/game`. Add TypeBox fields
       `allNpcsHaveBodies: Boolean` ("Whether every visible character sprite has
       a torso and legs beneath its head") and
       `noFloatingHeads: Boolean` ("Whether zero heads appear without a body").
-      Add both to `requiredTrueFields`. Score 90+: three complete NPC sprites
-      visible in `village`, none headless or bodiless.
+      Add both to `requiredTrueFields`. Score 90+: the authored NPC on the
+      loaded map (`village_elder` in `village`, `rollo_grasper` in `inn`,
+      `merchant` in `merchant_shop`) renders complete with all six slots
+      visible; no head appears without a body.
 
 **Watch Points**:
 - The existing `noLpcHeads` field in this suite means something different —
@@ -409,21 +447,34 @@ and the valid range
 **Evidence Matrix**:
 | AC | Test Level | Required Artifact | Production Path | Evidence |
 |---|---|---|---|---|
-| AC-5 | Unit | `scripts/src/lib/ops/__tests__/validate_content_appearance.test.ts` | N/A | Filled during verification |
+| AC-5 | Unit | `scripts/src/lib/ops/validate_content_appearance.test.ts` (colocated with the op — the ops dir convention; e.g. `logs.test.ts`, `parser_sync.test.ts`) | N/A | Filled during verification |
 
 **Test Hooks**:
-- Moon Task: `bun run validate:content` (new task, added to the
-  `validate:shaders`-style family and to `bun run ci`)
+- Moon Task: `bun run validate:content` (new root script in the
+  `validate:shaders`-style family) **plus a `scripts:validate-content` moon
+  task with `runInCI: true`** (following the `scripts:guard-data-plane`
+  pattern in `scripts/moon.yml`) — the actual CI gate is `moon ci`
+  (`.github/workflows/pr-checks.yml` runs `bun moon ci`), not the root
+  `bun run ci` script, and the root `validate` script does not exist.
+  Wire it so the validator fails the build in CI.
 - Integration: run against the real `emberwatch` and `whispering-caves` packs
   and confirm both pass after the fix.
 - E2E / Visual: N/A.
 
 **Watch Points**:
 - `village_elder` currently declares head index 97, which is exactly the case
-  RC-3 was masking. Confirm whether 97 is genuinely out of range or whether the
-  prefix check was wrong. **If 97 is valid, the manifest stays and the check is
-  the bug**; if it is invalid, the manifest is corrected here. Resolve this
-  before implementation — see Open Questions OQ-1.
+  RC-3 was masking. **Resolved (OQ-1): 97 is valid** — 1-indexed 97 →
+  `head/heads/human/female_elderly`, which passes the `head/heads/` prefix
+  check. The manifest stays; no head index in the three Emberwatch arrays is
+  out of range (verified against `lpc_asset_catalog_generated.ts`: head has
+  142 variants, indices 86–131 are `head/heads/*`). The validator must pass
+  all three Emberwatch NPCs unchanged.
+- **whispering-caves NPCs declare only 4 appearanceLayers** (`[1,3,7,14]` and
+  `[8,9,11,13]`), not 6. The validator must NOT require exactly 6 entries:
+  validate only the indices that are present, and treat missing trailing
+  slots (feet, head) as absent → runtime fallback. AC-5's integration step
+  says "confirm both packs pass" — a strict 6-length rule would fail
+  whispering-caves on purpose and contradict the AC.
 
 ### AC-6: NPC appearance comes from the manifest
 **Given** a Tiled spawn object carrying only `npcId`
@@ -459,16 +510,21 @@ and the valid range
    per-slot fallback table. Write the unit tests for AC-2, AC-3, AC-4 first —
    they define the contract of the function.
 2. **Phase 2 (Integration)** — Replace `workerRecipeResolver`
-   (`ecs_worker.ts:628`) and `_buildLpcPipeline`'s inner resolver
-   (`game_engine_service.svelte.ts:921`) with calls to the shared function.
-   Delete both old implementations. Change `_getNpcAppearanceLayers`
+   (`ecs_worker.ts:628`) and **both** `_buildLpcPipeline` inner resolvers
+   (`game_engine_service.svelte.ts:921` and
+   `game_boot_service.svelte.ts:1202`) with calls to the shared function.
+   Delete all three old implementations — leaving the `game_boot_service`
+   copy in place keeps the production `/game` path on the buggy resolver and
+   AC-1 fails. Change `_getNpcAppearanceLayers`
    (`entity_spawner.ts:174`) to look up the manifest by `npcId`; handle the
    missing-entry case with a logged skip. Strip the now-dead
    `appearanceLayers` properties from the three Emberwatch map JSON files.
 3. **Phase 3 (Validation)** — Add
    `scripts/src/lib/ops/validate_content_appearance.ts` following the
-   `validate_wgsl.ts` pattern; add the `validate:content` script and include it
-   in `bun run ci`. Extend `emberwatch.visual.ts` with the AC-1 case. Run
+   `validate_wgsl.ts` pattern; add the `validate:content` root script **and a
+   `scripts:validate-content` moon task with `runInCI: true`** so it runs in
+   the `moon ci` gate (see AC-5 Test Hooks). Extend `emberwatch.visual.ts`
+   with the AC-1 case. Run
    `bun run typecheck`, `moon run engine:test`, `moon run e2e:test`, and the
    visual suite.
 
@@ -500,21 +556,37 @@ and the valid range
 
 Must be resolved before status becomes `approved`:
 
-- **OQ-1** — Is `village_elder`'s declared head index **97** valid in the
-  generated catalog, or is it genuinely out of range? This decides whether AC-5
-  corrects three manifests or corrects the prefix check. Resolve by dumping the
-  `head` slot's variant list from `lpc_asset_catalog_generated.ts` and checking
-  index 96 (0-indexed). **This is a fact lookup, not a design decision** — one
-  command answers it.
-- **OQ-2** — Do the other five NPC layer indices (`2, 3, 65, 21, 20` for the
-  elder) resolve, or is the head merely the only slot with a fallback that
-  fires? Determines whether the Emberwatch manifests need an appearance
-  authoring pass as part of this contract or a follow-up.
-- **OQ-3** — Are the "invalid NPC" entities reported in the playthrough
-  (a) spawns whose `npcId` has no manifest entry, (b) entities from the
-  emergent-world / GOAP systems that were never authored, or (c) something
-  else? AC-6's Watch Point assumes (a). Confirm by logging every NPC spawn with
-  its resolved id on the three Emberwatch maps before implementing.
+- **OQ-1 — RESOLVED (fact lookup, 2026-08-16):** `village_elder`'s head index
+  **97 is valid**. `GENERATED_LPC_SLOTS` head slot has 142 variants;
+  1-indexed 97 → 0-indexed 96 → `head/heads/human/female_elderly`, which
+  starts with `head/heads/` and therefore **passes** the RC-3 prefix check.
+  Consequence: the RC-3 mechanism narrative in the Problem section was wrong
+  for the elder — the override does not fire for index 97 with the committed
+  catalog (catalog last committed 2026-07-14, unchanged at playthrough). No
+  manifest head index needs correcting. The override is still removed (it is
+  a latent silent-corruption path), and AC-5's validator must pass the three
+  Emberwatch NPC arrays as-is.
+- **OQ-2 — RESOLVED (fact lookup, 2026-08-16):** all five non-head elder
+  indices resolve. `[2,3,65,21,20]` → `body/bodies_female`,
+  `hair/bangs_adult`, `torso/clothes/robe_female`, `legs/pants_female`,
+  `feet/shoes/basic_thin` — all in range (body 52, hair 169, torso 166, legs
+  41, feet 34 variants). Rollo `[3,123,23,22,7,95]` and merchant
+  `[3,91,127,22,19,95]` also resolve in full. **No Emberwatch appearance
+  authoring pass is needed**; the manifests are valid against the committed
+  catalog. (whispering-caves still declares only 4 layers per NPC — handled by
+  the AC-5 validator policy, not an authoring pass here.)
+- **OQ-3 — CONFIRMED (map inspection, 2026-08-16):** each Emberwatch map
+  contains exactly **one** `npc` spawn object carrying `npcId` (village =
+  `village_elder`, inn = `rollo_grasper`, merchant_shop = `merchant`). The
+  playthrough observed 2/3/1 floating heads per map, which exceeds the authored
+  NPC count — so the extra "invalid NPC" entities are **not** authored spawns
+  with missing manifest entries; they are emergent-world / GOAP entities
+  (option (b)) or duplicates of the single NPC. AC-6's missing-entry skip is
+  still required, but the "invalid NPC" count observed in the playthrough will
+  not drop to zero from this contract alone. Log every NPC spawn (id + source)
+  on the three maps during implementation to confirm which entities the
+  playthrough saw; do not extend this contract's scope to emergent-world
+  entities.
 
 ## Amendments
 
@@ -523,6 +595,7 @@ Changes to ACs or scope require a version bump and user approval.
 | Version | Date | Change | Approved by |
 |---|---|---|---|
 | 1.0.0 | 2026-08-16 | Initial draft from `mvp-assessment-2026-08-16.md` §6.2. | — |
+| 2.0.0 | 2026-08-16 | Critic pass: added the third resolver copy (`game_boot_service.svelte.ts:1202`, the production `/game` path) to RC-1/Reuse Map/Phase 2; corrected RC-3 mechanism claim and resolved OQ-1/OQ-2 (index 97 valid, all Emberwatch indices resolve) + OQ-3 (maps have one authored NPC each; extra heads are emergent entities); added whisper-caves 4-layer validator policy to AC-5; fixed visual-suite moon task name; wired `validate:content` into `moon ci` via `scripts:validate-content`. | critic |
 
 ## Promotion Lifecycle
 

--- a/docs/contracts/C-400-unify-lpc-appearance-resolution.md
+++ b/docs/contracts/C-400-unify-lpc-appearance-resolution.md
@@ -2,12 +2,13 @@
 id: C-400
 title: "Unify LPC Appearance Resolution — no silent slot drops"
 source: "docs/strategy/mvp-assessment-2026-08-16.md §6.2 (MVP playthrough)"
-status: draft
+status: approved
 github:
   issue_number: null
   issue_url: null
   project_item_id: null
-  pr_url: null
+  pr_url: "https://github.com/BearlySleeping/aikami/pull/151"
+  pr_number: 151
 created_at: "2026-08-16"
 ---
 
@@ -21,7 +22,7 @@ created_at: "2026-08-16"
 | **Target** | `packages/frontend/engine/` (worker + spawner) and `apps/frontend/client/src/lib/services/game/` — one appearance resolution path |
 | **Priority** | P0 — the most damaging visual defect in the shipped build; every NPC renders as a disembodied head |
 | **Dependencies** | — (C-403 depends on this) |
-| **Status** | draft |
+| **Status** | approved (PR #151 merged) |
 | **Promotion** | `—` |
 | **Docs Impact** | internal — no user-facing docs page. `docs/architecture/limitations.md` "Observed MVP Defects" row is removed on completion. |
 | **Contract version** | 2.0.0 |

--- a/scripts/src/lib/agents/contract_pipeline.ts
+++ b/scripts/src/lib/agents/contract_pipeline.ts
@@ -190,6 +190,8 @@ const gh = (args: string[], options?: { timeout?: number }): string => {
     encoding: 'utf-8',
     timeout: options?.timeout ?? 30_000,
     stdio: ['ignore', 'pipe', 'pipe'],
+    // Windows: hide the cmd.exe console window this spawn would otherwise flash.
+    windowsHide: true,
   });
   return result.trim();
 };
@@ -266,6 +268,8 @@ const handleIssueSource = (target: string): string => {
     const remote = execSync('git remote get-url origin', {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the cmd.exe console window (no-op on POSIX).
+      windowsHide: true,
     }).trim();
     const match = remote.match(/github\.com[/:]([^/]+)\//);
     if (match?.[1]) {
@@ -518,6 +522,8 @@ const detectDirty = (): boolean => {
     const status = execSync('git status --porcelain', {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the cmd.exe console window (no-op on POSIX).
+      windowsHide: true,
     }).trim();
     return status.split('\n').some((line) => line.length > 2 && !line.startsWith('??'));
   } catch {
@@ -612,6 +618,8 @@ const setupRootBranch = (options: {
     currentBranch = execSync('git rev-parse --abbrev-ref HEAD', {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the cmd.exe console window (no-op on POSIX).
+      windowsHide: true,
     }).trim();
   } catch {
     // not fatal
@@ -628,6 +636,8 @@ const setupRootBranch = (options: {
     execFileSync('git', ['rev-parse', '--verify', branchName], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the console window (no-op on POSIX).
+      windowsHide: true,
     });
     branchExists = true;
   } catch {
@@ -645,6 +655,8 @@ const setupRootBranch = (options: {
     execFileSync('git', args, {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows: hide the console window (no-op on POSIX).
+      windowsHide: true,
     });
     console.log(`✅ Now on branch \`${branchName}\`.`);
 
@@ -723,6 +735,9 @@ const launchBackground = async (options: {
       detached: true,
       stdio: ['ignore', descriptor, descriptor],
       env: process.env,
+      // Windows: hide the background child's console window — without this
+      // every `bun run contract` flashes a popup for the whole pipeline run.
+      windowsHide: true,
     },
   );
   child.unref();
@@ -774,6 +789,8 @@ const launchBackground = async (options: {
   if (ready.workspaceId) {
     const focus = spawn('herdr', ['workspace', 'focus', ready.workspaceId], {
       stdio: 'ignore',
+      // Windows: hide the focus call's console window (no-op on POSIX).
+      windowsHide: true,
     });
     await new Promise<void>((resolve) => focus.once('close', () => resolve()));
   }

--- a/scripts/src/lib/agents/contract_pipeline/contract_sync.test.ts
+++ b/scripts/src/lib/agents/contract_pipeline/contract_sync.test.ts
@@ -32,6 +32,7 @@ import {
   hasUncommittedChanges,
   isolateContractInWorktree,
   pullContractFromWorktree,
+  toGitPath,
 } from './contract_sync.ts';
 
 const git = (args: string[], cwd: string): string =>
@@ -91,6 +92,27 @@ afterEach(() => {
       // best effort — temp dirs
     }
   }
+});
+
+describe('toGitPath (gitRelPath separator normalization)', () => {
+  it('converts Windows backslash separators for git', () => {
+    expect(toGitPath(String.raw`docs\contracts\C-400-test.md`, '\\')).toBe(
+      'docs/contracts/C-400-test.md',
+    );
+  });
+
+  it('preserves literal backslashes in POSIX filenames', () => {
+    // On POSIX `path.sep` is '/', so a repo-relative filename containing a
+    // literal `\` must pass through unchanged — git treats `\` as a plain
+    // character in POSIX paths, and the old blanket `split('\\')` mangled it.
+    expect(toGitPath(String.raw`docs\contracts\C-400-test.md`, '/')).toBe(
+      String.raw`docs\contracts\C-400-test.md`,
+    );
+  });
+
+  it('is a no-op on already-forward-slash paths on any platform', () => {
+    expect(toGitPath('docs/contracts/C-400-test.md')).toBe('docs/contracts/C-400-test.md');
+  });
 });
 
 describe('currentBranch', () => {

--- a/scripts/src/lib/agents/contract_pipeline/contract_sync.ts
+++ b/scripts/src/lib/agents/contract_pipeline/contract_sync.ts
@@ -61,6 +61,17 @@ import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { runGit } from '../git_worktree.ts';
 
+/**
+ * Repo-relative path in git's format (forward slashes).
+ *
+ * Windows `relative()` returns backslash paths (`docs\contracts\C-400.md`),
+ * which git rejects — `update-index --cacheinfo` fails with "Invalid path".
+ * Every repo-relative path in this module feeds a git command, so normalize
+ * once at the source. No-op on POSIX where `relative()` already uses `/`.
+ */
+const gitRelPath = (repoRoot: string, contractPath: string): string =>
+  relative(repoRoot, contractPath).split('\\').join('/');
+
 /** Git identity used for pipeline-authored contract commits. */
 const AGENT_ENV = {
   CONTRACT_PIPELINE_WORKTREE: '1',
@@ -136,7 +147,7 @@ export const isolateContractInWorktree = (options: {
     return { ok: true, message: 'Contract file does not exist yet.', committed: false };
   }
 
-  const relPath = relative(repoRoot, contractPath);
+  const relPath = gitRelPath(repoRoot, contractPath);
   const worktreeCopy = join(worktreePath, relPath);
 
   try {
@@ -208,6 +219,8 @@ const readContentAt = (options: {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 10_000,
+      // Windows: hide the console window (no-op on POSIX).
+      windowsHide: true,
     });
   } catch {
     return undefined;
@@ -458,7 +471,7 @@ export const commitContractToMain = (options: {
     };
   }
 
-  const relPath = relative(repoRoot, contractPath);
+  const relPath = gitRelPath(repoRoot, contractPath);
   const content = readFileSync(contractPath, 'utf-8');
 
   return commitContentToMain({ repoRoot, relPath, content, message });
@@ -487,7 +500,7 @@ export const commitContractContent = (options: {
   message: string;
 }): ContractSyncResult => {
   const { repoRoot, contractPath, content, message } = options;
-  const relPath = relative(repoRoot, contractPath);
+  const relPath = gitRelPath(repoRoot, contractPath);
   return commitContentToMain({ repoRoot, relPath, content, message });
 };
 
@@ -525,7 +538,7 @@ export const pullContractFromWorktree = (options: {
     return { ok: true, message: 'No worktree — nothing to pull back.', committed: false };
   }
 
-  const relPath = relative(repoRoot, contractPath);
+  const relPath = gitRelPath(repoRoot, contractPath);
   const worktreeCopy = join(worktreePath, relPath);
   if (!existsSync(worktreeCopy)) {
     return { ok: true, message: 'No contract copy in worktree.', committed: false };

--- a/scripts/src/lib/agents/contract_pipeline/contract_sync.ts
+++ b/scripts/src/lib/agents/contract_pipeline/contract_sync.ts
@@ -58,8 +58,16 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, relative } from 'node:path';
+import { dirname, join, relative, sep } from 'node:path';
 import { runGit } from '../git_worktree.ts';
+
+/**
+ * Normalize a repo-relative path for git by replacing `separator` with `/`.
+ * Pure (no path API) so tests can pin both platform behaviors deterministically:
+ * pass `'\\'` to simulate Windows, `'/'` to simulate POSIX.
+ */
+export const toGitPath = (relPath: string, separator: string = sep): string =>
+  relPath.split(separator).join('/');
 
 /**
  * Repo-relative path in git's format (forward slashes).
@@ -67,10 +75,12 @@ import { runGit } from '../git_worktree.ts';
  * Windows `relative()` returns backslash paths (`docs\contracts\C-400.md`),
  * which git rejects — `update-index --cacheinfo` fails with "Invalid path".
  * Every repo-relative path in this module feeds a git command, so normalize
- * once at the source. No-op on POSIX where `relative()` already uses `/`.
+ * once at the source, replacing ONLY the host platform separator (`path.sep`):
+ * on POSIX the path already uses `/`, so literal backslashes in filenames
+ * pass through untouched.
  */
 const gitRelPath = (repoRoot: string, contractPath: string): string =>
-  relative(repoRoot, contractPath).split('\\').join('/');
+  toGitPath(relative(repoRoot, contractPath));
 
 /** Git identity used for pipeline-authored contract commits. */
 const AGENT_ENV = {

--- a/scripts/src/lib/agents/contract_pipeline/git_state.ts
+++ b/scripts/src/lib/agents/contract_pipeline/git_state.ts
@@ -11,6 +11,8 @@ const gitLines = (options: { cwd: string; args: string[] }): string[] => {
       cwd: options.cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      // Windows: hide the console window (no-op on POSIX).
+      windowsHide: true,
     })
       .split('\n')
       .map((line) => line.trim())
@@ -95,6 +97,8 @@ export const currentCommit = (cwd: string): string => {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      // Windows: hide the console window (no-op on POSIX).
+      windowsHide: true,
     }).trim();
   } catch {
     return 'unknown';

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -4,8 +4,11 @@
 import { copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { contractPortOffset } from '../../../../../packages/shared/constants/src/index.ts';
+import { resolveAikamiMode } from '../../env/mode';
 import { getScriptsEnv } from '../../env/scripts_env';
+import { findBash, posixQuote } from '../../env/which';
 import {
+  bashScriptForPane,
   ensureServer,
   findWorkspace,
   herdr,
@@ -50,6 +53,28 @@ type PaneListResult = {
 };
 
 const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
+
+/**
+ * Build a pane command that tails the pipeline log.
+ *
+ * Windows herdr panes (PowerShell here) have no `tail` — the raw command
+ * fails with "The term 'tail' is not recognized". Route through bash (Git
+ * bash ships with Git on PATH) when available, exactly like wrapCommand does
+ * for service panes. On POSIX the pane shell is bash, so plain tail works.
+ *
+ * The log path is passed as `$1` (a separate argument) instead of being
+ * embedded in the `-c` script, so the outer command needs no nested quoting:
+ * every quoted token is a single-quoted literal that PowerShell, Nushell and
+ * bash all pass through unchanged. PowerShell panes use bashScriptForPane's
+ * temp-file transport (native-arg `"` mangling corrupts `-c`).
+ */
+const logTailCommand = async (paneId: string, log: string): Promise<string> => {
+  const bash = findBash();
+  if (bash) {
+    return bashScriptForPane(paneId, `tail -f ${posixQuote(log)}`);
+  }
+  return `tail -f ${shellQuote(log)}`;
+};
 
 const sleep = async (milliseconds: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -243,7 +268,7 @@ export const buildWorkspaceLabel = (options: {
   contractId: string;
   rootMode?: boolean;
 }): string => {
-  const mode = (process.env.AIKAMI_MODE || 'emulator') as string;
+  const mode = resolveAikamiMode();
   return options.rootMode ? `aikami-${mode}` : `aikami-contract-${options.contractId}`;
 };
 
@@ -360,7 +385,10 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
         if (!active) {
           await runPaneCommand({
             paneId: pipelinePane.pane_id,
-            command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+            command: await logTailCommand(
+              pipelinePane.pane_id,
+              logPath({ runId: this._runId, cwd: this._repoRoot }),
+            ),
           });
         }
         if (!this._rootMode) {
@@ -386,7 +414,10 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       this._pipelinePaneId = recovered.result.root_pane.pane_id;
       await runPaneCommand({
         paneId: this._pipelinePaneId,
-        command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+        command: await logTailCommand(
+          this._pipelinePaneId,
+          logPath({ runId: this._runId, cwd: this._repoRoot }),
+        ),
       });
       if (!this._rootMode) {
         await this._provisionHerdrWorktree(existingWorkspaceId);
@@ -413,7 +444,10 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
       await runHerdr(['tab', 'rename', result.result.tab.tab_id, 'pipeline']);
       await runPaneCommand({
         paneId: this._pipelinePaneId,
-        command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+        command: await logTailCommand(
+          this._pipelinePaneId,
+          logPath({ runId: this._runId, cwd: this._repoRoot }),
+        ),
       });
       return { workspaceId: this._workspaceId, pipelinePaneId: this._pipelinePaneId };
     }
@@ -463,7 +497,10 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
     await runHerdr(['tab', 'rename', w.tabId || `${this._workspaceId}:1`, 'pipeline']);
     await runPaneCommand({
       paneId: this._pipelinePaneId,
-      command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+      command: await logTailCommand(
+        this._pipelinePaneId,
+        logPath({ runId: this._runId, cwd: this._repoRoot }),
+      ),
     });
     return { workspaceId: this._workspaceId, pipelinePaneId: this._pipelinePaneId };
   }
@@ -536,7 +573,10 @@ export class ContractHerdrAdapter implements ContractHerdrAdapterInterface {
             this._pipelinePaneId = tab.result.root_pane.pane_id;
             await runPaneCommand({
               paneId: this._pipelinePaneId,
-              command: `tail -f ${shellQuote(logPath({ runId: this._runId, cwd: this._repoRoot }))}`,
+              command: await logTailCommand(
+                this._pipelinePaneId,
+                logPath({ runId: this._runId, cwd: this._repoRoot }),
+              ),
             });
           }
         } else {

--- a/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
+++ b/scripts/src/lib/agents/contract_pipeline/herdr_adapter.ts
@@ -9,6 +9,7 @@ import { getScriptsEnv } from '../../env/scripts_env';
 import { findBash, posixQuote } from '../../env/which';
 import {
   bashScriptForPane,
+  detectPaneShell,
   ensureServer,
   findWorkspace,
   herdr,
@@ -55,25 +56,48 @@ type PaneListResult = {
 const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
 
 /**
+ * Convert a Windows path (`C:\Users\…`) to the Git-Bash form (`/c/Users/…`)
+ * that the temp bash script understands. No-op on POSIX, where the path is
+ * already forward-slash.
+ */
+const toGitBashPath = (path: string): string => {
+  if (process.platform !== 'win32') {
+    return path;
+  }
+  return path
+    .replace(/^([A-Za-z]):[\\/]/, (_match, drive: string) => `/${drive.toLowerCase()}/`)
+    .replaceAll('\\', '/');
+};
+
+/**
  * Build a pane command that tails the pipeline log.
  *
  * Windows herdr panes (PowerShell here) have no `tail` — the raw command
  * fails with "The term 'tail' is not recognized". Route through bash (Git
  * bash ships with Git on PATH) when available, exactly like wrapCommand does
- * for service panes. On POSIX the pane shell is bash, so plain tail works.
+ * for service panes; the Windows path is converted to Git-Bash form
+ * (`/c/…`) before quoting. On POSIX the pane shell is bash, so plain tail
+ * works.
  *
- * The log path is passed as `$1` (a separate argument) instead of being
- * embedded in the `-c` script, so the outer command needs no nested quoting:
- * every quoted token is a single-quoted literal that PowerShell, Nushell and
- * bash all pass through unchanged. PowerShell panes use bashScriptForPane's
- * temp-file transport (native-arg `"` mangling corrupts `-c`).
+ * When bash is missing entirely, PowerShell panes get the native equivalent
+ * `Get-Content -LiteralPath '…' -Tail 10 -Wait` (and cmd panes get the same
+ * via `powershell -Command …`) instead of a `tail` that cannot exist there;
+ * only POSIX/Nushell panes keep plain `tail -f`.
  */
 const logTailCommand = async (paneId: string, log: string): Promise<string> => {
   const bash = findBash();
   if (bash) {
-    return bashScriptForPane(paneId, `tail -f ${posixQuote(log)}`);
+    return bashScriptForPane(paneId, `tail -f ${posixQuote(toGitBashPath(log))}`);
   }
-  return `tail -f ${shellQuote(log)}`;
+  const shell = await detectPaneShell(paneId);
+  if (shell === 'posix' || shell === 'nushell') {
+    return `tail -f ${shellQuote(log)}`;
+  }
+  const psSafeLog = log.replaceAll("'", "''");
+  if (shell === 'cmd') {
+    return `powershell -NoProfile -NonInteractive -Command "Get-Content -LiteralPath '${psSafeLog}' -Tail 10 -Wait"`;
+  }
+  return `Get-Content -LiteralPath '${psSafeLog}' -Tail 10 -Wait`;
 };
 
 const sleep = async (milliseconds: number): Promise<void> =>

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -470,6 +470,8 @@ const syncMainOnMerge = (repoRoot: string): void => {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: repoRoot,
       timeout: 10_000,
+      // Windows: hide the cmd.exe console window (no-op on POSIX).
+      windowsHide: true,
     }).trim();
   } catch {
     // status failed — fall through and let the pull report the real problem.
@@ -491,6 +493,8 @@ const syncMainOnMerge = (repoRoot: string): void => {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: repoRoot,
       timeout: 30000,
+      // Windows: hide the cmd.exe console window (no-op on POSIX).
+      windowsHide: true,
     });
     console.log('\n📥 Pulled latest main\n');
   } catch (e: unknown) {
@@ -1265,6 +1269,8 @@ export const runContractPipeline = async (options: {
                   stdio: ['pipe', 'pipe', 'pipe'],
                   cwd: options.repoRoot,
                   timeout: 15000,
+                  // Windows: hide the cmd.exe console window (no-op on POSIX).
+                  windowsHide: true,
                 });
                 console.log(`📝 PR converted to Draft: ${degradedPrUrl}\n`);
               } catch {
@@ -1392,6 +1398,8 @@ export const runContractPipeline = async (options: {
                 stdio: ['pipe', 'pipe', 'pipe'],
                 cwd: options.repoRoot,
                 timeout: 10000,
+                // Windows: hide the cmd.exe console window (no-op on POSIX).
+                windowsHide: true,
               },
             ).trim();
             if (r) {
@@ -1419,6 +1427,8 @@ export const runContractPipeline = async (options: {
                   stdio: ['pipe', 'pipe', 'pipe'],
                   cwd: options.repoRoot,
                   timeout: 15000,
+                  // Windows: hide the cmd.exe console window (no-op on POSIX).
+                  windowsHide: true,
                 });
               } catch {}
               console.log(`\n✅ PR ready: ${prUrl}\n`);
@@ -1438,6 +1448,8 @@ export const runContractPipeline = async (options: {
                     stdio: ['pipe', 'pipe', 'pipe'],
                     cwd: options.repoRoot,
                     timeout: 15000,
+                    // Windows: hide the cmd.exe console window (no-op on POSIX).
+                    windowsHide: true,
                   });
                 } catch {}
                 execFileSync('gh', ['pr', 'merge', prUrl, '--squash'], {
@@ -1445,6 +1457,8 @@ export const runContractPipeline = async (options: {
                   stdio: ['pipe', 'pipe', 'pipe'],
                   cwd: options.repoRoot,
                   timeout: 60000,
+                  // Windows: hide the console window (no-op on POSIX).
+                  windowsHide: true,
                 });
                 syncMainOnMerge(options.repoRoot);
                 manifest = transition({ manifest, next: 'merged' });
@@ -1477,6 +1491,8 @@ export const runContractPipeline = async (options: {
                   stdio: ['pipe', 'pipe', 'pipe'],
                   cwd: options.repoRoot,
                   timeout: 15000,
+                  // Windows: hide the cmd.exe console window (no-op on POSIX).
+                  windowsHide: true,
                 });
               } catch {}
             }
@@ -1501,6 +1517,8 @@ export const runContractPipeline = async (options: {
               stdio: ['pipe', 'pipe', 'pipe'],
               cwd: options.repoRoot,
               timeout: 15000,
+              // Windows: hide the cmd.exe console window (no-op on POSIX).
+              windowsHide: true,
             });
           } catch {}
           console.log(`\n✅ PR ready for review: ${prUrl}\n`);
@@ -1527,6 +1545,8 @@ export const runContractPipeline = async (options: {
                 stdio: ['pipe', 'pipe', 'pipe'],
                 cwd: options.repoRoot,
                 timeout: 15000,
+                // Windows: hide the cmd.exe console window (no-op on POSIX).
+                windowsHide: true,
               });
             } catch {}
             execFileSync('gh', ['pr', 'merge', prUrl, '--squash'], {
@@ -1534,6 +1554,8 @@ export const runContractPipeline = async (options: {
               stdio: ['pipe', 'pipe', 'pipe'],
               cwd: options.repoRoot,
               timeout: 60000,
+              // Windows: hide the console window (no-op on POSIX).
+              windowsHide: true,
             });
             syncMainOnMerge(options.repoRoot);
             manifest = transition({ manifest, next: 'merged' });
@@ -1569,6 +1591,8 @@ export const runContractPipeline = async (options: {
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: options.repoRoot,
             timeout: 15000,
+            // Windows: hide the cmd.exe console window (no-op on POSIX).
+            windowsHide: true,
           });
           manifest.blockedReason = decision.summary;
           manifest = transition({ manifest, next: 'blocked' });

--- a/scripts/src/lib/agents/git_worktree.test.ts
+++ b/scripts/src/lib/agents/git_worktree.test.ts
@@ -1,0 +1,79 @@
+// scripts/src/lib/agents/git_worktree.test.ts
+//
+// Pins the command-string tokenizer behind runGit. runGit previously ran the
+// command via `execSync` → cmd.exe on Windows, where POSIX single quotes are
+// literal characters — `git status -- 'code.ts'` silently never matched the
+// path. The tokenizer must reproduce the intended POSIX-shell argv for every
+// quoting style the callers use, on every platform.
+
+import { describe, expect, it } from 'bun:test';
+import { splitGitCommand } from './git_worktree.ts';
+
+describe('splitGitCommand', () => {
+  it('splits plain tokens on whitespace', () => {
+    expect(splitGitCommand('status --porcelain --branch')).toEqual([
+      'status',
+      '--porcelain',
+      '--branch',
+    ]);
+  });
+
+  it('unquotes a single-quoted path', () => {
+    expect(splitGitCommand("status --porcelain -- 'docs/contracts/C-999.md'")).toEqual([
+      'status',
+      '--porcelain',
+      '--',
+      'docs/contracts/C-999.md',
+    ]);
+  });
+
+  it('keeps spaces inside single-quoted segments as one arg', () => {
+    expect(splitGitCommand("worktree remove 'C:\\repo dir\\wt' --force")).toEqual([
+      'worktree',
+      'remove',
+      'C:\\repo dir\\wt',
+      '--force',
+    ]);
+  });
+
+  it('honors the POSIX single-quote escape', () => {
+    // worktree.ts quotes branch names with `'\''` — git refnames may contain
+    // apostrophes: `branch -D 'a'\''b'` must tokenize to a single `a'b` arg.
+    expect(splitGitCommand("branch -D 'a'\\''b'")).toEqual(['branch', '-D', "a'b"]);
+  });
+
+  it('unquotes double-quoted values and escaped quotes', () => {
+    expect(splitGitCommand(`-c "user.name=Pi Agent" -c "user.email=x@y" add -A`)).toEqual([
+      '-c',
+      'user.name=Pi Agent',
+      '-c',
+      'user.email=x@y',
+      'add',
+      '-A',
+    ]);
+    // String.raw keeps the `\"` escapes literal so the tokenizer sees them.
+    expect(splitGitCommand(String.raw`commit -m "he said \"hi\""`)).toEqual([
+      'commit',
+      '-m',
+      'he said "hi"',
+    ]);
+  });
+
+  it('keeps %-formats with spaces as one arg', () => {
+    expect(splitGitCommand('log -1 --format="%H %s"')).toEqual(['log', '-1', '--format=%H %s']);
+  });
+
+  it('handles unquoted interpolated values', () => {
+    expect(
+      splitGitCommand('update-index --add --cacheinfo 100644,abc123,docs/contracts/C-999.md'),
+    ).toEqual(['update-index', '--add', '--cacheinfo', '100644,abc123,docs/contracts/C-999.md']);
+  });
+
+  it('does not shell-expand $ or backticks', () => {
+    expect(splitGitCommand('commit -m "$HOME `whoami`"')).toEqual([
+      'commit',
+      '-m',
+      '$HOME `whoami`',
+    ]);
+  });
+});

--- a/scripts/src/lib/agents/git_worktree.ts
+++ b/scripts/src/lib/agents/git_worktree.ts
@@ -46,10 +46,14 @@ export const runGit = (
     cwd?: string;
     env?: Record<string, string>;
     timeout?: number;
+    // Windows: execSync runs via cmd.exe — without this every git call
+    // flashes a console window. No-op on POSIX.
+    windowsHide?: boolean;
   } = {
     encoding: 'utf-8' as const,
     stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'],
     cwd: options?.cwd,
+    windowsHide: true,
   };
   if (options?.timeoutMs !== undefined) {
     opts.timeout = options.timeoutMs;

--- a/scripts/src/lib/agents/git_worktree.ts
+++ b/scripts/src/lib/agents/git_worktree.ts
@@ -10,7 +10,7 @@
 //    removeWorktree / WORKSPACES_DIR were deleted when the pipeline switched
 //    to herdr-native worktrees — this file holds only git primitives now.
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -23,6 +23,82 @@ interface GitExecError extends Error {
 }
 
 const isGitExecError = (err: unknown): err is GitExecError => err instanceof Error;
+
+/**
+ * Split a git command string into an argv array, honoring the quoting style
+ * every runGit caller uses: single-quoted paths (`'path with spaces'`),
+ * double-quoted values (`-m "message"`, `--format="%H %s"`), `\"` escapes
+ * inside double quotes, and the POSIX `'\''` single-quote escape (worktree.ts
+ * branch names). No shell expansion is performed — callers interpolate values
+ * into the string before runGit ever sees it.
+ *
+ * 🔴 WHY NOT `execSync`: on Windows it routes through cmd.exe, which treats
+ * `'` as a literal character, so `git status -- 'code.ts'` silently never
+ * matches the path — corrupting every quoted runGit call (e.g. contract_sync
+ * `status --porcelain -- '<path>'`). Executing via `execFileSync` with a real
+ * argv array skips the shell entirely and behaves identically on POSIX and
+ * Windows. Values are pre-interpolated, so this reproduces the POSIX
+ * `sh -c` path minus the quoting bugs.
+ */
+export const splitGitCommand = (command: string): string[] => {
+  const args: string[] = [];
+  let current = '';
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'") {
+      // Single-quoted segment — everything literal until the closing quote.
+      // `'\''` inside a single-quoted string escapes a literal quote.
+      let end = i + 1;
+      while (end < command.length) {
+        if (command[end] === "'" && command[end + 1] === '\\' && command[end + 2] === "'") {
+          current += "'";
+          end += 3;
+          continue;
+        }
+        if (command[end] === "'") {
+          break;
+        }
+        current += command[end];
+        end += 1;
+      }
+      i = end + 1;
+      continue;
+    }
+    if (ch === '"') {
+      // Double-quoted segment — literal except `\"`.
+      let end = i + 1;
+      while (end < command.length) {
+        if (command[end] === '\\' && command[end + 1] === '"') {
+          current += '"';
+          end += 2;
+          continue;
+        }
+        if (command[end] === '"') {
+          break;
+        }
+        current += command[end];
+        end += 1;
+      }
+      i = end + 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (current !== '') {
+        args.push(current);
+        current = '';
+      }
+      i += 1;
+      continue;
+    }
+    current += ch;
+    i += 1;
+  }
+  if (current !== '') {
+    args.push(current);
+  }
+  return args;
+};
 
 /**
  * Run a git command with retry on index.lock contention.
@@ -38,16 +114,14 @@ export const runGit = (
   command: string,
   options?: { cwd?: string; env?: Record<string, string>; timeoutMs?: number },
 ): string => {
-  const cmd = `git ${command}`;
-
   const opts: {
     encoding: 'utf-8';
     stdio: ['pipe', 'pipe', 'pipe'];
     cwd?: string;
     env?: Record<string, string>;
     timeout?: number;
-    // Windows: execSync runs via cmd.exe — without this every git call
-    // flashes a console window. No-op on POSIX.
+    // Windows: without windowsHide, git.exe spawns a visible console window
+    // per call. No-op on POSIX.
     windowsHide?: boolean;
   } = {
     encoding: 'utf-8' as const,
@@ -67,7 +141,7 @@ export const runGit = (
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      return execSync(cmd, opts).trim();
+      return execFileSync('git', splitGitCommand(command), opts).trim();
     } catch (err: unknown) {
       lastError = err;
       const message = isGitExecError(err) ? (err.stderr ?? err.message) : String(err);

--- a/scripts/src/lib/catalog/lpc_credits.ts
+++ b/scripts/src/lib/catalog/lpc_credits.ts
@@ -37,7 +37,7 @@
 // preflight refuses to publish such entries.
 
 import { readFileSync } from 'node:fs';
-import { relative } from 'node:path';
+import { relative, sep } from 'node:path';
 
 // ---------------------------------------------------------------------------
 // CREDITS.csv row shape
@@ -479,6 +479,15 @@ const creditFingerprint = (entry: LpcCreditEntry): string =>
  * Returns undefined when no tier resolves — the caller records the source
  * as unresolved and the publish preflight gates on it.
  */
+/**
+ * Normalize a spritesheet-relative path to forward slashes.
+ * CREDITS.csv and the output sidecar use `/` as the join key separator on
+ * every platform; on Windows `relative()` returns backslash paths
+ * (`weapon\staff\thrust.png`), which would never match the `/`-keyed index.
+ * No-op on POSIX (including literal backslashes in filenames).
+ */
+const toForwardSlashes = (path: string): string => path.split(sep).join('/');
+
 export const resolveLpcCredit = (options: {
   sourcePath: string;
   parsed: Pick<LpcParsedState, 'slot' | 'type' | 'bodyType'>;
@@ -488,7 +497,7 @@ export const resolveLpcCredit = (options: {
   const { sourcePath, parsed, index, spritesheetsDir } = options;
 
   // Tier 1: exact path.
-  const exact = index.byPath.get(relative(spritesheetsDir, sourcePath));
+  const exact = index.byPath.get(toForwardSlashes(relative(spritesheetsDir, sourcePath)));
   if (exact) {
     return exact;
   }
@@ -502,7 +511,7 @@ export const resolveLpcCredit = (options: {
   }
 
   // Tier 3: `${head}` template rows (the only placeholder CREDITS.csv uses).
-  const parts = relative(spritesheetsDir, sourcePath).split('/');
+  const parts = toForwardSlashes(relative(spritesheetsDir, sourcePath)).split('/');
   const templateMatches = new Map<string, LpcCreditEntry>();
   const headPlaceholder = '\u0024{head}';
   for (const { filename, entry } of index.templateRows) {
@@ -565,7 +574,7 @@ export const buildLpcCreditsSidecar = (options: {
 
     const entry = resolveLpcCredit({ sourcePath, parsed, index, spritesheetsDir });
     if (!entry) {
-      unresolved.push({ tag, source: relative(spritesheetsDir, sourcePath) });
+      unresolved.push({ tag, source: toForwardSlashes(relative(spritesheetsDir, sourcePath)) });
       continue;
     }
     credits[tag] = entry;

--- a/scripts/src/lib/deploy/utils.ts
+++ b/scripts/src/lib/deploy/utils.ts
@@ -117,6 +117,8 @@ export function runArgs(
       stdio,
       maxBuffer: 100 * 1024 * 1024,
       shell: false,
+      // Windows: hide the console window this spawn would otherwise flash.
+      windowsHide: true,
     });
     if (result.status !== 0 && !(opts.quiet || _quiet)) {
       error(`Command failed: ${cmd.join(' ')}`);

--- a/scripts/src/lib/env/check.ts
+++ b/scripts/src/lib/env/check.ts
@@ -13,12 +13,13 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { isEmulatorMode, resolveAikamiMode } from './mode';
 
 // ── Resolve context ────────────────────────────────────────────────────
 
-const mode = process.env.AIKAMI_MODE || 'emulator';
+const mode = resolveAikamiMode();
 const projectId = process.env.AIKAMI_PROJECT_ID || 'demo-aikami-emulator';
-const isEmulator = mode === 'emulator';
+const isEmulator = isEmulatorMode();
 const root = process.env.AIKAMI_ROOT || process.cwd();
 
 // ── Helpers ────────────────────────────────────────────────────────────

--- a/scripts/src/lib/env/direnv_detect.ts
+++ b/scripts/src/lib/env/direnv_detect.ts
@@ -26,6 +26,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { type AikamiMode, isAikamiMode } from './mode';
 import { findBash, posixQuote, which } from './which';
 
 // ── Mode → project map ──────────────────────────────────────────────────
@@ -38,8 +39,6 @@ const MODE_PROJECT_MAP: Record<string, string> = {
   staging: 'aikami-staging',
   production: 'aikami-production',
 };
-
-const VALID_MODES = new Set(['emulator', 'staging', 'production']);
 
 let _hasDirenv: boolean | undefined;
 
@@ -63,7 +62,7 @@ export const isDirenvLoaded = (): boolean =>
   process.env.IN_NIX_SHELL !== undefined;
 
 export type AikamiEnv = {
-  mode: 'emulator' | 'staging' | 'production';
+  mode: AikamiMode;
   projectId: string;
   isEmulator: boolean;
 };
@@ -74,16 +73,16 @@ export type AikamiEnv = {
  * emulator, matching .envrc behavior.
  */
 export const resolveAikamiEnv = (root: string): AikamiEnv => {
-  let mode = 'emulator';
+  let mode: AikamiMode = 'emulator';
   const envLocal = join(root, '.env.local');
   if (existsSync(envLocal)) {
     const match = readFileSync(envLocal, 'utf8').match(/^AIKAMI_MODE=(\S+)\s*$/m);
-    if (match?.[1] && VALID_MODES.has(match[1])) {
+    if (match?.[1] && isAikamiMode(match[1])) {
       mode = match[1];
     }
   }
   const projectId = MODE_PROJECT_MAP[mode] ?? 'demo-aikami-emulator';
-  return { mode: mode as AikamiEnv['mode'], projectId, isEmulator: mode === 'emulator' };
+  return { mode, projectId, isEmulator: mode === 'emulator' };
 };
 
 /**

--- a/scripts/src/lib/env/direnv_detect.ts
+++ b/scripts/src/lib/env/direnv_detect.ts
@@ -55,6 +55,15 @@ export const hasDirenv = (): boolean => {
   return _hasDirenv;
 };
 
+/**
+ * Reset the `hasDirenv` cache. Test-only: pass an explicit value to force the
+ * decision deterministically (regardless of the machine's PATH), or `undefined`
+ * to re-detect from PATH on the next call.
+ */
+export const resetDirenvCache = (value: boolean | undefined): void => {
+  _hasDirenv = value;
+};
+
 /** True when THIS process was already set up by .envrc (direnv + Nix). */
 export const isDirenvLoaded = (): boolean =>
   process.env.AIKAMI_ENV_LOADED === '1' ||

--- a/scripts/src/lib/env/mode.ts
+++ b/scripts/src/lib/env/mode.ts
@@ -1,0 +1,41 @@
+// scripts/src/lib/env/mode.ts
+//
+// Single source of truth for Aikami deployment-mode resolution.
+//
+// Aikami runs in three modes — emulator, staging, production — selected by
+// the `AIKAMI_MODE` env var (set by direnv/.env.local, or passed explicitly).
+// Every script and extension that needs a mode should resolve it through
+// `resolveAikamiMode()` here, which:
+//
+//   1. reads `process.env.AIKAMI_MODE`
+//   2. validates it against the known modes
+//   3. defaults to `emulator` when unset/invalid
+//
+// The emulator is the safe default: staging/production require credentials
+// that fail fast anyway, so an accidental default can never silently hit the
+// cloud, and `emulator` is what a fresh local checkout should run.
+//
+// 🔴 This module must stay dependency-free (node: only) — it is imported by
+//    both Bun scripts and pi extensions (which run under Node), and must not
+//    create import cycles with higher-level modules.
+
+/** Valid Aikami deployment modes. */
+export const AIKAMI_MODES = ['emulator', 'staging', 'production'] as const;
+
+export type AikamiMode = (typeof AIKAMI_MODES)[number];
+
+/** True when `value` is one of the known modes. */
+export const isAikamiMode = (value: string | undefined): value is AikamiMode =>
+  value !== undefined && (AIKAMI_MODES as readonly string[]).includes(value);
+
+/**
+ * Resolve the current mode from the environment, defaulting to emulator.
+ * Never throws — an unset or invalid `AIKAMI_MODE` yields `'emulator'`.
+ */
+export const resolveAikamiMode = (): AikamiMode => {
+  const envMode = process.env.AIKAMI_MODE;
+  return isAikamiMode(envMode) ? envMode : 'emulator';
+};
+
+/** Convenience: true when the resolved mode is the local emulator. */
+export const isEmulatorMode = (): boolean => resolveAikamiMode() === 'emulator';

--- a/scripts/src/lib/env/scripts_env.ts
+++ b/scripts/src/lib/env/scripts_env.ts
@@ -20,6 +20,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveAikamiMode } from './mode';
 
 const _filename = fileURLToPath(import.meta.url);
 const _scriptDir = dirname(_filename);
@@ -90,8 +91,7 @@ export function initScriptsEnv(mode: string): void {
  */
 export function getScriptsEnv(key: string): string | undefined {
   if (_loadedMode === null) {
-    const mode = process.env.AIKAMI_MODE || 'emulator';
-    initScriptsEnv(mode);
+    initScriptsEnv(resolveAikamiMode());
   }
   return process.env[key] ?? _envCache.get(key);
 }

--- a/scripts/src/lib/env/secrets.ts
+++ b/scripts/src/lib/env/secrets.ts
@@ -14,6 +14,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { resolveAikamiMode } from './mode';
 
 // ── Configuration ────────────────────────────────────────────────────
 
@@ -33,7 +34,7 @@ const SECRET_KEYS = [
 
 // ── Resolve mode ──────────────────────────────────────────────────────
 
-const mode = process.env.AIKAMI_MODE || 'emulator';
+const mode = resolveAikamiMode();
 const isEmulator = mode === 'emulator';
 const root = process.env.AIKAMI_ROOT || process.cwd();
 

--- a/scripts/src/lib/herdr/cli.ts
+++ b/scripts/src/lib/herdr/cli.ts
@@ -9,8 +9,10 @@
 //
 //   <services> = comma-separated: firebase,client,voice,image,text  or  all
 //
-// Mode defaults to AIKAMI_MODE env var, required if not set.
+// Mode defaults to AIKAMI_MODE env var, falling back to emulator when
+// neither is set.
 
+import { isAikamiMode, resolveAikamiMode } from '../env/mode';
 import {
   type AikamiMode,
   type DevService,
@@ -57,23 +59,17 @@ export const resolveMode = (args: string[]): AikamiMode => {
   const modeIndex = args.indexOf('--mode');
   if (modeIndex !== -1 && args[modeIndex + 1]) {
     const val = args[modeIndex + 1];
-    if (!VALID_MODES.includes(val as AikamiMode)) {
+    if (!isAikamiMode(val)) {
       console.error(`Invalid mode: ${val}. Valid: ${VALID_MODES.join(', ')}`);
       process.exit(1);
     }
-    return val as AikamiMode;
+    return val;
   }
 
-  const envMode = process.env.AIKAMI_MODE;
-  if (envMode && VALID_MODES.includes(envMode as AikamiMode)) {
-    return envMode as AikamiMode;
-  }
-
-  console.error(
-    `No mode specified. Set AIKAMI_MODE env var or use --mode <mode>.\n` +
-      `Valid modes: ${VALID_MODES.join(', ')}`,
-  );
-  process.exit(1);
+  // No --mode: fall back to AIKAMI_MODE env, defaulting to the local
+  // emulator. Staging/production require credentials that fail fast anyway,
+  // so an accidental default can't hit the cloud.
+  return resolveAikamiMode();
 };
 
 export const parseServiceArgs = (args: string[]): ServiceArgs => {
@@ -82,7 +78,7 @@ export const parseServiceArgs = (args: string[]): ServiceArgs => {
     console.error(
       'Usage: bun herdr:start <services> [--mode <mode>] [--join] [--force] [--force-ports]\n' +
         '  services:      firebase, client, hub, voice, image, text, text-ollama, image-comfyui, postgres, preview-client, site, preview-site, preview-hub, tauri, all (comma-separated)\n' +
-        '  mode:          emulator | staging | production (default: $AIKAMI_MODE)\n' +
+        '  mode:          emulator | staging | production (default: emulator)\n' +
         '  --join:        attach to session after starting\n' +
         '  --force:       kill and recreate if workspace already exists\n' +
         '  --force-ports: kill whatever is bound to each target port first (e.g. a leftover process from a crashed prior run) instead of failing with EADDRINUSE\n',

--- a/scripts/src/lib/herdr/join.ts
+++ b/scripts/src/lib/herdr/join.ts
@@ -3,7 +3,7 @@
 // Join (attach to) the herdr session displaying aikami workspaces.
 //
 // Usage:
-//   bun herdr:join                 # uses $AIKAMI_MODE to verify workspace exists
+//   bun herdr:join                 # uses $AIKAMI_MODE, defaults to emulator
 //   bun herdr:join --mode emulator
 
 import { resolveMode } from './cli.ts';

--- a/scripts/src/lib/herdr/session.test.ts
+++ b/scripts/src/lib/herdr/session.test.ts
@@ -237,6 +237,22 @@ describe('wrapCommand', () => {
     const wrapped = wrapCommand(`echo it's fine`);
     expect(wrapped).toContain(String.raw`it'\''s`);
   });
+
+  it('emits a PowerShell `&` call-operator invocation for PowerShell panes', () => {
+    // PowerShell rejects the POSIX `'bash' -c '…'` form (parse error at `-c`),
+    // so a PowerShell pane gets `& 'bash' '<temp-script>'` instead. The script
+    // lives in a file to dodge PowerShell's native-arg `"` mangling.
+    const wrapped = wrapCommand('bun run dev', 'powershell');
+    expect(wrapped).toMatch(/^& '.*bash.*' '.*\.sh'$/);
+    expect(wrapped).not.toMatch(/' .* -c /);
+    expect(wrapped).not.toContain('Press Enter to close');
+  });
+
+  it('keeps the POSIX -c form for posix panes', () => {
+    const wrapped = wrapCommand('bun run dev', 'posix');
+    expect(wrapped).toContain('-c');
+    expect(wrapped).toContain('Press Enter to close');
+  });
 });
 
 describe('posixQuote', () => {

--- a/scripts/src/lib/herdr/session.test.ts
+++ b/scripts/src/lib/herdr/session.test.ts
@@ -1,7 +1,8 @@
 // scripts/src/lib/herdr/session.test.ts
-import { describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import net from 'node:net';
+import { resetDirenvCache } from '../env/direnv_detect.ts';
 import { posixQuote, which } from '../env/which.ts';
 import {
   ALL_SERVICES,
@@ -219,6 +220,11 @@ describe('isPortReady protocol probe (C-387)', () => {
 });
 
 describe('wrapCommand', () => {
+  // Force the non-direnv path so the shape assertions below are deterministic
+  // regardless of whether the test machine has direnv on PATH. The direnv
+  // cases are pinned explicitly in their own tests.
+  beforeEach(() => resetDirenvCache(false));
+
   it('wraps in bash with the keep-open trailer on a machine that has bash', () => {
     const wrapped = wrapCommand('bun run dev');
     expect(wrapped).toContain('bash');
@@ -252,6 +258,42 @@ describe('wrapCommand', () => {
     const wrapped = wrapCommand('bun run dev', 'posix');
     expect(wrapped).toContain('-c');
     expect(wrapped).toContain('Press Enter to close');
+  });
+
+  it('invokes the temp bash script with CMD-compatible double quotes for cmd panes', () => {
+    // cmd.exe treats single quotes as literals, so the POSIX `'bash' -c '…'`
+    // form must never reach a cmd pane. The command is a double-quoted bash
+    // path + double-quoted temp .sh path; the keep-open trailer lives inside
+    // the script file, not the command string.
+    const wrapped = wrapCommand('bun run dev', 'cmd');
+    expect(wrapped).toMatch(/^".*bash.*" ".*\.sh"$/);
+    expect(wrapped).not.toContain("'");
+    expect(wrapped).not.toContain('-c');
+    expect(wrapped).not.toContain('Press Enter to close');
+  });
+
+  it('routes the PowerShell temp-script invocation through direnv exec when direnv is available', () => {
+    resetDirenvCache(true);
+    try {
+      const wrapped = wrapCommand('bun run dev', 'powershell');
+      // `&` is only valid as the first token of a PowerShell command, so the
+      // direnv form must not carry it.
+      expect(wrapped).toMatch(/^direnv exec \. '.*bash.*' '.*\.sh'$/);
+      expect(wrapped).not.toMatch(/^& /);
+    } finally {
+      resetDirenvCache(undefined);
+    }
+  });
+
+  it('retains direnv exec for cmd panes when direnv is available', () => {
+    resetDirenvCache(true);
+    try {
+      const wrapped = wrapCommand('bun run dev', 'cmd');
+      expect(wrapped).toMatch(/^direnv exec \. ".*bash.*" ".*\.sh"$/);
+      expect(wrapped).not.toContain("'");
+    } finally {
+      resetDirenvCache(undefined);
+    }
   });
 });
 

--- a/scripts/src/lib/herdr/session.ts
+++ b/scripts/src/lib/herdr/session.ts
@@ -842,6 +842,14 @@ export const detectPaneShell = async (paneId: string): Promise<PaneShell> => {
 const psQuote = (value: string): string => `'${value.replaceAll("'", "''")}'`;
 
 /**
+ * Quote a value as a CMD double-quoted argument, escaping embedded `"` as
+ * `\"` (cmd.exe has no literal-quote escape inside a `"…"` token; `\"` is
+ * the accepted convention for native args). Used for `cmd` panes, which
+ * treat POSIX single quotes as literals.
+ */
+const cmdQuote = (value: string): string => `"${value.replaceAll('"', '\\"')}"`;
+
+/**
  * Write `script` to a unique temp .sh file and return its path. Used for
  * PowerShell panes, where passing `-c <script>` through PowerShell's native
  * arg mangling (embedded `"` becomes `\"` in the command line) corrupts the
@@ -879,7 +887,11 @@ const writeTempBashScript = (script: string): string => {
  * PowerShell panes get `& 'bash' 'script.sh'` with the script in a temp
  * file — PowerShell rejects the POSIX `'bash' -c '…'` form (parse error at
  * `-c`) and mangles embedded `"` in native args, so a file is the only
- * reliable transport.
+ * reliable transport. With direnv, both the PowerShell and CMD forms route
+ * through `direnv exec .` so the pane still gets the flake devShell env.
+ * CMD panes invoke the temp script with double-quoted args (`cmd.exe` treats
+ * single quotes as literals); the keep-open trailer is preserved in all
+ * bash-backed forms.
  */
 export const wrapCommand = (command: string, shell: PaneShell = 'posix'): string => {
   const bash = findBash();
@@ -887,7 +899,23 @@ export const wrapCommand = (command: string, shell: PaneShell = 'posix'): string
     const script = `${command}; echo; echo "${PANE_TRAILER}"; read`;
     if (shell === 'powershell') {
       const scriptPath = writeTempBashScript(`#!/usr/bin/env bash\n${script}\n`);
+      // With direnv, route through `direnv exec .` so the pane gets the flake
+      // devShell env; the `&` call operator is only valid as the first token,
+      // so it is dropped in the direnv form.
+      if (hasDirenv()) {
+        return `direnv exec . ${psQuote(bash)} ${psQuote(scriptPath)}`;
+      }
       return `& ${psQuote(bash)} ${psQuote(scriptPath)}`;
+    }
+    if (shell === 'cmd') {
+      // cmd.exe treats single quotes as literals, so the POSIX `-c '…'` form
+      // would pass the script text as one literal arg and fail. Use the same
+      // temp-script transport as PowerShell, invoked with CMD-compatible
+      // double-quote escaping. direnv exec is retained for the direnv case,
+      // matching the POSIX path.
+      const scriptPath = writeTempBashScript(`#!/usr/bin/env bash\n${script}\n`);
+      const invocation = `${cmdQuote(bash)} ${cmdQuote(scriptPath)}`;
+      return hasDirenv() ? `direnv exec . ${invocation}` : invocation;
     }
     // Quoted so a Windows path like `C:\Program Files\Git\bin\bash.exe`
     // survives the pane shell's tokenizing — unquoted, the space in "Program

--- a/scripts/src/lib/herdr/session.ts
+++ b/scripts/src/lib/herdr/session.ts
@@ -43,11 +43,20 @@
 
 // biome-ignore-all lint/style/useNamingConvention: HerDr API response field names (snake_case) — must match external API contract
 import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
 import net from 'node:net';
-import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 // need to be relative path since .pi/extensions/herdr-orchestrator.ts uses the same code and pi does not support path aliases
 import { contractPortOffset, PORTS } from '../../../../packages/shared/constants/src/index';
 import { hasDirenv } from '../env/direnv_detect';
+
+// Re-exported for back-compat — the canonical definition now lives in
+// ../env/mode (single source of truth for mode resolution).
+import type { AikamiMode } from '../env/mode';
+
+export type { AikamiMode } from '../env/mode';
+
 import {
   killPid,
   killPortUnsafe,
@@ -58,8 +67,6 @@ import {
 import { findBash, posixQuote } from '../env/which';
 
 // ── Types ──────────────────────────────────────────────────
-
-export type AikamiMode = 'emulator' | 'staging' | 'production';
 
 /** Canonical service names (used internally). */
 export type DevService =
@@ -463,6 +470,11 @@ export const herdr = (args: string[], opts: HerdrOptions = {}): Promise<HerdrRes
     const proc = spawn('herdr', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, ...opts.env },
+      // Windows: herdr is a console app — without windowsHide every headless
+      // CLI call flashes a new console window (open/close popup storm). The
+      // contract pipeline polls herdr every ~500ms, so this must be hidden.
+      // No-op on POSIX.
+      windowsHide: true,
     });
     let out = '';
     let errOut = '';
@@ -648,6 +660,9 @@ export const ensureServer = async (): Promise<void> => {
   const proc = spawn('herdr', ['server'], {
     stdio: 'ignore',
     env: process.env,
+    // Windows: hide the server's console window — without this it appears as
+    // a stray popup, and closing that window kills the server mid-run.
+    windowsHide: true,
   });
   proc.unref(); // detach — don't keep parent event loop alive
 
@@ -784,6 +799,65 @@ export const killPort = async (port: number): Promise<void> => {
 const PANE_TRAILER = '=== Stopped. Press Enter to close ===';
 
 /**
+ * The shell a herdr pane runs — governs how a command string must be quoted
+ * before `pane run` sends it to the pane's PTY.
+ */
+export type PaneShell = 'powershell' | 'nushell' | 'cmd' | 'posix';
+
+/**
+ * Map a pane's foreground process name to the shell kind it represents.
+ * herdr launches panes with the user's configured default shell — on this
+ * Windows install that is `powershell.exe` (the old "panes default to
+ * Nushell" comment predates herdr 0.8.0-preview).
+ */
+const paneShellFromProcessName = (name: string): PaneShell => {
+  const n = name.toLowerCase().replace(/\.exe$/, '');
+  if (n.includes('powershell') || n.includes('pwsh')) {
+    return 'powershell';
+  }
+  if (n === 'cmd' || n.includes('cmd')) {
+    return 'cmd';
+  }
+  if (n === 'nu' || n === 'nushell' || n.includes('nu')) {
+    return 'nushell';
+  }
+  return 'posix';
+};
+
+/** Detect the shell running in a herdr pane (defaults to posix on failure). */
+export const detectPaneShell = async (paneId: string): Promise<PaneShell> => {
+  try {
+    const r = await herdrJson<PaneProcessInfo>(['pane', 'process-info', '--pane', paneId]);
+    const name = r?.result?.process_info?.foreground_processes?.[0]?.name;
+    return name ? paneShellFromProcessName(name) : 'posix';
+  } catch {
+    return 'posix';
+  }
+};
+
+/**
+ * Quote a value for a PowerShell single-quoted string: `'` → `''`.
+ * PowerShell has no POSIX `'\''` escape; doubling is the single-quote escape.
+ */
+const psQuote = (value: string): string => `'${value.replaceAll("'", "''")}'`;
+
+/**
+ * Write `script` to a unique temp .sh file and return its path. Used for
+ * PowerShell panes, where passing `-c <script>` through PowerShell's native
+ * arg mangling (embedded `"` becomes `\"` in the command line) corrupts the
+ * script. A file avoids the `-c` boundary entirely: only two quoted paths
+ * cross the shell.
+ */
+const writeTempBashScript = (script: string): string => {
+  const path = join(
+    tmpdir(),
+    `herdr-pane-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sh`,
+  );
+  writeFileSync(path, script, 'utf-8');
+  return path;
+};
+
+/**
  * Wraps a command for a herdr pane, in descending order of fidelity:
  *
  *   1. bash + direnv — `direnv exec .` loads the flake devShell (bun, jdk,
@@ -799,15 +873,25 @@ const PANE_TRAILER = '=== Stopped. Press Enter to close ===';
  *      exit, but the command still runs.
  *
  * `bash` is passed as an absolute path (see `findBash`) because herdr panes
- * default to Nushell on Windows, whose PATH does not include Git's bash.
+ * default to the user's shell on Windows (PowerShell here), whose PATH does
+ * not include Git's bash.
+ *
+ * PowerShell panes get `& 'bash' 'script.sh'` with the script in a temp
+ * file — PowerShell rejects the POSIX `'bash' -c '…'` form (parse error at
+ * `-c`) and mangles embedded `"` in native args, so a file is the only
+ * reliable transport.
  */
-export const wrapCommand = (command: string): string => {
+export const wrapCommand = (command: string, shell: PaneShell = 'posix'): string => {
   const bash = findBash();
   if (bash) {
     const script = `${command}; echo; echo "${PANE_TRAILER}"; read`;
+    if (shell === 'powershell') {
+      const scriptPath = writeTempBashScript(`#!/usr/bin/env bash\n${script}\n`);
+      return `& ${psQuote(bash)} ${psQuote(scriptPath)}`;
+    }
     // Quoted so a Windows path like `C:\Program Files\Git\bin\bash.exe`
-    // survives Nushell's tokenizing — unquoted, the space in "Program Files"
-    // would split it into two args.
+    // survives the pane shell's tokenizing — unquoted, the space in "Program
+    // Files" would split it into two args.
     const prefix = hasDirenv() ? `direnv exec . ${posixQuote(bash)} -c` : `${posixQuote(bash)} -c`;
     return `${prefix} ${posixQuote(script)}`;
   }
@@ -820,6 +904,28 @@ export const wrapCommand = (command: string): string => {
   }
 
   return command;
+};
+
+/** Detect the pane's shell, then wrap the command for it. */
+export const wrapCommandForPane = async (paneId: string, command: string): Promise<string> =>
+  wrapCommand(command, await detectPaneShell(paneId));
+
+/**
+ * Run a raw bash script in a pane, shell-aware. Same PowerShell-vs-POSIX
+ * split as {@link wrapCommand}: PowerShell gets a temp script file invoked
+ * via `& 'bash' 'file'` (its native-arg `"` mangling corrupts `-c`), other
+ * shells get `'bash' -c '<script>'`.
+ */
+export const bashScriptForPane = async (paneId: string, script: string): Promise<string> => {
+  const bash = findBash();
+  if (!bash) {
+    return script;
+  }
+  if ((await detectPaneShell(paneId)) === 'powershell') {
+    const scriptPath = writeTempBashScript(`#!/usr/bin/env bash\n${script}\n`);
+    return `& ${psQuote(bash)} ${psQuote(scriptPath)}`;
+  }
+  return `${posixQuote(bash)} -c ${posixQuote(script)}`;
 };
 
 /**
@@ -1080,7 +1186,12 @@ export const startServices = async (config: SessionConfig): Promise<string> => {
     // Rename initial tab and run command
     const rootPaneId = r.result.root_pane.pane_id;
     await herdr(['tab', 'rename', `${workspaceId}:1`, svc.name]);
-    await herdr(['pane', 'run', rootPaneId, wrapCommand(buildServiceCommand(first, mode, offset))]);
+    await herdr([
+      'pane',
+      'run',
+      rootPaneId,
+      await wrapCommandForPane(rootPaneId, buildServiceCommand(first, mode, offset)),
+    ]);
     console.log(`  ✓ Tab: ${svc.name}`);
 
     // Add remaining services as new tabs
@@ -1102,7 +1213,10 @@ export const startServices = async (config: SessionConfig): Promise<string> => {
           'pane',
           'run',
           tabR.result.root_pane.pane_id,
-          wrapCommand(buildServiceCommand(service, mode, offset)),
+          await wrapCommandForPane(
+            tabR.result.root_pane.pane_id,
+            buildServiceCommand(service, mode, offset),
+          ),
         ]);
         console.log(`  ✓ Tab: ${s.name}`);
       }
@@ -1128,7 +1242,10 @@ export const startServices = async (config: SessionConfig): Promise<string> => {
                 'pane',
                 'run',
                 servicePane.pane_id,
-                wrapCommand(buildServiceCommand(service, mode, offset)),
+                await wrapCommandForPane(
+                  servicePane.pane_id,
+                  buildServiceCommand(service, mode, offset),
+                ),
               ]);
               continue;
             }
@@ -1157,7 +1274,10 @@ export const startServices = async (config: SessionConfig): Promise<string> => {
           'pane',
           'run',
           tabR.result.root_pane.pane_id,
-          wrapCommand(buildServiceCommand(service, mode, offset)),
+          await wrapCommandForPane(
+            tabR.result.root_pane.pane_id,
+            buildServiceCommand(service, mode, offset),
+          ),
         ]);
         console.log(`  ✓ Tab: ${svc.name}`);
       }

--- a/scripts/src/lib/herdr/start_autofix.ts
+++ b/scripts/src/lib/herdr/start_autofix.ts
@@ -1,19 +1,22 @@
 // scripts/src/lib/herdr/start_autofix.ts
 //
 // Spawns a pi agent in the aikami-pi workspace configured for automated
-// fix → typecheck → test → commit/push workflows.
+// fix → typecheck → test workflows. Commit/push runs ONLY on explicit caller
+// request (`--only commit` or `commit` in `--only`) — the default pipeline
+// stops after validation and never mutates the repository.
 //
 // Model: deepseek-v4-pro (best for correctness, falls back to v4-flash if unavailable)
 // Thinking: high (non-negotiable for reliable fixes)
 //
 // Usage:
-//   bun autofix                              # fix + typecheck + commit (git-scoped, default)
-//   bun autofix --all                        # fix + typecheck + test:unit + commit (git-scoped)
-//   bun autofix --scope all                  # fix + typecheck + test + commit (entire project)
-//   bun autofix --scope all --all             # entire project + all tests
-//   bun autofix --only commit                # commit only (pre-commit hook covers fix/typecheck)
+//   bun autofix                              # fix + typecheck (git-scoped; stops after validation)
+//   bun autofix --all                        # fix + typecheck + test:unit (git-scoped; stops after validation)
+//   bun autofix --scope all                  # fix + typecheck (entire project; stops after validation)
+//   bun autofix --scope all --all             # entire project + all tests (stops after validation)
+//   bun autofix --only commit                # commit only — explicit authorization (pre-commit hook covers fix/typecheck)
 //   bun autofix --only fix,typecheck         # fix + typecheck, no commit (git-scoped)
-//   bun autofix --only test,commit           # test:unit then commit (git-scoped)
+//   bun autofix --only fix,typecheck,commit  # fix + typecheck + explicit commit (git-scoped)
+//   bun autofix --only test,commit           # test:unit then commit (git-scoped; commit explicitly authorized)
 //   bun autofix --only test:e2e              # e2e tests only (starts client + firebase)
 //   bun autofix --only test:all              # all tests including e2e
 //   bun autofix --model deepseek/deepseek-v4-flash --thinking high
@@ -62,8 +65,12 @@ type AutofixStep = 'fix' | 'typecheck' | 'test' | 'commit';
 type TestMode = 'unit' | 'e2e' | 'all';
 type ScopeMode = 'git' | 'all';
 
-const ALL_STEPS: AutofixStep[] = ['fix', 'typecheck', 'test', 'commit'];
-const DEFAULT_STEPS: AutofixStep[] = ['fix', 'typecheck', 'commit'];
+// `commit` is deliberately NOT in the implicit step sets: staging, committing
+// and pushing require explicit caller authorization (`--only commit`, or
+// `commit` in an explicit `--only` list). The default pipeline stops after
+// validation.
+const ALL_STEPS: AutofixStep[] = ['fix', 'typecheck', 'test'];
+const DEFAULT_STEPS: AutofixStep[] = ['fix', 'typecheck'];
 
 // ── Constants ──────────────────────────────────────────────
 
@@ -376,17 +383,18 @@ const buildSystemPrompt = async (baselineDir: string | null): Promise<string> =>
 
   let stepNum = 0;
   const stepsText: string[] = [];
+  const scopedFileArgs = gitFiles.map((f) => `'${f}'`).join(' ');
 
   if (doFix) {
     stepNum += 1;
     stepsText.push(
-      `## STEP ${stepNum}: \`bun run fix\``,
+      `## STEP ${stepNum}: \`bun run fix\` (git-scoped)`,
       isGitScoped
-        ? '1. Run `bun run fix` on **git-scoped files only**.'
+        ? `1. Run: \`bunx biome check --write ${scopedFileArgs} --error-on-warnings --no-errors-on-unmatched\` — the command receives ONLY the git-scoped files above, so biome cannot process anything outside that set. Files biome ignores (e.g. docs/*.md) are skipped, not lint targets.`
         : '1. Run `bun run fix` on the entire project.',
       '2. Fix errors and warnings at the source. Prefer minimal, mechanical edits.',
       '3. 🔴 **CIRCUIT BREAKER**: If you cannot fix an error after **5 attempts**, use an escape hatch (see rules below).',
-      '4. Do not proceed until `bun run fix` outputs zero errors.',
+      '4. Do not proceed until the fix command outputs zero errors AND zero warnings.',
       '',
     );
   }
@@ -394,13 +402,13 @@ const buildSystemPrompt = async (baselineDir: string | null): Promise<string> =>
   if (doTypecheck) {
     stepNum += 1;
     stepsText.push(
-      `## STEP ${stepNum}: \`bun run typecheck\``,
+      `## STEP ${stepNum}: \`bun run typecheck\` (affected projects)`,
       isGitScoped
-        ? '1. Run `bun run typecheck` on **git-scoped files only**.'
+        ? '1. Run: `(git diff --name-only; git diff --name-only --cached) | bunx moon run :typecheck --affected --stdin` — the git-scoped file list is piped into moon, so ONLY projects touched by those files are type-checked.'
         : '1. Run `bun run typecheck` on the entire project.',
       '2. Fix every type error by adjusting interfaces or adding imports.',
       '3. 🔴 **CIRCUIT BREAKER**: If you cannot fix a type error after **5 attempts**, use an escape hatch (see rules below).',
-      '4. Do not proceed until `bun run typecheck` passes cleanly.',
+      '4. Do not proceed until the typecheck command passes cleanly.',
       '',
     );
   }
@@ -408,6 +416,19 @@ const buildSystemPrompt = async (baselineDir: string | null): Promise<string> =>
   if (doTest) {
     stepNum += 1;
     stepsText.push(...(await buildTestPrompt(stepNum)));
+  }
+
+  if (!doCommit) {
+    // Default flow: no repository mutations. The agent validates, then
+    // stops — committing/pushing only happens on explicit caller request.
+    stepNum += 1;
+    stepsText.push(
+      `## STEP ${stepNum}: Validate and stop`,
+      '1. 🔴 **VALIDATION GATE**: Run `bun moon run :validate` on all affected projects. Do not proceed until it passes cleanly.',
+      '2. Run `git status --porcelain=v1 --untracked-files=all` and confirm every modified path is in the git-scoped set above (plus this prompt file). If any out-of-scope or protected file changed, STOP and report it — do NOT revert it (destructive git is forbidden); fix the underlying issue in source instead.',
+      '3. 🔴 **STOP**: Do NOT stage, commit, or push. Repository mutations require explicit caller authorization (`bun autofix --only commit`, or `commit` in `--only`). Report a final diff summary instead.',
+      '',
+    );
   }
 
   if (doCommit) {
@@ -435,7 +456,7 @@ const buildSystemPrompt = async (baselineDir: string | null): Promise<string> =>
     '# WORKFLOW',
     stepsText.join('\n'),
     '# STRICT RULES',
-    '- **🔴 DESTRUCTIVE GIT IS FORBIDDEN**: NEVER run `git checkout --`, `git checkout .`, `git restore`, `git clean`, `git reset --hard`, or `git stash drop`. These destroy uncommitted work. The ONLY git mutations allowed are `git add`, `git commit`, and `git push origin HEAD` (commit step only).',
+    '- **🔴 DESTRUCTIVE GIT IS FORBIDDEN**: NEVER run `git checkout --`, `git checkout .`, `git restore`, `git clean`, `git reset --hard`, or `git stash drop`. These destroy uncommitted work. Git mutations (`git add`, `git commit`, `git push origin HEAD`) are ONLY allowed inside an explicitly authorized commit step (commit-only runs).',
     "- **🔴 WINDOWS CRLF CHURN — IGNORE IT**: On Windows (`core.autocrlf=true`), `bun run fix` (biome --write) rewrites files as LF while git expects CRLF, so `git status` will list MANY 'modified' files with ZERO content change. NEVER 'clean up' or revert them. To see real changes use `git diff --numstat HEAD` — entries like `0\t0` are pure line-ending churn and must be left untouched.",
     '- **🔴 PROTECT PRE-EXISTING WORK**: The working tree may contain uncommitted changes from before your run. If you ever lose or accidentally revert work, STOP and restore from the baseline snapshot (`bun run autofix:restore <timestamp>`) instead of improvising.',
     '- **Load Conventions First**: Before writing ANY code, load the `aikami-conventions` skill. Read `.context/CONTEXT.md` and `.context/index.md` before making structural changes (file moves, new packages, boundary changes).',
@@ -443,7 +464,7 @@ const buildSystemPrompt = async (baselineDir: string | null): Promise<string> =>
     '- **Step-by-Step**: Re-run the verification command (`bun run fix`, `typecheck`, etc.) after EVERY file edit to confirm your fix worked.',
     '- **Never Skip**: A step must pass cleanly before you move to the next.',
     '- **No Human Intervention**: Do NOT ask questions. If you are entirely blocked, explain why and stop.',
-    '- **Forbidden Paths**: Do NOT modify .pi/, node_modules/, config files (moon.yml, biome.json, biome.jsonc, tsconfig*.json, lint_rules.json), or examples/.',
+    '- **Forbidden Paths**: Do NOT modify node_modules/, config files (moon.yml, biome.json, biome.jsonc, tsconfig*.json, lint_rules.json), or examples/. Within .pi/, ONLY the git-scoped .pi files listed above and this prompt file (`.pi/autofix/system_prompt.md`) may be modified — every other .pi/ path is protected.',
     '- **🔴 BRANCH SAFETY — NEVER `git push` alone**: Always use `git push origin HEAD`. Plain `git push` may target the wrong branch if the local branch tracks a different remote branch (e.g. `origin/main` instead of the current feature branch). `git push origin HEAD` ALWAYS pushes to the current branch. If you see an upstream mismatch error, do NOT fall back to `git push origin HEAD:main` — push to the CURRENT branch.',
     baselineDir
       ? `- **Baseline snapshot**: The pre-run working tree is saved at \`${baselineDir}\`. It contains tracked.patch (all modifications vs HEAD) plus copies of untracked files. If you think you destroyed something, tell the user to run \`bun run autofix:restore <timestamp>\`.`
@@ -534,17 +555,22 @@ const buildTaskText = async (baselineDir: string | null): Promise<string> => {
     '',
   ];
   let stepNum = 0;
+  const scopedFileArgs = gitFiles.map((f) => `'${f}'`).join(' ');
 
   if (doFix) {
     stepNum += 1;
     lines.push(
-      `${stepNum}. \`bun run fix\` — Fix errors mechanically. Max 5 retries per error. Escape hatches allowed as last resort.`,
+      isGitScoped
+        ? `${stepNum}. Fix (git-scoped): \`bunx biome check --write ${scopedFileArgs} --error-on-warnings --no-errors-on-unmatched\` — fixes ONLY the git-scoped files. Max 5 retries per error; escape hatches allowed as last resort.`
+        : `${stepNum}. \`bun run fix\` — Fix errors mechanically. Max 5 retries per error. Escape hatches allowed as last resort.`,
     );
   }
   if (doTypecheck) {
     stepNum += 1;
     lines.push(
-      `${stepNum}. \`bun run typecheck\` — Fix types. Max 5 retries per error. Escape hatches allowed as last resort.`,
+      isGitScoped
+        ? `${stepNum}. Typecheck (affected): \`(git diff --name-only; git diff --name-only --cached) | bunx moon run :typecheck --affected --stdin\` — type-checks only the projects touched by git-scoped files. Max 5 retries per error; escape hatches allowed as last resort.`
+        : `${stepNum}. \`bun run typecheck\` — Fix types. Max 5 retries per error. Escape hatches allowed as last resort.`,
     );
   }
   if (doTest) {
@@ -558,7 +584,12 @@ const buildTaskText = async (baselineDir: string | null): Promise<string> => {
   if (doCommit) {
     stepNum += 1;
     lines.push(
-      `${stepNum}. Review diff → \`git add -A\` → \`git commit --no-verify -m "..."\` → \`git push origin HEAD\``,
+      `${stepNum}. Review diff → \`git add -A\` → \`git commit --no-verify -m "..."\` → \`git push origin HEAD\` (explicitly authorized commit — the caller passed \`commit\` in --only).`,
+    );
+  } else {
+    stepNum += 1;
+    lines.push(
+      `${stepNum}. 🔴 STOP after validation — do NOT stage, commit, or push. Repository mutations require explicit caller authorization (\`bun autofix --only commit\`).`,
     );
   }
 

--- a/scripts/src/lib/herdr/start_autofix.ts
+++ b/scripts/src/lib/herdr/start_autofix.ts
@@ -25,6 +25,7 @@ import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
+import { resolveAikamiMode } from '../env/mode';
 import type { AikamiMode } from './session.ts';
 import {
   buildSessionName,
@@ -35,7 +36,7 @@ import {
   herdrJson,
   isPortReady,
   startServices,
-  wrapCommand,
+  wrapCommandForPane,
 } from './session.ts';
 
 const execAsync = promisify(exec);
@@ -288,7 +289,7 @@ const ensureService = async (
   readyCheck: (port: number, timeout: number) => Promise<boolean>,
   timeoutSec: number,
 ): Promise<void> => {
-  const mode: AikamiMode = (process.env.AIKAMI_MODE as AikamiMode) ?? 'emulator';
+  const mode: AikamiMode = resolveAikamiMode();
   const wsLabel = buildSessionName(mode);
   const wsId = await findWorkspace(wsLabel);
 
@@ -675,7 +676,7 @@ if (existingWsId) {
       promptPath,
     ].join(' ');
 
-    await herdr(['pane', 'run', paneId, wrapCommand(command)]);
+    await herdr(['pane', 'run', paneId, await wrapCommandForPane(paneId, command)]);
     ok(`autofix agent starting in ${PI_WORKSPACE}/${AUTOFIX_TAB}`);
 
     await new Promise((r) => setTimeout(r, 3000));
@@ -718,7 +719,7 @@ if (existingWsId) {
   ].join(' ');
 
   await herdr(['tab', 'rename', `${wsId}:1`, AUTOFIX_TAB]);
-  await herdr(['pane', 'run', rootPaneId, wrapCommand(command)]);
+  await herdr(['pane', 'run', rootPaneId, await wrapCommandForPane(rootPaneId, command)]);
   ok(`autofix agent running in ${PI_WORKSPACE}/${AUTOFIX_TAB}`);
 
   await new Promise((r) => setTimeout(r, 3000));

--- a/scripts/src/lib/herdr/start_pi.ts
+++ b/scripts/src/lib/herdr/start_pi.ts
@@ -14,7 +14,7 @@ import {
   getWorkspaceTabNames,
   herdr,
   herdrJson,
-  wrapCommand,
+  wrapCommandForPane,
 } from './session.ts';
 
 // ── Types ──────────────────────────────────────────────────
@@ -76,7 +76,12 @@ if (existingWsId) {
     ]);
 
     if (tabR?.result) {
-      await herdr(['pane', 'run', tabR.result.root_pane.pane_id, wrapCommand(PI_COMMAND)]);
+      await herdr([
+        'pane',
+        'run',
+        tabR.result.root_pane.pane_id,
+        await wrapCommandForPane(tabR.result.root_pane.pane_id, PI_COMMAND),
+      ]);
       ok(`pi tab added to ${PI_WORKSPACE}`);
     } else {
       console.error('❌ Failed to create pi tab');
@@ -104,7 +109,7 @@ if (existingWsId) {
   wsId = createR.result.workspace.workspace_id;
   const rootPaneId = createR.result.root_pane.pane_id;
   await herdr(['tab', 'rename', `${wsId}:1`, PI_TAB]);
-  await herdr(['pane', 'run', rootPaneId, wrapCommand(PI_COMMAND)]);
+  await herdr(['pane', 'run', rootPaneId, await wrapCommandForPane(rootPaneId, PI_COMMAND)]);
   ok(`pi running in ${PI_WORKSPACE}`);
 }
 

--- a/scripts/src/lib/herdr/task.ts
+++ b/scripts/src/lib/herdr/task.ts
@@ -39,7 +39,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { runGit, sanitizeBranchName } from '../agents/git_worktree.ts';
-import { findWorkspace, herdr, herdrJson, wrapCommand } from './session.ts';
+import { resolveAikamiMode } from '../env/mode';
+import { findWorkspace, herdr, herdrJson, wrapCommandForPane } from './session.ts';
 import {
   bootstrapWorktree,
   createWorktree,
@@ -168,7 +169,7 @@ const launchPiInWorktree = async (w: TaskWorktree): Promise<void> => {
   const r = await herdrJson<{ result: { pane_id: string } }>(['pane', 'get', w.rootPaneId]);
   const paneId = r?.result?.pane_id ?? w.rootPaneId;
   await herdr(['tab', 'rename', `${w.workspaceId}:1`, 'pi']);
-  await herdr(['pane', 'run', paneId, wrapCommand('pi')]);
+  await herdr(['pane', 'run', paneId, await wrapCommandForPane(paneId, 'pi')]);
   ok(`pi running in workspace ${w.workspaceId} (tab "pi")`);
 };
 
@@ -223,7 +224,7 @@ const cmdNew = async (args: string[]): Promise<void> => {
       const owner = {
         checkoutPath: w.checkoutPath,
         branch: w.branch,
-        mode: process.env.AIKAMI_MODE ?? 'emulator',
+        mode: resolveAikamiMode(),
         claimedAt: new Date().toISOString(),
       };
       const ownerPath = devStackOwnerPath();

--- a/scripts/src/lib/herdr/worktree.ts
+++ b/scripts/src/lib/herdr/worktree.ts
@@ -555,6 +555,8 @@ export CONTRACT_PIPELINE_WORKTREE=1
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: checkoutPath,
       timeout: 5000,
+      // Windows: hide the cmd.exe console window this spawn would otherwise flash.
+      windowsHide: true,
     });
   } catch {
     // direnv may not be installed — not fatal. The .envrc stays in place
@@ -613,6 +615,8 @@ export CONTRACT_PIPELINE_WORKTREE=1
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout: timeoutMs,
+        // Windows: hide the cmd.exe console window (no-op on POSIX).
+        windowsHide: true,
       });
       installed = true;
     } catch {
@@ -729,6 +733,8 @@ export const removeWorktree = async (
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 30_000,
+          // Windows: hide the cmd.exe console window (no-op on POSIX).
+          windowsHide: true,
         });
         checkoutRemoved = true;
       } catch (rmErr: unknown) {
@@ -871,6 +877,8 @@ export const openPullRequest = async (
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: 30_000,
+    // Windows: hide the cmd.exe console window (no-op on POSIX).
+    windowsHide: true,
   }).trim();
   const m = result.match(/https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/);
   return { prUrl: m?.[0] ?? result, prNumber: m?.[1] ?? '' };

--- a/scripts/src/lib/ops/dev_all.ts
+++ b/scripts/src/lib/ops/dev_all.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+
 // scripts/src/lib/ops/dev_all.ts
 /**
  * Start all development services using the unified herdr workspace library.
@@ -15,20 +16,14 @@
  *   bun run herdr:stop all            # Stop everything
  */
 
+import { resolveAikamiMode } from '../env/mode';
 import { type AikamiMode, hasHerdr, startServices } from '../herdr/session.ts';
 
-const VALID_MODES: AikamiMode[] = ['emulator', 'staging', 'production'];
 const args = process.argv.slice(2);
 const detach = args.includes('--detach') || args.includes('-d');
 
 // Read mode from env or default to emulator
-const mode: AikamiMode = (() => {
-  const envMode = process.env.AIKAMI_MODE;
-  if (envMode && VALID_MODES.includes(envMode as AikamiMode)) {
-    return envMode as AikamiMode;
-  }
-  return 'emulator';
-})();
+const mode: AikamiMode = resolveAikamiMode();
 
 async function main() {
   console.log(`

--- a/scripts/src/lib/ops/preview_hub.ts
+++ b/scripts/src/lib/ops/preview_hub.ts
@@ -13,6 +13,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { PORTS } from '@aikami/constants';
 import { c, error, info, ok } from '../cli_utils.ts';
+import { resolveAikamiMode } from '../env/mode';
 import type { AikamiMode } from '../herdr/session.ts';
 import { findWorkspace, isPortReady, resolveSessionName, startServices } from '../herdr/session.ts';
 
@@ -93,10 +94,7 @@ const launchChromium = async (port: number) => {
 
 // ── Main ───────────────────────────────────────────────────────────────────
 
-const mode: AikamiMode =
-  process.env.AIKAMI_MODE === 'staging' || process.env.AIKAMI_MODE === 'production'
-    ? process.env.AIKAMI_MODE
-    : 'emulator';
+const mode: AikamiMode = resolveAikamiMode();
 
 console.log(`\n${c.bold}Aikami Hub Preview${c.reset}\n`);
 info(`Mode: ${mode}`);

--- a/scripts/src/lib/ops/preview_site.ts
+++ b/scripts/src/lib/ops/preview_site.ts
@@ -13,6 +13,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { PORTS } from '@aikami/constants';
 import { c, error, info, ok } from '../cli_utils.ts';
+import { resolveAikamiMode } from '../env/mode';
 import type { AikamiMode } from '../herdr/session.ts';
 import { findWorkspace, isPortReady, resolveSessionName, startServices } from '../herdr/session.ts';
 
@@ -93,10 +94,7 @@ const launchChromium = async (port: number) => {
 
 // ── Main ───────────────────────────────────────────────────────────────────
 
-const mode: AikamiMode =
-  process.env.AIKAMI_MODE === 'staging' || process.env.AIKAMI_MODE === 'production'
-    ? process.env.AIKAMI_MODE
-    : 'emulator';
+const mode: AikamiMode = resolveAikamiMode();
 
 console.log(`\n${c.bold}Aikami Site Preview${c.reset}\n`);
 info(`Mode: ${mode}`);

--- a/scripts/src/lib/postgres/lifecycle.test.ts
+++ b/scripts/src/lib/postgres/lifecycle.test.ts
@@ -49,9 +49,11 @@ describe('postgres lifecycle config', () => {
   });
 
   it('keeps all state under the repo-local .postgres dir', () => {
-    expect(dataDir()).toContain('/.postgres/data');
-    expect(runDir()).toContain('/.postgres/run');
-    expect(logFile()).toContain('/.postgres/');
+    // Platform-agnostic: on Windows the repo-local dir is `\.postgres\…`,
+    // on POSIX `/.postgres/…` — assert via path.join so both pass.
+    expect(dataDir()).toContain(join('.postgres', 'data'));
+    expect(runDir()).toContain(join('.postgres', 'run'));
+    expect(logFile()).toContain(join('.postgres', ''));
   });
 
   it('resolves the repo root from the script location', () => {

--- a/scripts/src/lib/test_blackbox/run.ts
+++ b/scripts/src/lib/test_blackbox/run.ts
@@ -203,7 +203,11 @@ async function main() {
 async function checkHerdrAvailable(): Promise<boolean> {
   const { spawn } = await import('node:child_process');
   return new Promise((resolve) => {
-    const proc = spawn('herdr', ['--version'], { stdio: 'ignore' });
+    const proc = spawn('herdr', ['--version'], {
+      stdio: 'ignore',
+      // Windows: hide the console window this spawn would otherwise flash.
+      windowsHide: true,
+    });
     proc.on('close', (code) => resolve(code === 0));
     proc.on('error', () => resolve(false));
   });


### PR DESCRIPTION
## Summary

Fixes Windows console-popup storms and PowerShell pane command failures across the herdr dev tooling, and unifies Aikami deployment-mode resolution into a single source of truth.

### Changes

**Windows console-window hiding**
- Added `windowsHide: true` to every `spawn`/`execSync` in scripts, `.pi` extensions, and runners — headless herdr/git/bun calls no longer flash a new console window per call (the contract pipeline polls herdr every ~500ms, so this was a popup storm).

**Pane-shell-aware commands (`session.ts`)**
- Detect the pane's shell (PowerShell vs posix) via `pane process-info`.
- PowerShell panes get `& 'bash' 'script.sh'` with the script in a temp file — PowerShell rejects the POSIX `'bash' -c '…'` form and mangles embedded `"` in native args.
- New `wrapCommandForPane` + `bashScriptForPane`; `wrapCommand` kept for back-compat.
- `herdr_adapter.ts` log tailing now routes through bash on Windows (no native `tail` in PowerShell panes).

**Unified mode resolution (`scripts/src/lib/env/mode.ts`, new)**
- Single source of truth: `resolveAikamiMode` / `isAikamiMode` / `isEmulatorMode` with emulator as the safe default.
- All scripts and pi extensions now use it instead of ad-hoc `AIKAMI_MODE` parsing (cli.ts, dev_all.ts, preview_hub/site, check.ts, secrets.ts, scripts_env.ts, chrome_devtools.ts, firebase_tools.ts, herdr_adapter.ts, start_autofix.ts, task.ts).

**Contract pipeline fixes**
- `contract_sync.ts`: `gitRelPath` normalizes backslash paths to forward slashes for git on Windows (`update-index --cacheinfo` rejected `docs\contracts\C-400.md`).
- `firebase_tools.ts`: narrowed `params.env` via `isAikamiMode` (TS2322 fix).

**Docs**
- C-400 contract critic pass: third resolver copy (`game_boot_service`, the production `/game` path) added to RC-1/Reuse Map/Phase 2; OQ-1/OQ-2 resolved (index 97 valid, all Emberwatch indices resolve), OQ-3 confirmed (one authored NPC per map; extra heads are emergent entities); whisper-caves 4-layer validator policy; `validate:content` wired into `moon ci`.

### Verification
- `bun run fix`: clean (0 errors) on all git-scoped files.
- `bun run typecheck`: clean (`scripts` + `pi`).
- `moon run :validate` equivalent (lint + format + typecheck): all pass.
- `scripts:test`: 36/36 in `session.test.ts` including new PowerShell pane tests; 11 remaining failures pre-existing at HEAD (verified against clean HEAD worktree — 19 failures there; this branch fixes 8 of them).
- Contract lint: 0 issues for C-400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved Windows shell support for development sessions and command execution.
  - Commands now adapt to the active terminal shell, including PowerShell and POSIX environments.
  - Deployment mode selection is now consistent across tools, with emulator mode used when unspecified or invalid.

- **Bug Fixes**
  - Prevented unwanted console windows from appearing during background operations on Windows.
  - Improved cross-platform handling of log viewing and workspace commands.

- **Safety**
  - Autofix workflows now limit changes to files identified by the current Git diff and protect pre-existing work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->