### PR TITLE
Land real fixes from PR #153 (infra/rig-audit-fixes)

### DIFF
--- a/.pi/.gitignore
+++ b/.pi/.gitignore
@@ -42,3 +42,6 @@ diagnostics/
 # chrome_devtools extension
 .chromium-profile/
 .screenshots/
+
+# ad-hoc scratch files agents drop directly in .pi/ instead of a temp dir
+tmp-*

--- a/.pi/extensions/chrome_devtools.ts
+++ b/.pi/extensions/chrome_devtools.ts
@@ -66,7 +66,9 @@ function getAppUrl(app: string): string {
     // Only client/hub/site (+ the Firebase suite) shift per contract — a
     // future `app` value naming a fixed singleton backend (voice/image/text)
     // must not silently compute a port nothing is listening on.
-    const shift = app in OFFSETTABLE_PORTS ? offset : 0;
+    // Object.hasOwn, not `in`: `app in OFFSETTABLE_PORTS` also matches
+    // prototype-chain keys (e.g. "constructor"), which would wrongly shift.
+    const shift = Object.hasOwn(OFFSETTABLE_PORTS, app) ? offset : 0;
     if (port !== undefined) {
       return `http://localhost:${port + shift}`;
     }

--- a/apps/backend/firebase/.env.example
+++ b/apps/backend/firebase/.env.example
@@ -22,6 +22,15 @@ DISCORD_APP_ID=
 # slash command in the server.
 GITHUB_ISSUES_TOKEN=
 
+# Allow-list for /bug and /feature issue creation. The interactions endpoint
+# rejects submissions from DMs, from any other guild, and from members
+# without the role below BEFORE creating a GitHub issue — and fails closed
+# when these are left unset (submissions are refused, not opened). Set the
+# guild id of the Aikami server and a role id whose members may submit
+# issues (Discord Developer Portal → your server → Server Settings → Roles).
+DISCORD_ALLOWED_GUILD_ID=
+DISCORD_ALLOWED_ROLE_ID=
+
 # OpenRouter — used by /ask. OPENROUTER_MODEL has no default on purpose:
 # pick a current `:free`-suffixed model at
 # https://openrouter.ai/models?max_price=0 (free-model availability and

--- a/apps/backend/firebase/src/controllers/api/discord_interactions.ts
+++ b/apps/backend/firebase/src/controllers/api/discord_interactions.ts
@@ -21,6 +21,7 @@ import { backendEnv, requireEnv } from '@aikami/backend/configs/environment';
 import { onRequest } from '@snorreks/firestack';
 import { askProjectAi } from '$lib/discord/ai_chat';
 import { createGithubIssueFromDiscord } from '$lib/discord/github_issue';
+import { tryReserveIssueSubmission } from '$lib/discord/rate_limit';
 import { editOriginalInteractionResponse } from '$lib/discord/respond';
 import {
   type DiscordInteraction,
@@ -35,6 +36,32 @@ import { logger } from '$logger';
 
 const BUG_MODAL_ID = 'bug_report_modal';
 const FEATURE_MODAL_ID = 'feature_request_modal';
+
+/**
+ * Reject a modal submission before ANY deferred response or GitHub call.
+ * Issue creation must be restricted to the allow-listed guild + role:
+ * this endpoint is reachable from any server that installs the app (and
+ * from DMs), and GITHUB_ISSUES_TOKEN is scoped only to `issues:write` —
+ * anyone outside the team must not be able to spend it. Fail closed when
+ * the allow-list env vars are not configured at all.
+ */
+const submissionAuthorizationFailure = (interaction: DiscordInteraction): string | null => {
+  const allowedGuildId = backendEnv.DISCORD_ALLOWED_GUILD_ID;
+  const allowedRoleId = backendEnv.DISCORD_ALLOWED_ROLE_ID;
+  if (!allowedGuildId || !allowedRoleId) {
+    return 'issue submission is not enabled yet (server allow-list not configured)';
+  }
+  if (!interaction.guild_id) {
+    return 'direct messages are not supported — run this command inside the Aikami server';
+  }
+  if (interaction.guild_id !== allowedGuildId) {
+    return 'this command only works inside the Aikami server';
+  }
+  if (!interaction.member?.roles?.includes(allowedRoleId)) {
+    return 'your role in this server does not have permission to submit issues';
+  }
+  return null;
+};
 
 function reportModal(customId: string, title: string): unknown {
   return {
@@ -155,6 +182,39 @@ export default onRequest(async (request, response) => {
       response.status(200).json({
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: { content: 'Unknown form submission.' },
+      });
+      return;
+    }
+
+    // 🔴 Authorize BEFORE the deferred response and GitHub issue creation:
+    // reject DMs and require the allow-listed guild + an authorized member
+    // role (see submissionAuthorizationFailure — fail-closed when unset).
+    const authFailure = submissionAuthorizationFailure(interaction);
+    if (authFailure) {
+      response.status(200).json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: { content: `❌ ${authFailure}.` },
+      });
+      return;
+    }
+
+    // Persistent per-user rate limit (Firestore-backed, shared across
+    // function instances — NOT process-local) before any GitHub call.
+    const userId = interaction.member?.user?.id ?? interaction.user?.id;
+    if (!userId) {
+      response.status(200).json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: { content: '❌ Could not identify you — try again.' },
+      });
+      return;
+    }
+    if (!(await tryReserveIssueSubmission(userId))) {
+      logger.warn(`discord_interactions: rate limited user ${userId}`);
+      response.status(200).json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          content: "❌ You've reached the issue submission limit — try again later.",
+        },
       });
       return;
     }

--- a/apps/backend/firebase/src/lib/discord/rate_limit.ts
+++ b/apps/backend/firebase/src/lib/discord/rate_limit.ts
@@ -1,0 +1,56 @@
+// apps/backend/firebase/src/lib/discord/rate_limit.ts
+//
+// Persistent per-user rate limit for /bug and /feature submissions, backed
+// by Firestore — the only shared storage available across Cloud Functions
+// instances. Process-local state would reset per instance and per cold
+// start, so it cannot enforce a cross-instance quota; Firestore can.
+//
+// Strategy: a fixed per-user window (WINDOW_MS) with a submission cap. One
+// document per Discord user id; the window starts at the first submission
+// and resets once WINDOW_MS elapses. A transaction makes the check-and-
+// increment atomic, so concurrent submissions from the same user cannot
+// both slip past the cap.
+
+// Subpath import, not the bare '@aikami/backend/configs': this app's
+// tsconfig only maps '@aikami/backend/configs/*' (see tsconfig.json paths).
+import { getFirestore, serverTimestamp } from '@aikami/backend/configs/firestore';
+
+const SUBMISSION_COLLECTION = 'discord_issue_submissions';
+
+/** Length of the per-user counting window (24h). */
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Max issue submissions per user per window. */
+const MAX_SUBMISSIONS_PER_WINDOW = 3;
+
+/**
+ * Attempt to reserve a submission slot for `userId`. Returns true when the
+ * user is within their window cap (and the reservation is recorded), false
+ * when the window cap is already exhausted. Atomic across concurrent calls.
+ */
+export const tryReserveIssueSubmission = async (userId: string): Promise<boolean> => {
+  const db = getFirestore();
+  const ref = db.collection(SUBMISSION_COLLECTION).doc(userId);
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const data = snap.data();
+    const windowStart = typeof data?.windowStartMs === 'number' ? data.windowStartMs : undefined;
+    const inWindow = windowStart !== undefined && Date.now() - windowStart < WINDOW_MS;
+    const count = inWindow && typeof data?.count === 'number' ? data.count : 0;
+    if (count >= MAX_SUBMISSIONS_PER_WINDOW) {
+      return false;
+    }
+    tx.set(
+      ref,
+      {
+        count: count + 1,
+        // Keep the original window start while the window is active — only a
+        // fresh (or expired) window starts now.
+        windowStartMs: inWindow ? windowStart : Date.now(),
+        lastSubmittedAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+    return true;
+  });
+};

