### PR TITLE
fix(emulator): offset the Firebase demo project id per contract

### DIFF
--- a/apps/backend/firebase/firestack.config.ts
+++ b/apps/backend/firebase/firestack.config.ts
@@ -6,19 +6,28 @@ import {
   EMULATOR_PORTS,
   MODE_PROJECT_MAP,
   withPortOffset,
+  withProjectIdOffset,
 } from '../../../packages/shared/constants/src/index.ts';
 
 // Shifts the whole emulator suite for contract-scoped pipeline runs so
 // concurrent contracts never fight over the same Firebase emulator ports.
 // scripts/src/lib/herdr/session.ts sets this env var when starting the
 // `firebase` tab for a contract workspace (0 for a manual, non-contract run).
-const emulatorPorts = withPortOffset(
-  EMULATOR_PORTS,
-  Number(process.env.PUBLIC_EMULATOR_PORT_OFFSET || 0),
-);
+const emulatorPortOffset = Number(process.env.PUBLIC_EMULATOR_PORT_OFFSET || 0);
+const emulatorPorts = withPortOffset(EMULATOR_PORTS, emulatorPortOffset);
+
+// Per-port offsetting alone isn't enough for concurrent `firestack emulate`
+// instances to coexist — see withProjectIdOffset's doc for why (firebase-tools'
+// Emulator Hub coordinates by project id, not by port). staging/production
+// are real GCP projects and must never be touched by this.
+const modes = {
+  ...MODE_PROJECT_MAP,
+  emulator: withProjectIdOffset(MODE_PROJECT_MAP.emulator, emulatorPortOffset),
+  testing: withProjectIdOffset(MODE_PROJECT_MAP.testing, emulatorPortOffset),
+};
 
 export default defineConfig(() => ({
-  modes: MODE_PROJECT_MAP,
+  modes,
   region: CLOUD_FUNCTIONS_REGION,
   nodeVersion: '24',
   engine: 'bun' as const,

--- a/apps/e2e/src/config.ts
+++ b/apps/e2e/src/config.ts
@@ -30,8 +30,17 @@ export const EMULATOR_PORTS = {
   voice: 8089,
 } as const;
 
-/** Emulator GCP project ID. The suite runs against one shared project. */
-export const EMULATOR_PROJECT_ID = 'demo-aikami-emulator' as const;
+/**
+ * Emulator GCP project ID. Offset the same way as EMULATOR_PORTS above (and
+ * must match withProjectIdOffset in packages/shared/constants/src/lib/project.ts,
+ * same CJS-loader constraint — can't import it here) so a contract-scoped
+ * test run connects to its own Firebase emulator instance's project instead
+ * of colliding with a concurrently-running contract's.
+ */
+export const EMULATOR_PROJECT_ID =
+  emulatorPortOffset > 0
+    ? (`demo-aikami-emulator-${emulatorPortOffset}` as const)
+    : ('demo-aikami-emulator' as const);
 
 /** Test API key for the Firebase Auth emulator (fake, emulator-only). */
 export const FIREBASE_API_KEY = 'fake-api-key' as const;

--- a/packages/frontend/configs/src/lib/environment.ts
+++ b/packages/frontend/configs/src/lib/environment.ts
@@ -5,6 +5,7 @@ import {
   EMULATOR_PORTS as BASE_EMULATOR_PORTS,
   MODE_PROJECT_MAP,
   withPortOffset,
+  withProjectIdOffset,
 } from '@aikami/constants';
 import { FrontendAppIdSchema, LogLevelSchema, ModeSchema } from '@aikami/schemas';
 import { toAppError } from '@aikami/utils';
@@ -169,7 +170,11 @@ export const getProjectId = (): string => {
   const projectId = (MODE_PROJECT_MAP as Record<string, string>)[currentMode];
 
   if (projectId) {
-    return projectId;
+    // Matches the offset firestack.config.ts applies on the backend side —
+    // must resolve to the SAME project id, or this app's Firebase SDK
+    // connects to a different contract's emulator instance than the one
+    // its own dev server is actually running against.
+    return withProjectIdOffset(projectId, emulatorPortOffset);
   }
 
   const validModes = Object.keys(MODE_PROJECT_MAP)

--- a/packages/shared/constants/src/lib/project.test.ts
+++ b/packages/shared/constants/src/lib/project.test.ts
@@ -1,0 +1,31 @@
+// packages/shared/constants/src/lib/project.test.ts
+
+import { describe, expect, it } from 'bun:test';
+import { MODE_PROJECT_MAP, withProjectIdOffset } from './project.ts';
+
+describe('withProjectIdOffset', () => {
+  it('leaves the project id untouched for offset 0 (manual, non-contract dev)', () => {
+    expect(withProjectIdOffset(MODE_PROJECT_MAP.emulator, 0)).toBe(MODE_PROJECT_MAP.emulator);
+  });
+
+  it('suffixes a demo project id by the offset', () => {
+    expect(withProjectIdOffset(MODE_PROJECT_MAP.emulator, 330)).toBe(
+      `${MODE_PROJECT_MAP.emulator}-330`,
+    );
+  });
+
+  it('gives two different offsets two different, non-colliding project ids', () => {
+    const a = withProjectIdOffset(MODE_PROJECT_MAP.emulator, 66);
+    const b = withProjectIdOffset(MODE_PROJECT_MAP.emulator, 132);
+    expect(a).not.toBe(b);
+  });
+
+  it('never mutates a real (non-demo) GCP project id, even with a nonzero offset', () => {
+    expect(withProjectIdOffset(MODE_PROJECT_MAP.staging, 66)).toBe(MODE_PROJECT_MAP.staging);
+    expect(withProjectIdOffset(MODE_PROJECT_MAP.production, 66)).toBe(MODE_PROJECT_MAP.production);
+  });
+
+  it('leaves a negative offset untouched (defensive — offsets are never negative in practice)', () => {
+    expect(withProjectIdOffset(MODE_PROJECT_MAP.emulator, -1)).toBe(MODE_PROJECT_MAP.emulator);
+  });
+});

--- a/packages/shared/constants/src/lib/project.ts
+++ b/packages/shared/constants/src/lib/project.ts
@@ -53,3 +53,28 @@ export const MODE_PROJECT_MAP = {
  * Must match the `region` field in `apps/backend/firebase/firestack.config.ts`.
  */
 export const CLOUD_FUNCTIONS_REGION = 'europe-west4' as const;
+
+/**
+ * Offset a demo Firebase project ID for contract-scoped pipeline runs, so
+ * concurrent `firestack emulate` instances never collide.
+ *
+ * Per-port offsetting (see development_ports.ts's withPortOffset) is not
+ * enough on its own: firebase-tools' Emulator Hub coordinates running
+ * instances via a locator file keyed by the literal project ID
+ * (`hub-${projectId}.json` in the shared OS temp dir, independent of which
+ * port that hub ends up on). Two concurrent instances that both resolve to
+ * the bare `demo-aikami-emulator` collide there and kill each other —
+ * reproduced directly: whichever instance (re)started most recently stays
+ * up, the other's port goes dark within moments, no crash log, because the
+ * hub locator file gets overwritten out from under it. Suffixing the
+ * project id by offset gives each contract its own locator file too.
+ *
+ * Only ever applied to `demo-` project ids (emulator/testing) — a
+ * staging/production project id is a real GCP project and must never be
+ * mutated; `offset <= 0` (manual, non-contract dev) leaves the id
+ * untouched so today's exact project id keeps working everywhere it's
+ * already relied on (e.g. cached emulator data, browser bookmarks to the
+ * Emulator UI).
+ */
+export const withProjectIdOffset = (projectId: string, offset: number): string =>
+  offset > 0 && projectId.startsWith('demo-') ? `${projectId}-${offset}` : projectId;


### PR DESCRIPTION
## Summary

Per-port offsetting alone isn't enough for concurrent `firestack emulate` instances to coexist. firebase-tools' Emulator Hub coordinates running instances via a locator file keyed by the literal project id (`hub-${projectId}.json` in the shared OS temp dir) — independent of which ports that instance's emulators actually bind to. Two contracts both resolving to the bare `demo-aikami-emulator` collide there. Reproduced directly: whichever instance (re)started most recently stayed up, the other's port went dark within moments, no crash log — because the hub locator file got overwritten out from under it.

`withProjectIdOffset` (new, in `packages/shared/constants/src/lib/project.ts`) suffixes a demo project id by the contract's port offset, same pattern as the existing `withPortOffset`. Wired into the two sides that need to agree on the same id (`firestack.config.ts` for the running instance, `environment.ts` for the client SDK connecting to it), plus `apps/e2e/src/config.ts`'s duplicated-constant convention.

**Verified fixed:** two concurrent instances (this checkout + a separate worktree — same-checkout concurrency hits a different, unrelated `dist/emulator` build-output collision) now resolve to distinct project ids and distinct hub locator files, confirmed via `firebase-debug.log` and the actual running Java process command lines.

## ⚠️ Known remaining issue — not fixed by this PR

With two instances running concurrently, the first instance's Auth emulator specifically still intermittently goes dark shortly after a second instance starts, even with project ids/ports/hub locators all confirmed distinct. Reproduced multiple times. Ruled out: raw port collision, project-id/hub-locator collision, stale zombie processes (also found and worth its own follow-up: `herdr stop` doesn't reliably kill orphaned JVM grandchildren on Windows).

Separately, `firestack`'s `resolveHubPort()` computes an offset-aware Hub port from `emulatorPorts.emulatorHub`, but the generated `dist/emulator/firebase.json` never actually contains a `hub` key — that computed value doesn't survive into what's handed to `firebase-tools`, which falls back to its own default (auto-negotiated, so not itself a collision, just not actually offset).

Both look like they're inside `@snorreks/firestack` itself (third-party package), not fixable from this repo's config alone — flagging for a follow-up investigation or upstream report rather than continuing to dig blind in this PR.

## Test plan

- [x] `moon run :typecheck --affected` — 32/32 pass
- [x] `bun test` on `project.test.ts` + `development_ports.test.ts` — 12/12 pass
- [x] Live-verified project id + hub locator file uniqueness across two concurrent instances (see commit body for detail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)