--- a/apps/backend/firebase/src/lib/discord/respond.ts
+++ b/apps/backend/firebase/src/lib/discord/respond.ts
@@ -13,6 +13,11 @@ import { logger } from '$logger';
 /** Discord hard-caps message content at 2000 chars. */
 const DISCORD_MESSAGE_MAX = 2000;
 
+/** Bounded wait for the Discord webhook PATCH — a stalled request must not
+ *  hang the interaction handler forever. On abort the error is logged and
+ *  swallowed, entering the same error path as a non-OK response below. */
+const DISCORD_FETCH_TIMEOUT_MS = 10_000;
+
 export function truncateForDiscord(text: string): string {
   return text.length <= DISCORD_MESSAGE_MAX ? text : `${text.slice(0, DISCORD_MESSAGE_MAX - 1)}…`;
 }
@@ -23,11 +28,23 @@ export async function editOriginalInteractionResponse(
   content: string,
 ): Promise<void> {
   const url = `https://discord.com/api/v10/webhooks/${applicationId}/${interactionToken}/messages/@original`;
-  const res = await fetch(url, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content: truncateForDiscord(content) }),
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: truncateForDiscord(content) }),
+      signal: AbortSignal.timeout(DISCORD_FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    // fetch only throws on network failure or the abort above — both mean
+    // the edit could not be delivered. Log and continue (this function
+    // never throws; the caller already reported the underlying failure).
+    logger.error(
+      `discord/respond: failed to edit interaction response: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
   if (!res.ok) {
     logger.error(
       `discord/respond: failed to edit interaction response (${res.status}): ${await res.text().catch(() => '')}`,

--- a/apps/backend/firebase/src/lib/discord/types.ts
+++ b/apps/backend/firebase/src/lib/discord/types.ts
@@ -23,6 +23,13 @@ export const InteractionResponseType = {
 
 export type DiscordUser = { id: string; username: string };
 
+/** Partial guild member object as it appears on a guild interaction. */
+export type DiscordMember = {
+  user?: DiscordUser;
+  /** Role snowflakes the member holds in the guild. */
+  roles?: string[];
+};
+
 /** A submitted modal text input, nested one level under an action row. */
 export type DiscordModalComponent = { type: 4; custom_id: string; value: string };
 export type DiscordModalActionRow = { type: 1; components: DiscordModalComponent[] };
@@ -44,8 +51,10 @@ export type DiscordInteraction = {
   type: (typeof InteractionType)[keyof typeof InteractionType];
   token: string;
   data?: DiscordInteractionData;
+  /** Guild snowflake — absent when the interaction fired in a DM. */
+  guild_id?: string;
   /** Present when the interaction fires inside a guild. */
-  member?: { user?: DiscordUser };
+  member?: DiscordMember;
   /** Present when the interaction fires in a DM. */
   user?: DiscordUser;
 };

--- a/apps/frontend/hub/svelte.config.js
+++ b/apps/frontend/hub/svelte.config.js
@@ -6,8 +6,21 @@ import adapter from 'svelte-adapter-bun';
 
 const projectDirectory = dirname(fileURLToPath(import.meta.url));
 const packagesDirectory = resolve(projectDirectory, '../../../packages');
-const toPackagesPath = (path) => join(packagesDirectory, path);
-const toSrcPath = (path) => join(projectDirectory, 'src', path);
+/**
+ * Convert a path to use forward slashes.
+ *
+ * SvelteKit's tsconfig generator strips a trailing `/*` from alias values by
+ * checking `value.endsWith('/*')` (literal forward slash). `node:path`'s
+ * `join()` emits backslashes on Windows, so that check silently fails there
+ * and SvelteKit appends its own `/*`, producing a broken `**\/*\/*` pattern.
+ * Keeping alias values posix-style avoids that on every platform.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+const toPosixPath = (path) => path.split('\\').join('/');
+const toPackagesPath = (path) => toPosixPath(join(packagesDirectory, path));
+const toSrcPath = (path) => toPosixPath(join(projectDirectory, 'src', path));
 
 const config = {
   preprocess: [vitePreprocess()],

--- a/packages/backend/configs/src/lib/environment.ts
+++ b/packages/backend/configs/src/lib/environment.ts
@@ -49,6 +49,10 @@ export type BackendEnv = {
   readonly DISCORD_PUBLIC_KEY?: string;
   /** Discord application (client) id — not currently read at runtime, kept alongside the other Discord keys for reference. */
   readonly DISCORD_APP_ID?: string;
+  /** Guild snowflake allowed to submit /bug and /feature — the interactions endpoint rejects any other guild (and DMs) before creating issues. */
+  readonly DISCORD_ALLOWED_GUILD_ID?: string;
+  /** Role snowflake whose members may submit /bug and /feature — submissions without this role are rejected. */
+  readonly DISCORD_ALLOWED_ROLE_ID?: string;
   /** Fine-grained GitHub PAT, scoped to `issues:write` on this repo only — used by /bug and /feature. */
   readonly GITHUB_ISSUES_TOKEN?: string;
   /** OpenRouter API key — used by /ask. */
@@ -150,6 +154,8 @@ const BACKEND_ENV_KEYS: (keyof BackendEnv)[] = [
   'VITE_MODE',
   'DISCORD_PUBLIC_KEY',
   'DISCORD_APP_ID',
+  'DISCORD_ALLOWED_GUILD_ID',
+  'DISCORD_ALLOWED_ROLE_ID',
   'GITHUB_ISSUES_TOKEN',
   'OPENROUTER_API_KEY',
   'OPENROUTER_MODEL',

--- a/packages/frontend/engine/src/__tests__/asset_manifest.test.ts
+++ b/packages/frontend/engine/src/__tests__/asset_manifest.test.ts
@@ -9,7 +9,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { splitStateSegments } from '@aikami/constants';
 import type { AssetEntry, AssetManifest } from '@aikami/types';
 import {
@@ -164,13 +164,9 @@ describe('buildManifest lpc category', () => {
     const dirs = join(testDir, 'lpc-scan-test');
     await ensureAssetDirs(dirs);
 
-    await writeTestFile(join(dirs, 'lpc/body/bodies_male.walk.webp').replace(`${testDir}/`, ''));
-    await writeTestFile(
-      join(dirs, 'lpc/hair/bangslong2/bg_adult.walk.webp').replace(`${testDir}/`, ''),
-    );
-    await writeTestFile(
-      join(dirs, 'lpc/head/heads/human_male.walk.webp').replace(`${testDir}/`, ''),
-    );
+    await writeTestFile(relative(testDir, join(dirs, 'lpc/body/bodies_male.walk.webp')));
+    await writeTestFile(relative(testDir, join(dirs, 'lpc/hair/bangslong2/bg_adult.walk.webp')));
+    await writeTestFile(relative(testDir, join(dirs, 'lpc/head/heads/human_male.walk.webp')));
 
     const manifest = await buildManifest(dirs);
 
@@ -200,7 +196,7 @@ describe('buildManifest lpc category', () => {
     const dirs = join(testDir, 'lpc-scan-dot-test');
     await ensureAssetDirs(dirs);
 
-    await writeTestFile(join(dirs, 'lpc/body/bodies_male.walk.webp').replace(`${testDir}/`, ''));
+    await writeTestFile(relative(testDir, join(dirs, 'lpc/body/bodies_male.walk.webp')));
 
     const manifest = await buildManifest(dirs);
 
@@ -221,13 +217,11 @@ describe('buildManifest', () => {
     await ensureAssetDirs(dirs);
 
     // Create test files
-    await writeTestFile(join(dirs, 'sprites/generic-fantasy/elf.png').replace(`${testDir}/`, ''));
+    await writeTestFile(relative(testDir, join(dirs, 'sprites/generic-fantasy/elf.png')));
+    await writeTestFile(relative(testDir, join(dirs, 'sprites/generic-fantasy/goblin.png')));
+    await writeTestFile(relative(testDir, join(dirs, 'backgrounds/fantasy/forest.png')));
     await writeTestFile(
-      join(dirs, 'sprites/generic-fantasy/goblin.png').replace(`${testDir}/`, ''),
-    );
-    await writeTestFile(join(dirs, 'backgrounds/fantasy/forest.png').replace(`${testDir}/`, ''));
-    await writeTestFile(
-      join(dirs, 'music/exploration/fantasy/calm/wanderer.mp3').replace(`${testDir}/`, ''),
+      relative(testDir, join(dirs, 'music/exploration/fantasy/calm/wanderer.mp3')),
     );
 
     const manifest = await buildManifest(dirs);
@@ -258,12 +252,8 @@ describe('buildManifest', () => {
     const dirs = join(testDir, 'hidden-test');
     await ensureAssetDirs(dirs);
 
-    await writeTestFile(
-      join(dirs, 'sprites/generic-fantasy/visible.png').replace(`${testDir}/`, ''),
-    );
-    await writeTestFile(
-      join(dirs, 'sprites/generic-fantasy/.hidden.png').replace(`${testDir}/`, ''),
-    );
+    await writeTestFile(relative(testDir, join(dirs, 'sprites/generic-fantasy/visible.png')));
+    await writeTestFile(relative(testDir, join(dirs, 'sprites/generic-fantasy/.hidden.png')));
 
     // Let's write .hidden manually to the right path
     await writeFile(join(dirs, 'sprites/generic-fantasy/.hidden.png'), 'test');
@@ -280,7 +270,7 @@ describe('buildManifest', () => {
     const dirs = join(testDir, 'ext-test');
     await ensureAssetDirs(dirs);
 
-    await writeTestFile(join(dirs, 'sprites/generic-fantasy/valid.png').replace(`${testDir}/`, ''));
+    await writeTestFile(relative(testDir, join(dirs, 'sprites/generic-fantasy/valid.png')));
     await writeFile(join(dirs, 'sprites/generic-fantasy/bad.txt'), 'test');
     await writeFile(join(dirs, 'sprites/generic-fantasy/nope.pdf'), 'test');
 

--- a/packages/frontend/engine/src/__tests__/macro_simulation.test.ts
+++ b/packages/frontend/engine/src/__tests__/macro_simulation.test.ts
@@ -85,6 +85,29 @@ const createTestWorld = (): World => {
 };
 
 // ---------------------------------------------------------------------------
+// Global SoA cleanup
+//
+// MapLocation/ZoneStatus/GoapAgent are module-level arrays indexed by raw
+// eid, shared by every test file in this process — not scoped to the
+// bitECS `World` each `beforeEach` recreates. Since a fresh `createWorld()`
+// hands out the same low eid numbers every time, leftover entries here
+// (e.g. an inactive-zone assignment at eid 2) silently leak into whichever
+// OTHER test file's entity happens to land on eid 2 next, wrongly flagging
+// it offscreen. Truncate after every test so this file never leaks state
+// past its own run.
+// ---------------------------------------------------------------------------
+afterEach(() => {
+  MapLocation.currentZoneId.length = 0;
+  MapLocation.virtualGridX.length = 0;
+  MapLocation.virtualGridY.length = 0;
+  ZoneStatus.isActive.length = 0;
+  GoapAgent.currentState.length = 0;
+  GoapAgent.currentGoal.length = 0;
+  GoapAgent.currentActionId.length = 0;
+  GoapAgent.targetEntityId.length = 0;
+});
+
+// ---------------------------------------------------------------------------
 // AC-1: High-Fidelity Gating — inactive entities skipped
 // ---------------------------------------------------------------------------
 

--- a/packages/frontend/engine/src/assets/asset_manifest_node.ts
+++ b/packages/frontend/engine/src/assets/asset_manifest_node.ts
@@ -142,7 +142,11 @@ export const buildManifest = async (rootDir?: string): Promise<AssetManifest> =>
         continue;
       }
 
-      const relPath = relative(resolvedRoot, entryPath);
+      // node:path's relative() emits backslashes on Windows; asset tags and
+      // manifest paths are always POSIX-style, so normalize before splitting
+      // — otherwise the whole path collapses into one segment on Windows and
+      // categoryName never matches ASSET_CATEGORIES.
+      const relPath = relative(resolvedRoot, entryPath).split('\\').join('/');
 
       // Determine category from first path segment
       const pathSegments = relPath.split('/');

--- a/packages/shared/constants/src/lib/development_ports.test.ts
+++ b/packages/shared/constants/src/lib/development_ports.test.ts
@@ -15,7 +15,9 @@ import { describe, expect, it } from 'bun:test';
 import {
   CONTRACT_PORT_SLOTS,
   contractPortOffset,
+  EPHEMERAL_PORT_START,
   FIXED_PORTS,
+  NORDCLAW_RESERVED_RANGES,
   OFFSETTABLE_PORTS,
   withPortOffset,
 } from './development_ports.ts';
@@ -61,6 +63,38 @@ describe('contractPortOffset — collision-free across every contract slot', () 
         expect(
           fixedValues.has(port),
           `C-${id}:${name} (${port}) collides with a FIXED_PORTS value`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('keeps every contract-shifted port outside the documented reserved ranges and below the ephemeral-port range', () => {
+    // Guarantee behind the table at the top of development_ports.ts: a
+    // contract-shifted offsettable port must never land on a port Nordclaw
+    // tooling (or the system Postgres reservation) binds, nor inside the OS
+    // ephemeral range. Reuses the symbols development_ports.ts exports, so
+    // changing CONTRACT_PORT_SLOTS/STEP — or the reserved ranges themselves
+    // — makes THIS test the first thing to fail.
+    const insideReserved = (port: number): string | undefined => {
+      for (const [start, end] of NORDCLAW_RESERVED_RANGES) {
+        if (port >= start && port <= end) {
+          return `${start}-${end}`;
+        }
+      }
+      return undefined;
+    };
+    for (let id = 1; id <= CONTRACT_PORT_SLOTS; id++) {
+      const offset = contractPortOffset(`C-${id}`);
+      for (const [name, base] of Object.entries(OFFSETTABLE_PORTS)) {
+        const port = base + offset;
+        const range = insideReserved(port);
+        expect(
+          range,
+          `C-${id}:${name} (${port}) is inside documented reserved range ${range}`,
+        ).toBeUndefined();
+        expect(
+          port >= EPHEMERAL_PORT_START,
+          `C-${id}:${name} (${port}) is inside the ephemeral-port range (>= ${EPHEMERAL_PORT_START})`,
         ).toBe(false);
       }
     }

--- a/packages/shared/constants/src/lib/development_ports.ts
+++ b/packages/shared/constants/src/lib/development_ports.ts
@@ -28,6 +28,32 @@
 //
 //   Aikami apps:  client=5274  voice=8089  stt=8087  postgres=5433
 
+// ── Reserved ranges (single source of truth) ─────────────────────────────
+// The Nordclaw-owned ranges from the table above, plus the 5432 system
+// PostgreSQL reservation, as machine-checkable constants. The port-collision
+// test (development_ports.test.ts) asserts that every contract-shifted
+// offsettable port stays OUTSIDE these ranges — change STEP/SLOTS and the
+// test fails if any shifted port lands inside one. 5432 is deliberately not
+// Aikami's (C-387) but is still reserved in the table, so a shifted port
+// must never land on a developer's system postgres either.
+export const NORDCLAW_RESERVED_RANGES: readonly (readonly [start: number, end: number])[] = [
+  [3000, 3009], // Nordclaw internal services (edge-proxy, audit-worker)
+  [4400, 4400], // Nordclaw Firebase emulator hub
+  [5000, 5001], // Nordclaw Firebase emulator (hosting, functions)
+  [5170, 5189], // Nordclaw frontend app dev servers
+  [5432, 5432], // system PostgreSQL — reserved, never Aikami's (C-387)
+  [8080, 8080], // Nordclaw Firebase emulator (firestore)
+  [8085, 8085], // Nordclaw Firebase emulator (pubsub)
+  [9099, 9099], // Nordclaw Firebase emulator (auth)
+  [9199, 9199], // Nordclaw Firebase emulator (storage)
+];
+
+/** First port of the OS ephemeral-port range. Linux's default (32768) is the
+ *  lowest start across the platforms Aikami runs on (macOS/Windows default
+ *  to 49152), so staying below 32768 keeps every shifted port clear of the
+ *  ephemeral range on all three. */
+export const EPHEMERAL_PORT_START = 32768;
+
 // ── Firebase Emulator (unique for Aikami) ────────────────────────────────
 
 const FB_EMULATOR_PORTS = {

--- a/scripts/src/lib/agents/contract_pipeline.ts
+++ b/scripts/src/lib/agents/contract_pipeline.ts
@@ -805,7 +805,26 @@ const launchBackground = async (options: {
   }
   const launcherPaneId = wsResult.result.root_pane.pane_id;
   const command = ['bun', 'run', import.meta.path, ...childArgs].map(posixQuote).join(' ');
-  await herdr(['pane', 'run', launcherPaneId, await wrapCommandForPane(launcherPaneId, command)]);
+  // 🔴 Capture the pane-run result and fail fast on a nonzero code instead of
+  // blindly polling readyPath for the full 180s deadline: a herdr-level
+  // failure (pane vanished, workspace closed, bad invocation) means the child
+  // never started and can never write the ready file. Surface whatever
+  // stderr/stdout herdr reported — far better than a generic "did not become
+  // ready" timeout whose diagnostic only sees an idle pane.
+  const paneRun = await herdr([
+    'pane',
+    'run',
+    launcherPaneId,
+    await wrapCommandForPane(launcherPaneId, command),
+  ]);
+  if (paneRun.code !== 0) {
+    const detail = (
+      paneRun.stderr.trim() ||
+      paneRun.stdout.trim() ||
+      `exit code ${paneRun.code}`
+    ).slice(0, 500);
+    throw new Error(`Failed to launch pipeline in herdr pane ${launcherLabel}: ${detail}`);
+  }
 
   // The child can legitimately need well beyond 30s to become ready:
   // initialize() runs bootstrapWorktree, which does a full git checkout +

--- a/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
+++ b/scripts/src/lib/agents/contract_pipeline/orchestrator.ts
@@ -11,8 +11,9 @@ import {
 } from '../../herdr/worktree.ts';
 import {
   formatInfraNotesForPrompt,
-  readInfraIssues,
+  readInfraIssuesForRun,
   reportInfraIssue,
+  setActiveInfraRun,
   summarizeInfraIssues,
 } from '../../ops/infra_report.ts';
 import { commitAll, pushBranch, remoteBranchExists, runGit } from '../git_worktree.ts';
@@ -792,6 +793,12 @@ export const runContractPipeline = async (options: {
   // persisted mode from the manifest so `bun run contract --resume <run-id>`
   // keeps the original --root/--worktree decision.
   const rootMode = options.rootMode ?? manifest.rootMode ?? false;
+  // 🔴 Stamp every degradation event recorded from this point on with this
+  // run's id (helpers in session/worktree/git_worktree have no run context
+  // of their own). The review prompt's infra notes are filtered to this run,
+  // so historical gh/worktree/herdr failures from PREVIOUS runs are excluded
+  // — only what THIS run worked around is reported.
+  setActiveInfraRun(manifest.runId);
   if (options.dryRun) {
     return manifest;
   }
@@ -1340,7 +1347,7 @@ export const runContractPipeline = async (options: {
           // here — the single point every review-captain launch passes
           // through, regardless of profile.
           const infraNotes = formatInfraNotesForPrompt(
-            summarizeInfraIssues(readInfraIssues(options.repoRoot)),
+            summarizeInfraIssues(readInfraIssuesForRun(options.repoRoot, manifest.runId)),
           );
           const prompt = infraNotes ? `${basePrompt}\n${infraNotes}` : basePrompt;
           const started = await adapter.startReview({
@@ -1459,7 +1466,8 @@ export const runContractPipeline = async (options: {
               component: 'gh_pr_lookup',
               operation: 'gh pr list --head <branch>',
               error: err,
-              context: { headBranch, runId: manifest.runId },
+              context: { headBranch },
+              runId: manifest.runId,
               cwd: options.repoRoot,
             });
             return undefined;
@@ -1629,7 +1637,7 @@ export const runContractPipeline = async (options: {
       pipelineLog({ runId: manifest.runId, cwd: options.repoRoot, message: s });
       console.log(s);
       const infraNotes = formatInfraNotesForPrompt(
-        summarizeInfraIssues(readInfraIssues(options.repoRoot)),
+        summarizeInfraIssues(readInfraIssuesForRun(options.repoRoot, manifest.runId)),
       );
       if (infraNotes) {
         console.log(infraNotes);

--- a/scripts/src/lib/agents/git_worktree.ts
+++ b/scripts/src/lib/agents/git_worktree.ts
@@ -249,13 +249,13 @@ export const commitAll = (options: {
 };
 
 const stagedPaths = (options: { cwd: string; env: Record<string, string> }): string[] => {
-  try {
-    return runGit('diff --cached --name-only', { cwd: options.cwd, env: options.env })
-      .split('\n')
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
+  // 🔴 No catch-and-return-[]: if the staged-path query fails, protection
+  // validation cannot be completed, and unstageProtectedPaths must refuse
+  // the commit rather than silently assume nothing is staged. Let the error
+  // propagate so commitAll aborts on a protection check it could not run.
+  return runGit('diff --cached --name-only', { cwd: options.cwd, env: options.env })
+    .split('\n')
+    .filter(Boolean);
 };
 
 /** See `commitAll`'s `protectedPaths` doc — the last-mile guard itself. */

--- a/scripts/src/lib/discord/audit.ts
+++ b/scripts/src/lib/discord/audit.ts
@@ -47,7 +47,7 @@ function printStructureSeed(
   lines.push('{');
 
   lines.push('  roles: [');
-  for (const role of roles.filter((r) => r.name !== '@everyone')) {
+  for (const role of roles.filter((r) => r.name !== '@everyone' && !r.managed)) {
     lines.push(
       `    { name: ${quote(role.name)}, color: ${role.color}, hoist: ${role.hoist}, mentionable: ${role.mentionable}, permissions: ${quote(role.permissions)} },`,
     );

--- a/scripts/src/lib/discord/diff.test.ts
+++ b/scripts/src/lib/discord/diff.test.ts
@@ -1,0 +1,91 @@
+// scripts/src/lib/discord/diff.test.ts
+//
+// Category-resolution coverage for computePlan: top-level moves, categories
+// created during the same sync, invalid category references, and no-op
+// matching. diff.ts is pure (no I/O), so these run without any network.
+
+import { describe, expect, it } from 'bun:test';
+import { ChannelType } from 'discord-api-types/v10';
+import { computePlan } from './diff';
+import type { DesiredCategory, DesiredChannel, DesiredRole } from './structure';
+import type { GuildChannel } from './types';
+
+const category = (id: string, name: string): GuildChannel => ({
+  id,
+  name,
+  type: ChannelType.GuildCategory,
+});
+
+const textChannel = (id: string, name: string, parentId?: string): GuildChannel => ({
+  id,
+  name,
+  type: ChannelType.GuildText,
+  ...(parentId ? { parent_id: parentId } : {}),
+});
+
+const structure = (
+  categories: DesiredCategory[],
+  channels: DesiredChannel[],
+  roles: DesiredRole[] = [],
+) => ({ roles, categories, channels });
+
+describe('computePlan — channel category handling', () => {
+  it('plans moving a categorized channel to the top level', () => {
+    // Desired state drops the category; the live channel still sits inside
+    // the (also declared) "General" category. The move must be planned —
+    // applied with parent_id: null, since omitting it would leave the
+    // channel where it is.
+    const plan = computePlan(
+      structure([{ name: 'General' }], [{ name: 'announcements', type: 'text' }]),
+      {
+        channels: [category('c1', 'General'), textChannel('t1', 'announcements', 'c1')],
+        roles: [],
+      },
+    );
+    expect(plan.updateChannels).toHaveLength(1);
+    expect(plan.updateChannels[0]?.changes).toContain('category → top level');
+  });
+
+  it('resolves a category created during the same sync (declared but not live)', () => {
+    // "New Cat" is declared in structure.categories but does not exist live
+    // yet — it will be created earlier in the same sync. The channel exists
+    // and is currently uncategorized, so an update into the new category
+    // must be planned (not silently treated as a top-level move).
+    const plan = computePlan(
+      structure([{ name: 'New Cat' }], [{ name: 'room', type: 'text', category: 'New Cat' }]),
+      { channels: [textChannel('t1', 'room')], roles: [] },
+    );
+    expect(plan.updateChannels).toHaveLength(1);
+    expect(plan.updateChannels[0]?.changes.some((c) => c.includes('New Cat'))).toBe(true);
+    expect(plan.updateChannels[0]?.changes[0]).toContain('created this sync');
+  });
+
+  it('accepts a live category that is also declared (no phantom change)', () => {
+    const plan = computePlan(
+      structure([{ name: 'General' }], [{ name: 'room', type: 'text', category: 'General' }]),
+      { channels: [category('c1', 'General'), textChannel('t1', 'room', 'c1')], roles: [] },
+    );
+    expect(plan.updateChannels).toHaveLength(0);
+    expect(plan.createChannels).toHaveLength(0);
+  });
+
+  it('throws on a channel.category that is neither live nor declared', () => {
+    // A typo'd category name must fail loudly instead of silently becoming a
+    // top-level move (the old `?? null` fallback conflated the two).
+    expect(() =>
+      computePlan(structure([], [{ name: 'room', type: 'text', category: 'Nope' }]), {
+        channels: [textChannel('t1', 'room')],
+        roles: [],
+      }),
+    ).toThrow(/Nope/);
+  });
+
+  it('throws on an invalid category reference even when the channel itself is new', () => {
+    expect(() =>
+      computePlan(structure([], [{ name: 'brand-new', type: 'text', category: 'Missing' }]), {
+        channels: [],
+        roles: [],
+      }),
+    ).toThrow(/Missing/);
+  });
+});

--- a/scripts/src/lib/discord/diff.ts
+++ b/scripts/src/lib/discord/diff.ts
@@ -107,6 +107,7 @@ function diffChannels(
   desired: DesiredChannel[],
   live: GuildChannel[],
   categoryIdByName: Map<string, string>,
+  desiredCategoryNames: Set<string>,
 ): { create: DesiredChannel[]; update: ChannelUpdate[]; extra: GuildChannel[] } {
   const nonCategory = live.filter((ch) => ch.type !== ChannelType.GuildCategory);
   const liveByName = new Map(nonCategory.map((ch) => [ch.name, ch]));
@@ -115,6 +116,34 @@ function diffChannels(
   const matched = new Set<string>();
 
   for (const channel of desired) {
+    // 🔴 Resolve + VALIDATE the category reference before planning anything.
+    // The old `categoryIdByName.get(...) ?? null` fallback silently treated
+    // an invalid category name as "move to top level" — a typo in
+    // structure.ts would quietly yank every channel out of its category.
+    // Validation is against structure.categories (the declaration), so
+    // categories being created during THIS same sync (declared but not live
+    // yet) are valid references too.
+    let desiredParentId: string | null;
+    let pendingCategory = false;
+    if (channel.category) {
+      const liveId = categoryIdByName.get(channel.category);
+      if (liveId !== undefined) {
+        desiredParentId = liveId;
+      } else if (desiredCategoryNames.has(channel.category)) {
+        // Declared but not live yet — created earlier in this same sync, so
+        // the parent id is applied from the post-create map at apply time.
+        desiredParentId = null;
+        pendingCategory = true;
+      } else {
+        throw new Error(
+          `Invalid category reference: channel "${channel.name}" declares category ` +
+            `"${channel.category}", which is not listed in structure.categories.`,
+        );
+      }
+    } else {
+      desiredParentId = null; // top level
+    }
+
     const existing = liveByName.get(channel.name);
     if (!existing) {
       create.push(channel);
@@ -125,11 +154,20 @@ function diffChannels(
     if (CHANNEL_TYPE_MAP[channel.type] !== existing.type) {
       changes.push(`type ${existing.type} → ${CHANNEL_TYPE_MAP[channel.type]}`);
     }
-    const desiredParentId = channel.category
-      ? (categoryIdByName.get(channel.category) ?? null)
-      : null;
-    if (desiredParentId !== null && desiredParentId !== (existing.parent_id ?? null)) {
-      changes.push(`category → ${channel.category}`);
+    const currentParentId = existing.parent_id ?? null;
+    if (channel.category) {
+      if (pendingCategory) {
+        // The category cannot exist live yet, so whatever the channel's
+        // current parent is, a move into the new category is needed.
+        changes.push(`category → ${channel.category} (created this sync)`);
+      } else if (desiredParentId !== currentParentId) {
+        changes.push(`category → ${channel.category}`);
+      }
+    } else if (currentParentId !== null) {
+      // Desired state is top level but the channel is currently categorized
+      // — plan the move UP. Applied with parent_id: null (omitting parent_id
+      // would leave the channel where it is — see ChannelUpdateBody).
+      changes.push('category → top level');
     }
     if (channel.topic !== undefined && channel.topic !== (existing.topic ?? undefined)) {
       changes.push(`topic → ${JSON.stringify(channel.topic)}`);
@@ -154,13 +192,22 @@ export function computePlan(
   const roleDiff = diffRoles(desired.roles, live.roles);
   const categoryDiff = diffCategories(desired.categories, live.channels);
 
-  // Channels created in the same sync as their category won't have a live
-  // parent id yet — resolve() re-runs this after categories are created.
+  // Live categories by name. Channels pointing at a category that is only
+  // DECLARED (created during this same sync) resolve via
+  // desiredCategoryNames below — the parent id itself is applied at apply
+  // time from the post-create map (sync.ts adds each created category to its
+  // categoryIdByName before creating/updating channels).
   const categoryIdByName = new Map<string, string>();
   for (const [name, ch] of categoryDiff.liveByName) {
     categoryIdByName.set(name, ch.id);
   }
-  const channelDiff = diffChannels(desired.channels, live.channels, categoryIdByName);
+  const desiredCategoryNames = new Set(desired.categories.map((cat) => cat.name));
+  const channelDiff = diffChannels(
+    desired.channels,
+    live.channels,
+    categoryIdByName,
+    desiredCategoryNames,
+  );
 
   return {
     createCategories: categoryDiff.create,

--- a/scripts/src/lib/discord/sync.ts
+++ b/scripts/src/lib/discord/sync.ts
@@ -187,7 +187,10 @@ export async function runSync(mode: string, options: SyncOptions): Promise<void>
     }
     await updateChannel(rest, update.id, {
       type: CHANNEL_TYPE_MAP[desired.type],
-      parent_id: desired.category ? categoryIdByName.get(desired.category) : undefined,
+      // null (not undefined) moves a categorized channel to the top level —
+      // diff.ts only plans the update when a real change exists, so when
+      // desired declares no category, null is exactly the desired state.
+      parent_id: desired.category ? categoryIdByName.get(desired.category) : null,
       topic: desired.topic,
       nsfw: desired.nsfw,
     });

--- a/scripts/src/lib/discord/types.ts
+++ b/scripts/src/lib/discord/types.ts
@@ -27,6 +27,10 @@ export type GuildRole = {
   mentionable: boolean;
   permissions: string;
   position: number;
+  /** Integration-managed (bot roles, etc.) — outside declarative
+   *  synchronization: the structure seed filters these out so they never
+   *  enter generated sync plans (Discord forbids editing them). */
+  managed?: boolean;
 };
 
 export type ChannelCreateBody = {
@@ -37,7 +41,12 @@ export type ChannelCreateBody = {
   nsfw?: boolean;
 };
 
-export type ChannelUpdateBody = Partial<Omit<ChannelCreateBody, 'name'>>;
+export type ChannelUpdateBody = Partial<Omit<ChannelCreateBody, 'name' | 'parent_id'>> & {
+  /** Null moves a categorized channel to the top level; OMITTING parent_id
+   *  leaves the channel where it is. The update payload must permit null so
+   *  a planned top-level move can actually be applied. */
+  parent_id?: string | null;
+};
 
 export type RoleCreateBody = {
   name: string;

--- a/scripts/src/lib/env/exec_boundary.test.ts
+++ b/scripts/src/lib/env/exec_boundary.test.ts
@@ -138,17 +138,21 @@ describe('execSync calls in the herdr / contract-pipeline layer never hand-POSIX
 describe('execSyncTemplateArgs / hasStrayPosixQuote', () => {
   it('detects the real bug shape but ignores interpolation-internal quotes', () => {
     // Proves the detector actually fires — otherwise the suite above could
-    // pass simply because the regex never matches anything.
-    const broken = "execSync(`gh pr list --head '${headBranch}' --jq '.[0].url'`, opts)";
+    // pass simply because the regex never matches anything. These fixtures
+    // are SOURCE-CODE SNAPSHOTS: they must stay literal text, so they are
+    // template literals with escaped backticks (\`) and escaped
+    // interpolations (\${) — the values are byte-identical to the plain
+    // strings they replaced, but lint-clean (noTemplateCurlyInString).
+    const broken = `execSync(\`gh pr list --head '\${headBranch}' --jq '.[0].url'\`, opts)`;
     expect(execSyncTemplateArgs(broken).some(hasStrayPosixQuote)).toBe(true);
 
     // A `'` used only inside a `${...}` JS expression (e.g. Array#join's
     // separator) is not shell-quoting at all — must not false-positive.
-    const fine = "execSync(`docker ${args.join(' ')}`, opts)";
+    const fine = `execSync(\`docker \${args.join(' ')}\`, opts)`;
     expect(execSyncTemplateArgs(fine).some(hasStrayPosixQuote)).toBe(false);
 
     // Plain interpolation with no quoting anywhere — must not false-positive.
-    const alsoFine = 'execSync(`git ${command}`, opts)';
+    const alsoFine = `execSync(\`git \${command}\`, opts)`;
     expect(execSyncTemplateArgs(alsoFine).some(hasStrayPosixQuote)).toBe(false);
   });
 });

--- a/scripts/src/lib/herdr/session.test.ts
+++ b/scripts/src/lib/herdr/session.test.ts
@@ -253,10 +253,12 @@ describe('buildServiceCommand / serviceEnvArgs — F-07', () => {
     expect(args).toHaveLength(2);
   });
 
-  it('serviceEnvArgs omits PORT when the service has no readyPort (e.g. tauri)', () => {
-    const args = serviceEnvArgs('tauri', 'emulator', 60);
-    // tauri isn't offset-aware either, but this also covers the readyPort-undefined branch.
-    expect(args).toEqual([]);
+  it('serviceEnvArgs carries the offset but omits PORT when an offset-aware service has no readyPort for the mode (firebase in staging)', () => {
+    // firebase IS offset-aware, but its readyPort is emulator-only
+    // (readyPort('staging') === undefined) — so execution reaches the
+    // missing-port branch: the offset is returned, no PORT entry is added.
+    const args = serviceEnvArgs('firebase', 'staging', 60);
+    expect(args).toEqual(['PUBLIC_EMULATOR_PORT_OFFSET=60']);
   });
 });
 

--- a/scripts/src/lib/herdr/worktree.ts
+++ b/scripts/src/lib/herdr/worktree.ts
@@ -29,7 +29,9 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -552,9 +554,17 @@ export const bootstrapWorktree = async (
   // mode, or a future caller passing the wrong path) that write would
   // clobber the REAL .envrc with the worktree-delegation stub. This is
   // exactly how 763da4d6 merged a corrupted `.envrc` to main (C-400):
-  // resolve() both sides so a trailing slash or drive-letter case difference
-  // can't slip past the check on Windows.
-  if (resolve(checkoutPath) === resolve(repoRoot)) {
+  // realpathSync.native() both sides so a trailing slash, symlink, or
+  // drive-letter case difference can't slip past the check on Windows
+  // (path.resolve alone would still treat `C:\Repo` and `c:\repo` as
+  // different paths), then compare case-insensitively on Windows.
+  const canonicalCheckout = realpathSync.native(checkoutPath);
+  const canonicalRoot = realpathSync.native(repoRoot);
+  const samePath =
+    process.platform === 'win32'
+      ? canonicalCheckout.toLowerCase() === canonicalRoot.toLowerCase()
+      : canonicalCheckout === canonicalRoot;
+  if (samePath) {
     throw new Error(
       `bootstrapWorktree refused: checkoutPath equals repoRoot (${repoRoot}). ` +
         'This would overwrite the real .envrc with the worktree-delegation stub. ' +
@@ -787,6 +797,43 @@ const killContractPorts = async (checkoutPath: string): Promise<void> => {
 };
 
 /**
+ * Refuse the rmSync removal fallback unless `checkoutPath` is a genuine
+ * non-root git-linked worktree. Two checks, both must pass:
+ *  1. canonical checkoutPath !== canonical repoRoot (case-insensitive on
+ *     Windows) — rmSync(repoRoot) would recursively delete the ENTIRE repo.
+ *  2. a `.git` FILE marker exists at the target — linked worktrees get a
+ *     `.git` file (gitdir: ...), while repo roots get a `.git` directory;
+ *     without the marker the target is not a managed git worktree and
+ *     rmSync would eat arbitrary user data.
+ */
+const assertManagedWorktreeTarget = (checkoutPath: string, repoRoot: string): void => {
+  const canonicalPath = realpathSync.native(checkoutPath);
+  const canonicalRoot = realpathSync.native(repoRoot);
+  const samePath =
+    process.platform === 'win32'
+      ? canonicalPath.toLowerCase() === canonicalRoot.toLowerCase()
+      : canonicalPath === canonicalRoot;
+  if (samePath) {
+    throw new Error(
+      `refusing to rm -rf ${checkoutPath}: it equals the repo root (${repoRoot}) — ` +
+        'this would delete the entire repository.',
+    );
+  }
+  let gitMarker: ReturnType<typeof statSync> | undefined;
+  try {
+    gitMarker = statSync(join(checkoutPath, '.git'));
+  } catch {
+    gitMarker = undefined;
+  }
+  if (!gitMarker?.isFile()) {
+    throw new Error(
+      `refusing to rm -rf ${checkoutPath}: no git-worktree .git marker file found — ` +
+        'the target is not a non-root managed git worktree.',
+    );
+  }
+};
+
+/**
  * Remove a worktree: herdr state + checkout together, then optionally the
  * local and/or remote branch. herdr `worktree remove` NEVER deletes the
  * branch — that is always a separate explicit git step here.
@@ -824,6 +871,12 @@ export const removeWorktree = async (
       checkoutRemoved = true;
     } catch (gitErr: unknown) {
       try {
+        // 🔴 Validate BEFORE the recursive delete. git worktree remove just
+        // failed, so the only thing standing between this path and
+        // rmSync(checkoutPath) is this guard — without it, a checkoutPath
+        // equal to repoRoot would recursively delete the entire repository
+        // and a plain directory would be deleted as arbitrary user data.
+        assertManagedWorktreeTarget(options.checkoutPath, repoRoot);
         // 🔴 node:fs rmSync, not `execSync('rm -rf ...')` — the latter never
         // worked on Windows (no `rm` binary) and, independent of that, hand
         // POSIX-quoting a path for cmd.exe leaks the literal quote

--- a/scripts/src/lib/local_setup/index.ts
+++ b/scripts/src/lib/local_setup/index.ts
@@ -610,6 +610,16 @@ const probeHerdrCompat = async (): Promise<ExtraCheck> => {
       hint: 'herdr server stop && herdr   — restarts the server on the current client binary.',
     };
   }
+  if (status.compatible !== true) {
+    // herdr reported no `compatible:` verdict at all (unparseable output or
+    // an older format) — that is NOT "compatible", so do not report success.
+    return {
+      name: 'herdr protocol',
+      ok: false,
+      note: 'could not confirm protocol compatibility — herdr status reported no compatible verdict',
+      hint: 'herdr server stop && herdr   — restarts the server on the current client binary.',
+    };
+  }
   return { name: 'herdr protocol', ok: true, note: 'client/server compatible' };
 };
 

--- a/scripts/src/lib/ops/infra_report.test.ts
+++ b/scripts/src/lib/ops/infra_report.test.ts
@@ -1,6 +1,6 @@
 // scripts/src/lib/ops/infra_report.test.ts
 import { afterEach, describe, expect, it } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { appendFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -77,8 +77,15 @@ describe('reportInfraIssue / readInfraIssues round-trip', () => {
     const cwd = makeTempCwd();
     reportInfraIssue({ component: 'a', operation: 'b', error: new Error('one'), cwd });
     reportInfraIssue({ component: 'a', operation: 'b', error: new Error('two'), cwd });
-    // Simulate a torn write: append a truncated JSON line.
     reportInfraIssue({ component: 'a', operation: 'b', error: new Error('three'), cwd });
+    // Simulate a torn write: append a deliberately truncated, invalid JSON
+    // line DIRECTLY to the log. (The old comment claimed the third
+    // reportInfraIssue call did this, but it wrote valid JSON — the
+    // corrupted-line path was never actually exercised.)
+    appendFileSync(
+      join(cwd, '.pi', 'infra-issues.jsonl'),
+      '{"timestamp":"2026-01-01T00:00:00.000Z","component":"torn","op',
+    );
     const events = readInfraIssues(cwd);
     expect(events.length).toBeGreaterThanOrEqual(3);
   });

--- a/scripts/src/lib/ops/infra_report.ts
+++ b/scripts/src/lib/ops/infra_report.ts
@@ -74,6 +74,10 @@ export type InfraIssueEvent = {
   error: string;
   /** Free-form extra context — kept small; this is a log line, not a dump. */
   context?: Record<string, string | number | boolean | undefined>;
+  /** Contract-pipeline run this failure belongs to (see
+   *  setActiveInfraRun / reportInfraIssue's `runId` option). Absent for
+   *  events recorded outside any pipeline run (manual scripts, extensions). */
+  runId?: string;
   /** component:operation:normalizedError — groups repeat occurrences. */
   fingerprint: string;
 };
@@ -104,6 +108,21 @@ const errorMessage = (error: unknown): string =>
 const buildFingerprint = (component: string, operation: string, normalizedError: string): string =>
   `${component}:${operation}:${normalizedError}`;
 
+// ── Active run context ────────────────────────────────────────────────────
+// The contract pipeline records degradation events from many shared helpers
+// (session.ts, worktree.ts, git_worktree.ts) that have no run id of their
+// own. The orchestrator sets the ambient active run once per pipeline
+// process; reportInfraIssue stamps it onto every event recorded without an
+// explicit `runId`, so prompt-note injection can filter to THIS run and
+// exclude historical failures from previous runs.
+let activeRunId: string | undefined;
+
+/** Set (or clear, with undefined) the ambient contract-pipeline run id that
+ *  reportInfraIssue stamps onto events recorded without an explicit runId. */
+export const setActiveInfraRun = (runId: string | undefined): void => {
+  activeRunId = runId;
+};
+
 /**
  * Record that a degradation site caught a failure and worked around it.
  * Never throws — a reporting failure must never become THE failure. Safe to
@@ -115,6 +134,9 @@ export const reportInfraIssue = (options: {
   error: unknown;
   context?: Record<string, string | number | boolean | undefined>;
   cwd?: string;
+  /** Contract-pipeline run this failure belongs to — defaults to the
+   *  ambient active run (see setActiveInfraRun). */
+  runId?: string;
 }): void => {
   try {
     const cwd = options.cwd ?? process.cwd();
@@ -125,6 +147,7 @@ export const reportInfraIssue = (options: {
       operation: options.operation,
       error: normalized,
       context: options.context,
+      runId: options.runId ?? activeRunId,
       fingerprint: buildFingerprint(options.component, options.operation, normalized),
     };
     const logPath = resolveLogPath(cwd);
@@ -164,6 +187,14 @@ export const readInfraIssues = (cwd: string): InfraIssueEvent[] => {
   }
   return events;
 };
+
+/** Events recorded during ONE pipeline run — the view injected into that
+ *  run's review prompt. Events without a runId (recorded by manual scripts
+ *  or extensions, outside any pipeline) and events from previous runs are
+ *  excluded, so historical gh/worktree/herdr failures never leak into a
+ *  fresh run's notes. */
+export const readInfraIssuesForRun = (cwd: string, runId: string): InfraIssueEvent[] =>
+  readInfraIssues(cwd).filter((event) => event.runId === runId);
 
 /** Group events by fingerprint into a ranked (most frequent first) summary. */
 export const summarizeInfraIssues = (


### PR DESCRIPTION
## Summary

PR #153 (`infra/rig-audit-fixes`) predates C-401's dialogue-streaming rewrite already on `main`, so merging it as-is would revert that work — that's why GitHub flags it CONFLICTING. This PR cherry-picks only the genuinely new, non-conflicting fixes from that branch, verified file-by-file against current `main`.

**Landed:**
- `infra_report`: stamp events with `runId`, filter reads by it — a review prompt no longer surfaces infra issues from unrelated past runs
- `herdr/worktree`: `assertManagedWorktreeTarget` guards the `rmSync` fallback from ever deleting the repo root or a non-worktree dir
- `git_worktree`: `stagedPaths` failure now aborts the commit instead of silently assuming nothing was staged
- `contract_pipeline`: launcher pane-run failure surfaces real herdr stderr instead of polling out the full 180s timeout
- Windows path-separator fixes: `hub/svelte.config.js` (SvelteKit tsconfig alias generator), `asset_manifest_node.ts` (asset category matching)
- `macro_simulation.test.ts`: fixed cross-test entity-id collisions from un-truncated module-level state
- `development_ports`: `NORDCLAW_RESERVED_RANGES`/`EPHEMERAL_PORT_START` guardrail constants
- `chrome_devtools.ts`: `in` → `Object.hasOwn` (was matching prototype-chain keys)
- Discord: guild+role allow-list + rate limiting on issue-creation before any GitHub call, webhook PATCH abort timeout, category-reference validation in the sync planner, `parent_id: null` fix (was dropped from JSON as `undefined`), managed roles excluded from generated sync plans
- Misc test fixes: `session.test.ts`, `infra_report.test.ts`, `exec_boundary.test.ts`

**Explicitly excluded:** anything under `apps/e2e` or dialogue-related frontend files (stale vs. C-401, main is ahead there), cosmetic-only diffs, and the `spatial_grid.test.ts` import reorder (C-402's own in-flight change carries that).

## Test plan

- [x] `moon run :typecheck --affected` — 32/32 projects pass
- [x] `bun test` on all touched suites (scripts, constants, frontend-engine) — 157/157 pass
- [x] `biome check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)