### PR TITLE
C-405: Cut world generation from the new-campaign critical path

### DIFF
--- a/apps/e2e/src/visual/core/capture.ts
+++ b/apps/e2e/src/visual/core/capture.ts
@@ -162,6 +162,12 @@ const _waitForGameReady = async (page: Page, timeout = 20_000): Promise<void> =>
         return true;
       }
 
+      // Start menu / main menu (C-405 pack-picker visual suite)
+      const startMenu = document.querySelector('[data-testid="start-menu"]');
+      if (startMenu) {
+        return true;
+      }
+
       // E2E test mode — engine state exposed on window (C-217)
       const engineState = (window as unknown as Record<string, unknown>).__AIKAMI_ENGINE_STATE__ as
         | Record<string, unknown>

--- a/apps/e2e/src/visual/suites/start_picker.visual.ts
+++ b/apps/e2e/src/visual/suites/start_picker.visual.ts
@@ -1,0 +1,97 @@
+// apps/e2e/src/visual/suites/start_picker.visual.ts
+// Start screen pack picker — declarative visual test suite.
+//
+// Captures the C-345/C-405 content-pack picker modal on the start screen:
+// two distinct pack cards with readable names and descriptions (no clipped
+// text), the selected pack highlighted, and the detail panel rendered.
+//
+// Contract: C-405 AC-3 (pack picker appears when multiple packs are installed)
+
+import { Type } from 'typebox';
+import { defineConfig } from '$visual/core/config';
+
+// ── Schema ───────────────────────────────────────────────────
+
+const PackPickerSchema = Type.Object({
+  score: Type.Number({ description: '0-100 score of visual correctness' }),
+  modalVisible: Type.Boolean({
+    description: 'Whether the "Choose Your Adventure" modal is visible',
+  }),
+  twoPackCardsVisible: Type.Boolean({
+    description: 'Whether exactly two pack cards are rendered side by side',
+  }),
+  packNamesReadable: Type.Boolean({
+    description:
+      'Whether both pack names ("Emberwatch: The Fading Ward" and "Whispering Caves") are fully readable',
+  }),
+  descriptionsNotClipped: Type.Boolean({
+    description: 'Whether both pack card descriptions render fully without clipped/cut-off text',
+  }),
+  selectionHighlightVisible: Type.Boolean({
+    description: 'Whether the selected pack card shows a highlighted border',
+  }),
+  startButtonVisible: Type.Boolean({
+    description: 'Whether the primary "Start New Game" confirm button is visible',
+  }),
+  issues: Type.Array(Type.String(), { description: 'List of visual issues detected' }),
+});
+
+// ── Prompt ───────────────────────────────────────────────────
+
+const PACK_PICKER_PROMPT = [
+  'This is a screenshot of the Aikami start screen with the content-pack picker modal open.',
+  '',
+  'EXPECTED LAYOUT:',
+  '- A modal dialog titled "Choose Your Adventure".',
+  '- Exactly two pack cards side by side:',
+  '  - "Emberwatch: The Fading Ward" (version 2.1.0).',
+  '  - "Whispering Caves" (version 1.0.0).',
+  '- Each card shows its full description with NO clipped or truncated text.',
+  '- The Emberwatch card is highlighted with a colored border (selected).',
+  '- Below the cards, a detail panel shows the selected pack name, version,',
+  '  updated date and full description.',
+  '- Bottom action row with "Cancel" and a primary "Start New Game" button.',
+  '',
+  'EVALUATE:',
+  '- Is the modal visible?',
+  '- Are two distinct pack cards rendered?',
+  '- Are both pack names fully readable?',
+  '- Are both descriptions fully visible (no line-clamp clipping)?',
+  '- Is the selected pack highlighted?',
+  '- Is the "Start New Game" button visible?',
+  '',
+  'Return ONLY valid JSON matching the schema.',
+].join('\n');
+
+// ── Setup hook ────────────────────────────────────────────────
+
+/**
+ * Opens the pack picker by pressing "New Game" on the start screen.
+ * The default character count is zero, so the browser appears when two
+ * packs are installed.
+ */
+const openPackPicker = async (page: import('playwright').Page): Promise<void> => {
+  await page.getByRole('button', { name: 'New Game' }).click();
+  await page.getByText('Choose Your Adventure').waitFor({ timeout: 10_000 });
+  await page.waitForTimeout(800);
+};
+
+// ── Suite ────────────────────────────────────────────────────
+
+export default defineConfig({
+  id: 'start_picker',
+  route: '/',
+  waitCondition: 'game_ready',
+  requiresAuth: false,
+  cases: [
+    {
+      name: 'Pack Picker — Two Installed Packs',
+      prompt: PACK_PICKER_PROMPT,
+      schema: PackPickerSchema,
+      // The modal overlay covers the full viewport — capture it whole instead
+      // of the default 256px canvas center-crop.
+      screenshotSelector: '.modal',
+      setupHook: openPackPicker,
+    },
+  ],
+});

--- a/apps/e2e/src/visual/suites/start_picker.visual.ts
+++ b/apps/e2e/src/visual/suites/start_picker.visual.ts
@@ -72,8 +72,16 @@ const PACK_PICKER_PROMPT = [
  */
 const openPackPicker = async (page: import('playwright').Page): Promise<void> => {
   await page.getByRole('button', { name: 'New Game' }).click();
-  await page.getByText('Choose Your Adventure').waitFor({ timeout: 10_000 });
-  await page.waitForTimeout(800);
+  await page.getByRole('heading', { name: 'Choose Your Adventure' }).waitFor({
+    timeout: 10_000,
+  });
+  // Both cards and the detail panel must be painted before capture: wait for
+  // the second pack card, the detail panel's metadata row (only rendered once
+  // the default selection is applied), and the confirm button instead of a
+  // fixed sleep.
+  await page.getByRole('button', { name: 'Select Whispering Caves' }).waitFor();
+  await page.getByText('Updated', { exact: true }).waitFor();
+  await page.getByRole('button', { name: 'Start New Game' }).waitFor();
 };
 
 // ── Suite ────────────────────────────────────────────────────

--- a/apps/e2e/tests/client/new_campaign_flow.spec.ts
+++ b/apps/e2e/tests/client/new_campaign_flow.spec.ts
@@ -1,0 +1,125 @@
+// apps/e2e/tests/client/new_campaign_flow.spec.ts
+//
+// E2E tests for the C-405 new-campaign entry flow.
+//
+// AC-1: fresh install → "Start campaign" → pack picker (2+ packs) → persona
+//       creation (onboarding) — WITHOUT passing through the world-generation
+//       wizard, and WITHOUT any world-generation AI call (request spy, not
+//       timing).
+// AC-3: the picker lists both installed packs with name + description and the
+//       chosen pack id reaches startNewCampaign.
+// AC-4: the Advanced entry (/worldgen) renders the wizard with an honest
+//       preview notice.
+//
+// Contract: C-405 Cut World Generation from the Critical Path
+
+import { expect, test } from '@playwright/test';
+
+// Bypass the mandatory text-provider gate so the default path can proceed to
+// persona creation without configuring an AI provider in the test context.
+const AI_GATE_BYPASS = `
+  window.__AIKAMI_AI_GATE_BYPASS__ = true;
+`;
+
+test.describe('New Campaign Flow — C-405', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(AI_GATE_BYPASS);
+    // Fresh install: no saved characters, no saves.
+    await page.addInitScript(() => {
+      try {
+        localStorage.clear();
+      } catch {
+        // best effort — storage may not exist on about:blank
+      }
+    });
+  });
+
+  test('AC-1: fresh start reaches persona creation without world generation', async ({ page }) => {
+    // ── Request spy: any world-gen / AI-provider call during the default
+    //    path is a regression (asserted via the spy, never by timing). ──
+    const aiRequestUrls: string[] = [];
+    await page.route('**/*', (route) => {
+      const url = route.request().url();
+      // Real AI-provider API endpoints (text/voice/image microservices on
+      // their fixed emulator ports + external LLM hosts). Dev-server source
+      // module fetches (localhost:10554) must NOT match.
+      if (
+        /localhost:(11434|8089|8087|8188)\/|api\.openrouter\.ai|generativelanguage\.googleapis\.com|api\.anthropic\.com|api\.deepseek\.com|api\.groq\.com|api\.openai\.com/i.test(
+          url,
+        )
+      ) {
+        aiRequestUrls.push(url);
+      }
+      route.continue();
+    });
+
+    await page.goto('/');
+
+    // Start campaign — the front door.
+    await page.getByRole('button', { name: 'New Game' }).click();
+
+    // AC-3: with both emberwatch and whispering-caves installed, the pack
+    // picker must appear listing both packs by name.
+    await expect(page.getByRole('dialog').first()).toBeVisible();
+    await expect(page.getByText('Choose Your Adventure')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Select Emberwatch: The Fading Ward' }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Select Whispering Caves' })).toBeVisible();
+
+    // Pick the second pack and confirm.
+    await page.getByRole('button', { name: 'Select Whispering Caves' }).click();
+    await page.getByRole('button', { name: 'Start New Game' }).click();
+
+    // AC-1: lands on persona creation (onboarding), never the wizard.
+    await expect(page.getByRole('heading', { name: 'Choose Your Hero' })).toBeVisible({
+      timeout: 10000,
+    });
+    expect(page.url()).toContain('/personas/create');
+
+    // The world-gen wizard must not be present.
+    await expect(page.getByRole('heading', { name: 'Genre' })).toHaveCount(0);
+
+    // No world-generation AI provider call was made on the default path.
+    expect(aiRequestUrls).toEqual([]);
+  });
+
+  test('AC-1: selecting a starter hero completes the flow into /game', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'New Game' }).click();
+    await expect(page.getByText('Choose Your Adventure')).toBeVisible();
+
+    // Default selection is the first pack — confirm directly.
+    await page.getByRole('button', { name: 'Start New Game' }).click();
+
+    // Onboarding coordinator with three starter heroes.
+    await expect(page.getByRole('heading', { name: 'Choose Your Hero' })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Pick the first starter hero card.
+    await page.locator('button').filter({ hasText: 'Thaldrin' }).first().click();
+
+    // Campaign completes setup and boots the game.
+    await expect(page).toHaveURL(/\/game/, { timeout: 15000 });
+  });
+
+  test('AC-4: /worldgen Advanced entry is reachable and honestly labelled', async ({ page }) => {
+    await page.goto('/');
+
+    // Advanced entry on the start screen.
+    await page.locator('summary', { hasText: 'Advanced' }).click();
+    await page.getByRole('button', { name: 'World Generation (Preview)' }).click();
+
+    // The wizard renders on its own production route (not /dev).
+    await expect(page).toHaveURL(/\/worldgen/);
+    await expect(page.locator('progress.progress')).toBeAttached({ timeout: 10000 });
+
+    // The preview notice states plainly that the world is not playable yet.
+    const notice = page.getByTestId('worldgen-preview-badge');
+    await expect(notice).toBeVisible();
+    await expect(page.getByText(/preview and is not playable yet/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'issue #81' })).toBeVisible();
+  });
+});

--- a/apps/frontend/client/src/lib/constants/routes.ts
+++ b/apps/frontend/client/src/lib/constants/routes.ts
@@ -72,6 +72,12 @@ export const routes = {
     routeId: '/setup',
     type: 'public',
   },
+  worldgen: {
+    getPath: () => '/worldgen',
+    queryParameters: undefined,
+    routeId: '/worldgen',
+    type: 'public',
+  },
   personaCreate: {
     getPath: () => '/personas/create',
     queryParameters: undefined as

--- a/apps/frontend/client/src/lib/data/ai_prompts/world_gen_schema.ts
+++ b/apps/frontend/client/src/lib/data/ai_prompts/world_gen_schema.ts
@@ -140,6 +140,85 @@ export const WorldGenSchema = Type.Object(
 /** Inferred TypeScript type from the output schema. */
 export type WorldGenOutput = Type.Static<typeof WorldGenSchema>;
 
+// ---------------------------------------------------------------------------
+// Per-stage schemas (C-405 AC-5 parallel generation)
+// ---------------------------------------------------------------------------
+//
+// The wizard generates the world in stages so independent sections can be
+// produced concurrently. Each stage validates against its own sub-schema and
+// the results are merged into a full WorldGenOutput.
+//
+// Dependency graph:
+//   setting | npcs | locations | hudWidgets  — mutually independent (parallel)
+//   partyArcs                                  — depends on npcs (questGivers
+//                                                must be names from the roster)
+
+/** Stage: world name + description prose. */
+export const WorldGenSettingStageSchema = Type.Object(
+  {
+    worldName: Type.String({
+      minLength: 1,
+      maxLength: 100,
+      description: 'A compelling name for the generated world',
+    }),
+    worldDescription: Type.String({
+      minLength: 20,
+      maxLength: 2000,
+      description:
+        'A 2-4 paragraph immersive description of the world — its atmosphere, key locations, factions, and overall feel',
+    }),
+  },
+  { additionalProperties: false },
+);
+
+/** Stage: NPC roster only. */
+export const WorldGenNpcsStageSchema = Type.Object(
+  {
+    npcs: Type.Array(WorldGenNpcSchema, {
+      minItems: 3,
+      maxItems: 12,
+      description: 'Key NPCs inhabiting this world (3-12 recommended)',
+    }),
+  },
+  { additionalProperties: false },
+);
+
+/** Stage: location list only. */
+export const WorldGenLocationsStageSchema = Type.Object(
+  {
+    locations: Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 3,
+      maxItems: 20,
+      description: 'Notable location names in this world (3-20)',
+    }),
+  },
+  { additionalProperties: false },
+);
+
+/** Stage: HUD widget blueprints only. */
+export const WorldGenHudWidgetsStageSchema = Type.Object(
+  {
+    hudWidgets: Type.Array(HudWidgetBlueprintSchema, {
+      minItems: 1,
+      maxItems: 8,
+      description: "HUD widget blueprints for this world's UI (1-8)",
+    }),
+  },
+  { additionalProperties: false },
+);
+
+/** Stage: party story arcs only (must reference names from the NPC roster). */
+export const WorldGenPartyArcsStageSchema = Type.Object(
+  {
+    partyArcs: Type.Array(PartyArcSchema, {
+      minItems: 1,
+      maxItems: 6,
+      description: 'Story arcs / chapters for the adventure (1-6)',
+    }),
+  },
+  { additionalProperties: false },
+);
+
 /** Schema for validating LLM world generation input (sent to the LLM). */
 export const WorldGenInputSchema = Type.Object(
   {

--- a/apps/frontend/client/src/lib/views/setup/setup_view.svelte
+++ b/apps/frontend/client/src/lib/views/setup/setup_view.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
 // apps/frontend/client/src/lib/views/setup/setup_view.svelte
+//
+// Setup route view — hosts the onboarding coordinator (persona creation).
+// C-405: the world-generation wizard no longer lives on this route; it moved
+// to the Advanced entry at /worldgen.
 import BaseViewModelContainer from '$lib/components/base_view_model_container.svelte';
-import PersonaCreateView from '$views/character/persona/create/persona_create_view.svelte';
-import WorldGenWizardView from '$views/worldgen/world_gen_wizard_view.svelte';
+import OnboardingCoordinatorView from '$views/onboarding/onboarding_coordinator_view.svelte';
 import type { SetupViewModelInterface } from './setup_view_model.svelte';
 
 let { viewModel }: { viewModel: SetupViewModelInterface } = $props();
 </script>
 
 <BaseViewModelContainer {viewModel}>
-  {#if viewModel.skipWizard}
-    <PersonaCreateView viewModel={viewModel.personaViewModel} />
-  {:else}
-    <WorldGenWizardView viewModel={viewModel.wizardViewModel} />
-  {/if}
+  <OnboardingCoordinatorView viewModel={viewModel.onboardingViewModel} />
 </BaseViewModelContainer>

--- a/apps/frontend/client/src/lib/views/setup/setup_view_model.svelte.ts
+++ b/apps/frontend/client/src/lib/views/setup/setup_view_model.svelte.ts
@@ -1,22 +1,20 @@
 // apps/frontend/client/src/lib/views/setup/setup_view_model.svelte.ts
 //
-// ViewModel for the Setup route — orchestrates the world-generation wizard
-// and persona creation flow. Bypasses the wizard when ?skip-wizard=true is
-// present in the URL, or after the user accepts the generated world.
+// ViewModel for the Setup route — the legacy new-campaign landing route.
+// C-405: this route no longer fronts the world-generation wizard. It hosts
+// the onboarding coordinator (fast persona creation) so stale bookmarks and
+// the remaining legacy callers land on persona creation, never the wizard.
 //
-// Contract: C-233 World Generation Wizard
+// Contract: C-233 World Generation Wizard (superseded by C-405)
+// Contract: C-405 Cut World Generation from the Critical Path
 
 import {
   BaseViewModel,
   type BaseViewModelInterface,
   type BaseViewModelOptions,
 } from '@aikami/frontend/services';
-import type { WorldGenOutput } from '@aikami/types';
-import { worldStateService } from '$services';
-import type { PersonaCreateViewModelInterface } from '$views/character/persona/create/persona_create_view_model.svelte';
-import { getPersonaCreateViewModel } from '$views/character/persona/create/persona_create_view_model.svelte';
-import type { WorldGenWizardViewModelInterface } from '$views/worldgen/world_gen_wizard_view_model.svelte';
-import { getWorldGenWizardViewModel } from '$views/worldgen/world_gen_wizard_view_model.svelte';
+import type { OnboardingCoordinatorViewModelInterface } from '$views/onboarding/onboarding_coordinator_view_model.svelte';
+import { getOnboardingCoordinatorViewModel } from '$views/onboarding/onboarding_coordinator_view_model.svelte';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,14 +23,8 @@ import { getWorldGenWizardViewModel } from '$views/worldgen/world_gen_wizard_vie
 export type SetupViewModelOptions = BaseViewModelOptions;
 
 export type SetupViewModelInterface = BaseViewModelInterface & {
-  /** Whether to bypass the world-gen wizard and show persona creation. */
-  readonly skipWizard: boolean;
-
-  /** The world-generation wizard ViewModel. */
-  readonly wizardViewModel: WorldGenWizardViewModelInterface;
-
-  /** The persona creation ViewModel. */
-  readonly personaViewModel: PersonaCreateViewModelInterface;
+  /** The onboarding (persona creation) ViewModel. */
+  readonly onboardingViewModel: OnboardingCoordinatorViewModelInterface;
 };
 
 // ---------------------------------------------------------------------------
@@ -43,49 +35,15 @@ class SetupViewModel
   extends BaseViewModel<SetupViewModelOptions>
   implements SetupViewModelInterface
 {
-  /** Whether the wizard should be skipped (query param or after world accepted). */
-  private _skipWizard = $state(false);
-
-  /** The world-generation wizard ViewModel. */
-  wizardViewModel: WorldGenWizardViewModelInterface;
-
-  /** The persona creation ViewModel (always instantiated for direct access). */
-  personaViewModel: PersonaCreateViewModelInterface;
+  /** The onboarding coordinator — fast persona creation is the setup flow. */
+  onboardingViewModel: OnboardingCoordinatorViewModelInterface;
 
   constructor(options: SetupViewModelOptions) {
     super(options);
 
-    // Persona VM — always created (used after wizard or via bypass)
-    this.personaViewModel = getPersonaCreateViewModel({
-      className: 'PersonaCreateViewModel',
+    this.onboardingViewModel = getOnboardingCoordinatorViewModel({
+      className: 'OnboardingCoordinatorViewModel',
     });
-
-    // Wizard VM with an arrow-function callback that preserves `this` binding.
-    // Seeds the world-gen output into game state and toggles skipWizard so
-    // the view switches to persona creation.
-    this.wizardViewModel = getWorldGenWizardViewModel({
-      className: 'WorldGenWizardViewModel',
-      onWorldAccepted: async (output: WorldGenOutput): Promise<void> => {
-        worldStateService.setWorldGenOutput(output);
-        this._skipWizard = true;
-        this.debug('onWorldAccepted', { worldName: output.worldName });
-      },
-    });
-  }
-
-  /** @inheritdoc */
-  get skipWizard(): boolean {
-    return this._skipWizard;
-  }
-
-  /** @inheritdoc */
-  override async initialize(): Promise<void> {
-    // Read ?skip-wizard=true from the current URL on mount
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href);
-      this._skipWizard = url.searchParams.get('skip-wizard') === 'true';
-    }
-    await super.initialize();
   }
 }
 

--- a/apps/frontend/client/src/lib/views/start/components/pack_browser_view.svelte
+++ b/apps/frontend/client/src/lib/views/start/components/pack_browser_view.svelte
@@ -52,7 +52,7 @@ let { packs, selectedPackId, onselect, onconfirm, oncancel }: Props = $props();
             <h4 class="font-semibold text-base">{pack.name}</h4>
             <p class="text-xs text-base-content/60 font-mono">v{pack.version}</p>
             {#if pack.description}
-              <p class="text-sm text-base-content/70 mt-2 line-clamp-2">{pack.description}</p>
+              <p class="text-sm text-base-content/70 mt-2">{pack.description}</p>
             {/if}
           </button>
         {/each}

--- a/apps/frontend/client/src/lib/views/start/start_view.svelte
+++ b/apps/frontend/client/src/lib/views/start/start_view.svelte
@@ -99,9 +99,18 @@ let { viewModel }: { viewModel: StartViewModelInterface } = $props();
               >
                 World Generation (Preview)
               </button>
-              <p class="text-[11px] text-base-content/40 leading-snug">
+              <p class="text-[11px] text-base-content/60 leading-snug">
                 Generates a world preview that is not yet playable — used to prototype story
-                content.
+                content. See
+                <a
+                  href="https://github.com/BearlySleeping/aikami/issues/81"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="link link-primary"
+                >
+                  issue #81
+                </a>
+                for the content-pack compiler that will make generated worlds playable.
               </p>
             </div>
           </details>

--- a/apps/frontend/client/src/lib/views/start/start_view.svelte
+++ b/apps/frontend/client/src/lib/views/start/start_view.svelte
@@ -26,7 +26,7 @@ let { viewModel }: { viewModel: StartViewModelInterface } = $props();
       </div>
     </div>
   {:else}
-    <div class="hero min-h-screen bg-base-200">
+    <div class="hero min-h-screen bg-base-200" data-testid="start-menu">
       <div class="hero-content text-center">
         <div class="max-w-md">
           <!-- Title -->
@@ -83,6 +83,28 @@ let { viewModel }: { viewModel: StartViewModelInterface } = $props();
               </button>
             {/if}
           </div>
+
+          <!-- C-405 AC-4: Advanced entry for the world-generation preview -->
+          <details class="mt-8 text-left">
+            <summary
+              class="text-xs text-base-content/40 hover:text-base-content/70 cursor-pointer select-none"
+            >
+              Advanced
+            </summary>
+            <div class="mt-3 flex flex-col gap-2 w-64 mx-auto">
+              <button
+                type="button"
+                class="btn btn-outline btn-sm"
+                onclick={() => viewModel.startWorldGeneration()}
+              >
+                World Generation (Preview)
+              </button>
+              <p class="text-[11px] text-base-content/40 leading-snug">
+                Generates a world preview that is not yet playable — used to prototype story
+                content.
+              </p>
+            </div>
+          </details>
         </div>
       </div>
     </div>

--- a/apps/frontend/client/src/lib/views/start/start_view_model.svelte.ts
+++ b/apps/frontend/client/src/lib/views/start/start_view_model.svelte.ts
@@ -531,78 +531,81 @@ class StartViewModel
 
   /**
    * Proceeds with campaign creation using the given pack ID.
-   * Handles existing-character branching from the original startNewGame logic.
-   * C-405: the zero-character branch routes to onboarding, not /setup.
+   * The resolved NewCampaignDestination is the single routing decision —
+   * character-count branching lives only in _resolveNewCampaignDestination.
+   * C-405: the onboarding branch routes to persona creation, not /setup.
    */
   private async _proceedWithPack(packId: string): Promise<void> {
     try {
-      // Check for existing characters from previous sessions
-      const characterCount = this._getCharacterCount();
       const destination = this._resolveNewCampaignDestination(packId);
       this.debug('_proceedWithPack:destination', {
         kind: destination.kind,
-        contentPackId: packId,
-        characterCount,
+        contentPackId: destination.contentPackId,
       });
 
-      if (characterCount === 1) {
-        // One character — load it directly into /game with this pack
-        inventoryService.reset();
-        worldStateService.reset();
-        playerStateService.reset();
-        equipmentService.reset();
-        gameModeService.reset();
+      switch (destination.kind) {
+        case 'game': {
+          // One character — load it directly into /game with this pack
+          inventoryService.reset();
+          worldStateService.reset();
+          playerStateService.reset();
+          equipmentService.reset();
+          gameModeService.reset();
 
-        try {
-          const stored = localStorage.getItem('aikami-characters');
-          if (stored) {
-            const characters = JSON.parse(stored) as Array<{ persona: { id: string } }>;
-            if (characters.length > 0) {
-              try {
-                await personaService.setActivePersona(characters[0].persona.id);
-              } catch {
-                // Non-critical
+          try {
+            const stored = localStorage.getItem('aikami-characters');
+            if (stored) {
+              const characters = JSON.parse(stored) as Array<{ persona: { id: string } }>;
+              if (characters.length > 0) {
+                try {
+                  await personaService.setActivePersona(characters[0].persona.id);
+                } catch {
+                  // Non-critical
+                }
               }
             }
+          } catch (error) {
+            this.warn('_proceedWithPack:persona-set-failed', error);
           }
-        } catch (error) {
-          this.warn('_proceedWithPack:persona-set-failed', error);
+
+          await campaignService.startNewCampaign({ contentPackId: destination.contentPackId });
+          campaignService.completeSetup();
+          await routerService.goToRoute('game', {
+            queryParameters: undefined,
+            pathParameters: undefined,
+          });
+          return;
         }
 
-        await campaignService.startNewCampaign({ contentPackId: packId });
-        campaignService.completeSetup();
-        await routerService.goToRoute('game', {
-          queryParameters: undefined,
-          pathParameters: undefined,
-        });
-        return;
+        case 'persona_picker': {
+          // Multiple characters — create campaign, let user choose character
+          await campaignService.startNewCampaign({ contentPackId: destination.contentPackId });
+          await routerService.goToRoute('personas', {
+            queryParameters: undefined,
+            pathParameters: undefined,
+          });
+          return;
+        }
+
+        case 'onboarding': {
+          // Zero characters — go to persona creation (onboarding) with the pack
+          // selected. C-405 AC-1: this must NOT pass through the world-generation
+          // wizard; the onboarding coordinator is the default destination.
+          inventoryService.reset();
+          worldStateService.reset();
+          playerStateService.reset();
+          equipmentService.reset();
+          gameModeService.reset();
+
+          await campaignService.startNewCampaign({ contentPackId: destination.contentPackId });
+
+          await routerService.goToRoute('personaCreate', {
+            queryParameters: { onboarding: '1' },
+            pathParameters: undefined,
+          });
+          return;
+        }
       }
-
-      if (characterCount > 1) {
-        // Multiple characters — create campaign, let user choose character
-        await campaignService.startNewCampaign({ contentPackId: packId });
-        await routerService.goToRoute('personas', {
-          queryParameters: undefined,
-          pathParameters: undefined,
-        });
-        return;
-      }
-
-      // Zero characters — go to persona creation (onboarding) with the pack
-      // selected. C-405 AC-1: this must NOT pass through the world-generation
-      // wizard; the onboarding coordinator is the default destination.
-      inventoryService.reset();
-      worldStateService.reset();
-      playerStateService.reset();
-      equipmentService.reset();
-      gameModeService.reset();
-
-      await campaignService.startNewCampaign({ contentPackId: packId });
-
-      await routerService.goToRoute('personaCreate', {
-        queryParameters: { onboarding: '1' },
-        pathParameters: undefined,
-      });
     } catch (error) {
       if (isAiTextProviderRequiredError(error)) {
         this.warn('_proceedWithPack:no-text-provider', { error: String(error) });

--- a/apps/frontend/client/src/lib/views/start/start_view_model.svelte.ts
+++ b/apps/frontend/client/src/lib/views/start/start_view_model.svelte.ts
@@ -34,6 +34,16 @@ import type { SaveSlotInfo } from '$types';
 
 export type StartViewModelOptions = BaseViewModelOptions;
 
+/**
+ * Where "Start campaign" sends the player, resolved from existing state.
+ * C-405: the default path must never route through the world-generation
+ * wizard — the generated world is a preview, not a playable map (issue #81).
+ */
+type NewCampaignDestination =
+  | { readonly kind: 'onboarding'; readonly contentPackId: string }
+  | { readonly kind: 'persona_picker'; readonly contentPackId: string }
+  | { readonly kind: 'game'; readonly contentPackId: string };
+
 export type StartViewModelInterface = BaseViewModelInterface & {
   /** Whether running inside Tauri (desktop). */
   readonly isTauri: boolean;
@@ -90,6 +100,9 @@ export type StartViewModelInterface = BaseViewModelInterface & {
 
   /** C-334 AC-5: Declines recovery — clears the session marker silently. */
   declineRecovery(): Promise<void>;
+
+  /** C-405 AC-4: Navigates to the world-generation preview (Advanced entry). */
+  startWorldGeneration(): Promise<void>;
 
   // ── Pack Browser (C-345) ──
 
@@ -244,8 +257,17 @@ class StartViewModel
 
   /** @inheritdoc */
   async startNewGame(): Promise<void> {
-    // Campaign generation is beta; default to Emberwatch directly.
-    await this._proceedWithPack('emberwatch');
+    // C-405 AC-3: route through the pack browser — it shows the picker when
+    // multiple packs are installed and proceeds directly for a single pack.
+    await this.openPackBrowser();
+  }
+
+  /** @inheritdoc */
+  async startWorldGeneration(): Promise<void> {
+    await routerService.goToRoute('worldgen', {
+      queryParameters: undefined,
+      pathParameters: undefined,
+    });
   }
 
   /** @inheritdoc */
@@ -357,7 +379,7 @@ class StartViewModel
 
   /**
    * Returns the number of saved characters in localStorage.
-   * Used to determine the New Game flow: 0→/setup, 1→/game, 2+→/characters.
+   * Used to determine the New Game flow: 0→onboarding, 1→/game, 2+→/personas.
    */
   private _getCharacterCount(): number {
     try {
@@ -489,13 +511,39 @@ class StartViewModel
   }
 
   /**
+   * Resolves where a new campaign should send the player, based on the
+   * number of existing characters. C-405: the zero-character branch targets
+   * persona creation (onboarding), never the world-generation wizard.
+   */
+  private _resolveNewCampaignDestination(packId: string): NewCampaignDestination {
+    const characterCount = this._getCharacterCount();
+
+    if (characterCount === 1) {
+      return { kind: 'game', contentPackId: packId };
+    }
+
+    if (characterCount > 1) {
+      return { kind: 'persona_picker', contentPackId: packId };
+    }
+
+    return { kind: 'onboarding', contentPackId: packId };
+  }
+
+  /**
    * Proceeds with campaign creation using the given pack ID.
    * Handles existing-character branching from the original startNewGame logic.
+   * C-405: the zero-character branch routes to onboarding, not /setup.
    */
   private async _proceedWithPack(packId: string): Promise<void> {
     try {
       // Check for existing characters from previous sessions
       const characterCount = this._getCharacterCount();
+      const destination = this._resolveNewCampaignDestination(packId);
+      this.debug('_proceedWithPack:destination', {
+        kind: destination.kind,
+        contentPackId: packId,
+        characterCount,
+      });
 
       if (characterCount === 1) {
         // One character — load it directly into /game with this pack
@@ -540,7 +588,9 @@ class StartViewModel
         return;
       }
 
-      // Zero characters — go to character creation with pack selected
+      // Zero characters — go to persona creation (onboarding) with the pack
+      // selected. C-405 AC-1: this must NOT pass through the world-generation
+      // wizard; the onboarding coordinator is the default destination.
       inventoryService.reset();
       worldStateService.reset();
       playerStateService.reset();
@@ -549,8 +599,8 @@ class StartViewModel
 
       await campaignService.startNewCampaign({ contentPackId: packId });
 
-      await routerService.goToRoute('setup', {
-        queryParameters: undefined,
+      await routerService.goToRoute('personaCreate', {
+        queryParameters: { onboarding: '1' },
         pathParameters: undefined,
       });
     } catch (error) {

--- a/apps/frontend/client/src/lib/views/start/start_view_model.test.ts
+++ b/apps/frontend/client/src/lib/views/start/start_view_model.test.ts
@@ -193,6 +193,7 @@ const createViewModel = () => {
     selectedPackId: string | undefined;
     initialize(): Promise<void>;
     startNewGame(): Promise<void>;
+    startWorldGeneration(): Promise<void>;
     continueGame(): Promise<void>;
     acceptRecovery(): Promise<void>;
     declineRecovery(): Promise<void>;
@@ -637,6 +638,31 @@ describe('StartViewModel', () => {
       const vm = createViewModel();
       await vm.confirmPackSelection();
       expect(routeCalls).toHaveLength(0);
+    });
+
+    test('startWorldGeneration routes to the worldgen preview', async () => {
+      const vm = createViewModel();
+
+      await vm.startWorldGeneration();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('worldgen');
+    });
+
+    test('openPackBrowser falls back to emberwatch when no packs are installed', async () => {
+      mockAvailablePacks = [];
+      setCharacters(0);
+      const vm = createViewModel();
+
+      await vm.openPackBrowser();
+
+      expect(vm.showPackBrowser).toBe(false);
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personaCreate');
+      expect(routeCalls[0].options?.queryParameters).toEqual({ onboarding: '1' });
+      expect(
+        (_svcStubs.campaignService.startNewCampaign as ReturnType<typeof mock>).mock.calls[0]?.[0],
+      ).toEqual({ contentPackId: 'emberwatch' });
     });
   });
 });

--- a/apps/frontend/client/src/lib/views/start/start_view_model.test.ts
+++ b/apps/frontend/client/src/lib/views/start/start_view_model.test.ts
@@ -1,5 +1,7 @@
 // apps/frontend/client/src/lib/views/start/start_view_model.test.ts
 // Contract: C-323 AC-3 (start menu routes to capability screen instead of dialog)
+// Contract: C-345 (pack browser) — wired into startNewGame by C-405
+// Contract: C-405 AC-1/AC-2/AC-3 (default path skips world generation)
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 // $state and $derived are polyfilled globally via test_preload.ts.
@@ -46,6 +48,32 @@ let routeCalls: Array<{
   options?: { queryParameters?: Record<string, string>; pathParameters?: unknown };
 }> = [];
 
+type MockPack = {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  updatedAt: string;
+};
+
+let mockAvailablePacks: MockPack[] = [];
+
+const PACK_EMBERWATCH: MockPack = {
+  id: 'emberwatch',
+  name: 'Emberwatch: The Fading Ward',
+  description: 'The wardstone that protects Emberwatch Village is failing.',
+  version: '2.1.0',
+  updatedAt: '2026-07-13T00:00:00.000Z',
+};
+
+const PACK_WHISPERING_CAVES: MockPack = {
+  id: 'whispering-caves',
+  name: 'Whispering Caves',
+  description: 'Deep beneath the foothills, an ancient network of caves hums.',
+  version: '1.0.0',
+  updatedAt: '2026-07-20T00:00:00.000Z',
+};
+
 // ---------------------------------------------------------------------------
 // Import the stub barrel (preloaded mock) so we can mutate service methods.
 // These are the same Proxy stubs that test_preload installed globally.
@@ -84,6 +112,13 @@ const _setupServiceOverrides = (): void => {
     state: 'playing',
   }));
 
+  // Fresh mock each test so `.mock.calls` assertions are scoped to this test.
+  (_svcStubs.campaignService as Record<string, unknown>).startNewCampaign = mock(async () => ({
+    id: 'camp-new',
+    state: 'creating',
+  }));
+  (_svcStubs.campaignService as Record<string, unknown>).completeSetup = mock(() => {});
+
   // ── routerService ─────────────────────────────────────────────────────
   (_svcStubs.routerService as Record<string, unknown>).goToRoute = mock(
     async (
@@ -110,6 +145,17 @@ const _setupServiceOverrides = (): void => {
   // ── aiSettingsService.textProvider — ensure it returns a configured key ──
   Object.defineProperty(_svcStubs.aiSettingsService, 'textProvider', {
     get: () => ({ apiKey: 'test-key', endpoint: '', model: '' }),
+    configurable: true,
+  });
+
+  // ── packRegistryService (C-345 / C-405) ────────────────────────────────
+  (_svcStubs.packRegistryService as Record<string, unknown>).refresh = mock(async () => {
+    // The getter below returns mockAvailablePacks — the real service would
+    // populate this from /content-packs/index.json.
+  });
+
+  Object.defineProperty(_svcStubs.packRegistryService, 'availablePacks', {
+    get: () => mockAvailablePacks,
     configurable: true,
   });
 };
@@ -143,12 +189,30 @@ const createViewModel = () => {
     showRecoveryPrompt: boolean;
     recoveryCampaignId: string | undefined;
     isRecovering: boolean;
+    showPackBrowser: boolean;
+    selectedPackId: string | undefined;
     initialize(): Promise<void>;
     startNewGame(): Promise<void>;
     continueGame(): Promise<void>;
     acceptRecovery(): Promise<void>;
     declineRecovery(): Promise<void>;
+    openPackBrowser(): Promise<void>;
+    closePackBrowser(): void;
+    selectPack(packId: string): void;
+    confirmPackSelection(): Promise<void>;
   };
+};
+
+/** Sets the stored characters in localStorage for the character-count branch. */
+const setCharacters = (count: number): void => {
+  if (count === 0) {
+    localStorage.removeItem('aikami-characters');
+    return;
+  }
+  const characters = Array.from({ length: count }, (_, i) => ({
+    persona: { id: `persona-${i}` },
+  }));
+  localStorage.setItem('aikami-characters', JSON.stringify(characters));
 };
 
 // ---------------------------------------------------------------------------
@@ -161,27 +225,97 @@ describe('StartViewModel', () => {
     mockClearSessionMarkerCalls = 0;
     fetchSavesResult = [];
     routeCalls = [];
+    mockAvailablePacks = [];
+    localStorage.clear();
     _setupServiceOverrides();
   });
 
-  // ── AC-1: New Game routes to /setup ──────────────────────────────────
+  // ── C-405 AC-1: New Game routes to persona creation (onboarding) ──────
 
   describe('startNewGame()', () => {
-    test('routes to /setup', async () => {
+    test('with zero characters and one pack routes to onboarding', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH];
       const vm = createViewModel();
 
       await vm.startNewGame();
 
       expect(routeCalls).toHaveLength(1);
-      expect(routeCalls[0].route).toBe('setup');
+      expect(routeCalls[0].route).toBe('personaCreate');
+      expect(routeCalls[0].options?.queryParameters).toEqual({ onboarding: '1' });
     });
 
     test('calls gameStateService.reset() to clear stale state', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH];
       const vm = createViewModel();
 
       await vm.startNewGame();
 
       expect(resetCalls).toBe(1);
+    });
+
+    test('with zero characters and multiple packs shows the pack browser without routing', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      const vm = createViewModel();
+
+      await vm.startNewGame();
+
+      expect(routeCalls).toHaveLength(0);
+      expect(vm.showPackBrowser).toBe(true);
+      expect(vm.selectedPackId).toBe('emberwatch');
+    });
+  });
+
+  // ── C-405 AC-2: all three character-count branches reach a playable path ──
+
+  describe('NewCampaignDestination (AC-2)', () => {
+    test('zero characters → persona creation (onboarding)', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH];
+      setCharacters(0);
+      const vm = createViewModel();
+
+      await vm.startNewGame();
+
+      expect(routeCalls[0].route).toBe('personaCreate');
+      expect(routeCalls[0].options?.queryParameters).toEqual({ onboarding: '1' });
+    });
+
+    test('one character → /game directly', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH];
+      setCharacters(1);
+      const vm = createViewModel();
+
+      await vm.startNewGame();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('game');
+    });
+
+    test('two characters → persona picker (/personas)', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH];
+      setCharacters(2);
+      const vm = createViewModel();
+
+      await vm.startNewGame();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personas');
+    });
+
+    test('confirmPackSelection carries the selected pack into the branch', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      setCharacters(0);
+      const vm = createViewModel();
+
+      await vm.startNewGame();
+      vm.selectPack('whispering-caves');
+      await vm.confirmPackSelection();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personaCreate');
+      expect(routeCalls[0].options?.queryParameters).toEqual({ onboarding: '1' });
+      expect(
+        (_svcStubs.campaignService.startNewCampaign as ReturnType<typeof mock>).mock.calls[0]?.[0],
+      ).toEqual({ contentPackId: 'whispering-caves' });
     });
   });
 
@@ -244,21 +378,22 @@ describe('StartViewModel', () => {
     });
   });
 
-  // ── AC-3: starts new game with Emberwatch regardless of AI gate ──
+  // ── AC-3: starts new game regardless of AI gate ──
 
-  test('startNewGame routes to /setup even when gateway resolveMode would fail', async () => {
+  test('startNewGame routes to onboarding even when gateway resolveMode would fail', async () => {
+    mockAvailablePacks = [PACK_EMBERWATCH];
     const vm = createViewModel();
 
-    // Even when gateway resolution would fail, we default to Emberwatch
+    // Even when gateway resolution would fail, we proceed with the pack
     (_svcStubs.aiGatewayService as Record<string, unknown>).resolveMode = mock(() => {
       throw new Error('No text generation provider configured.');
     });
 
     await vm.startNewGame();
 
-    // Should route to setup with Emberwatch, not /capability
+    // Should route to persona creation with the pack, not /capability
     expect(routeCalls).toHaveLength(1);
-    expect(routeCalls[0].route).toBe('setup');
+    expect(routeCalls[0].route).toBe('personaCreate');
   });
 
   test('continueGame succeeds even when gateway resolveMode would fail', async () => {
@@ -280,10 +415,11 @@ describe('StartViewModel', () => {
     expect(routeCalls[0].route).toBe('game');
   });
 
-  test('startNewGame routes to /setup when gateway resolves successfully', async () => {
+  test('startNewGame routes to onboarding when gateway resolves successfully', async () => {
+    mockAvailablePacks = [PACK_EMBERWATCH];
     const vm = createViewModel();
 
-    // Gateway resolves successfully (default mock returns undefined, which is fine)
+    // Gateway resolves successfully
     (_svcStubs.aiGatewayService as Record<string, unknown>).resolveMode = mock(() => ({
       capability: 'text',
       mode: 'offline',
@@ -294,7 +430,7 @@ describe('StartViewModel', () => {
     await vm.startNewGame();
 
     expect(routeCalls).toHaveLength(1);
-    expect(routeCalls[0].route).toBe('setup');
+    expect(routeCalls[0].route).toBe('personaCreate');
   });
 
   // ── AC-5: Crash Recovery ────────────────────────────────────────────
@@ -401,16 +537,106 @@ describe('StartViewModel', () => {
     });
   });
 
-  // ── C-345 Pack Browser ────────────────────────────────────────────────
+  // ── C-345 Pack Browser (wired by C-405 AC-3) ───────────────────────────
 
   describe('pack browser', () => {
-    test.todo('openPackBrowser loads packs and shows browser when multiple packs available');
-    test.todo('openPackBrowser skips browser when only one pack available');
-    test.todo('closePackBrowser hides the browser and clears selection');
-    test.todo('selectPack updates selectedPackId');
-    test.todo('confirmPackSelection hides browser and proceeds with selected pack');
-    test.todo('confirmPackSelection with 1 character routes directly to /game');
-    test.todo('confirmPackSelection with 0 characters routes to /setup');
-    test.todo('confirmPackSelection with 2+ characters routes to /characters');
+    test('openPackBrowser loads packs and shows browser when multiple packs available', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      const vm = createViewModel();
+
+      await vm.openPackBrowser();
+
+      expect(vm.showPackBrowser).toBe(true);
+      expect(vm.selectedPackId).toBe('emberwatch');
+      expect(routeCalls).toHaveLength(0);
+    });
+
+    test('openPackBrowser skips browser when only one pack available', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH];
+      const vm = createViewModel();
+
+      await vm.openPackBrowser();
+
+      expect(vm.showPackBrowser).toBe(false);
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personaCreate');
+    });
+
+    test('closePackBrowser hides the browser and clears selection', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      const vm = createViewModel();
+      await vm.openPackBrowser();
+      expect(vm.showPackBrowser).toBe(true);
+
+      vm.closePackBrowser();
+
+      expect(vm.showPackBrowser).toBe(false);
+      expect(vm.selectedPackId).toBeUndefined();
+      expect(routeCalls).toHaveLength(0);
+    });
+
+    test('selectPack updates selectedPackId', async () => {
+      const vm = createViewModel();
+      vm.selectPack('whispering-caves');
+      expect(vm.selectedPackId).toBe('whispering-caves');
+    });
+
+    test('confirmPackSelection hides browser and proceeds with selected pack', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      const vm = createViewModel();
+      await vm.openPackBrowser();
+      vm.selectPack('whispering-caves');
+
+      await vm.confirmPackSelection();
+
+      expect(vm.showPackBrowser).toBe(false);
+      expect(vm.selectedPackId).toBeUndefined();
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personaCreate');
+    });
+
+    test('confirmPackSelection with 1 character routes directly to /game', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      setCharacters(1);
+      const vm = createViewModel();
+      await vm.openPackBrowser();
+      vm.selectPack('whispering-caves');
+
+      await vm.confirmPackSelection();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('game');
+    });
+
+    test('confirmPackSelection with 0 characters routes to persona creation', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      setCharacters(0);
+      const vm = createViewModel();
+      await vm.openPackBrowser();
+
+      await vm.confirmPackSelection();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personaCreate');
+      expect(routeCalls[0].options?.queryParameters).toEqual({ onboarding: '1' });
+    });
+
+    test('confirmPackSelection with 2+ characters routes to /personas', async () => {
+      mockAvailablePacks = [PACK_EMBERWATCH, PACK_WHISPERING_CAVES];
+      setCharacters(2);
+      const vm = createViewModel();
+      await vm.openPackBrowser();
+
+      await vm.confirmPackSelection();
+
+      expect(routeCalls).toHaveLength(1);
+      expect(routeCalls[0].route).toBe('personas');
+    });
+
+    test('confirmPackSelection with no selection is a no-op', async () => {
+      const vm = createViewModel();
+      await vm.confirmPackSelection();
+      expect(routeCalls).toHaveLength(0);
+    });
   });
 });

--- a/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.svelte.ts
+++ b/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.svelte.ts
@@ -524,19 +524,36 @@ export class WorldGenWizardViewModel
     try {
       const input = this._buildInput();
 
-      // Stage A — mutually independent sections, issued concurrently.
-      const [settingRaw, npcsRaw, locationsRaw, hudWidgetsRaw] = await Promise.all([
+      // Stage A — mutually independent sections, issued concurrently. Every
+      // active stage promise must settle before a retry can begin: a
+      // fast-failing stage must not start the retry path while sibling
+      // requests are still in flight (which would multiply provider requests).
+      const settledStages = await Promise.allSettled([
         this._generateStage(input, 'setting'),
         this._generateStage(input, 'npcs'),
         this._generateStage(input, 'locations'),
         this._generateStage(input, 'hudWidgets'),
       ]);
 
+      const failedStage = settledStages.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+      if (failedStage) {
+        throw failedStage.reason instanceof Error
+          ? failedStage.reason
+          : new Error('World generation stage failed');
+      }
+
+      const [settingRaw, npcsRaw, locationsRaw, hudWidgetsRaw] = settledStages
+        .filter(
+          (result): result is PromiseFulfilledResult<Record<string, unknown>> =>
+            result.status === 'fulfilled',
+        )
+        .map((result) => result.value);
+
       // Stage B — party arcs reference NPC names as quest-givers, so they
       // must wait for the NPC roster before resolving.
-      const npcNames = (Array.isArray(npcsRaw.npcs) ? npcsRaw.npcs : []).map(
-        (npc: unknown) => (npc as { name?: unknown }).name as string,
-      );
+      const npcNames = this._extractNpcNames(Array.isArray(npcsRaw.npcs) ? npcsRaw.npcs : []);
       const arcsRaw = await this._generateStage(input, 'partyArcs', npcNames);
 
       const parsed = this._mergeStages({
@@ -691,8 +708,19 @@ export class WorldGenWizardViewModel
   }
 
   /**
+   * Extracts the NPC name list from a raw npcs stage array. Used both to
+   * feed the partyArcs prompt (quest-givers must be roster names) and to
+   * validate the merged output.
+   */
+  private _extractNpcNames(npcs: unknown[]): string[] {
+    return npcs.map((npc: unknown) => String((npc as { name?: unknown }).name ?? ''));
+  }
+
+  /**
    * Merges the per-stage results into a full WorldGenOutput.
-   * Runtime validation of the merged shape happens in _performGeneration.
+   * Party arcs must reference quest-givers that exist in the generated NPC
+   * roster — an arc pointing at a missing NPC is rejected so the retry path
+   * in _performGeneration re-runs the stages.
    */
   private _mergeStages(options: {
     settingRaw: Record<string, unknown>;
@@ -703,12 +731,28 @@ export class WorldGenWizardViewModel
   }): WorldGenOutput {
     const { settingRaw, npcsRaw, locationsRaw, hudWidgetsRaw, arcsRaw } = options;
 
+    const npcs = Array.isArray(npcsRaw.npcs) ? npcsRaw.npcs : [];
+    const npcNames = new Set(this._extractNpcNames(npcs));
+
+    const partyArcs = Array.isArray(arcsRaw.partyArcs) ? arcsRaw.partyArcs : [];
+    for (const arc of partyArcs) {
+      const questGivers = Array.isArray((arc as { questGivers?: unknown }).questGivers)
+        ? (arc as { questGivers: unknown[] }).questGivers
+        : [];
+      const unknownGiver = questGivers.find(
+        (giver: unknown) => typeof giver !== 'string' || !npcNames.has(giver),
+      );
+      if (unknownGiver !== undefined) {
+        throw new Error('Party arc references an NPC not in the generated roster');
+      }
+    }
+
     return {
       worldName: String(settingRaw.worldName ?? ''),
       worldDescription: String(settingRaw.worldDescription ?? ''),
-      npcs: Array.isArray(npcsRaw.npcs) ? npcsRaw.npcs : [],
+      npcs,
       locations: Array.isArray(locationsRaw.locations) ? locationsRaw.locations : [],
-      partyArcs: Array.isArray(arcsRaw.partyArcs) ? arcsRaw.partyArcs : [],
+      partyArcs,
       hudWidgets: Array.isArray(hudWidgetsRaw.hudWidgets) ? hudWidgetsRaw.hudWidgets : [],
     } as WorldGenOutput;
   }

--- a/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.svelte.ts
+++ b/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.svelte.ts
@@ -15,7 +15,14 @@ import {
 } from '@aikami/frontend/services';
 import type { WizardStep, WorldGenInput, WorldGenOutput } from '@aikami/types';
 import { getRandomPreset } from '@aikami/types';
-import { WorldGenSchema } from '$lib/data/ai_prompts/world_gen_schema';
+import {
+  WorldGenHudWidgetsStageSchema,
+  WorldGenLocationsStageSchema,
+  WorldGenNpcsStageSchema,
+  WorldGenPartyArcsStageSchema,
+  WorldGenSchema,
+  WorldGenSettingStageSchema,
+} from '$lib/data/ai_prompts/world_gen_schema';
 import { WORLD_GEN_SYSTEM_PROMPT } from '$lib/data/ai_prompts/world_gen_system_prompt';
 import {
   campaignService,
@@ -125,6 +132,49 @@ const GENERATING_STEP_INDEX = 3;
 
 /** Maximum auto-retries on LLM failure before showing error. */
 const MAX_RETRIES = 3;
+
+// ---------------------------------------------------------------------------
+// C-405 AC-5: parallel generation stages
+// ---------------------------------------------------------------------------
+//
+// Dependency graph (written down before parallelizing — OQ-3):
+//   setting | npcs | locations | hudWidgets  — mutually independent
+//   partyArcs                                 — DEPENDS on npcs: arcs reference
+//                                               NPC names as questGivers, so
+//                                               the arcs call runs only after
+//                                               the NPC roster resolves.
+
+/** The five generation stages. */
+type GenerationStage = 'setting' | 'npcs' | 'locations' | 'hudWidgets' | 'partyArcs';
+
+/** Per-stage TypeBox schema used for LLM structured-output validation. */
+const STAGE_SCHEMAS: Record<GenerationStage, Record<string, unknown>> = {
+  setting: WorldGenSettingStageSchema,
+  npcs: WorldGenNpcsStageSchema,
+  locations: WorldGenLocationsStageSchema,
+  hudWidgets: WorldGenHudWidgetsStageSchema,
+  partyArcs: WorldGenPartyArcsStageSchema,
+} as const;
+
+/** Human-readable label for each stage (used in stage prompts). */
+const STAGE_LABELS: Record<GenerationStage, string> = {
+  setting: 'the world name and description',
+  npcs: 'the NPC roster',
+  locations: 'the location list',
+  hudWidgets: 'the HUD widget blueprints',
+  partyArcs: 'the party story arcs',
+} as const;
+
+/** Minimal JSON shape hint embedded in each stage prompt. */
+const STAGE_SHAPE_HINTS: Record<GenerationStage, string> = {
+  setting: '{ "worldName": "...", "worldDescription": "..." }',
+  npcs: '{ "npcs": [ { "name": "...", "race": "...", "class": "...", "role": "...", "description": "...", "personality": "..." } ] }',
+  locations: '{ "locations": [ "...", "...", "..." ] }',
+  hudWidgets:
+    '{ "hudWidgets": [ { "slot": "...", "label": "...", "icon": "...", "defaultVisibility": true } ] }',
+  partyArcs:
+    '{ "partyArcs": [ { "chapter": "...", "description": "...", "objectives": [ "..." ], "questGivers": [ "<NPC name from the roster>" ] } ] }',
+} as const;
 
 /** Fallback step label if not found. */
 const FALLBACK_LABEL = 'Unknown';
@@ -467,19 +517,35 @@ export class WorldGenWizardViewModel
   /**
    * Calls the LLM to generate a world from current inputs.
    * On failure, triggers auto-retry logic.
+   * C-405 AC-5: independent stages (setting, npcs, locations, hudWidgets) are
+   * issued concurrently; partyArcs run after npcs resolves.
    */
   private async _performGeneration(): Promise<void> {
     try {
       const input = this._buildInput();
-      const prompt = this._assembleGmPrompt();
 
-      const rawOutput = await this._callLlm(input, prompt);
+      // Stage A — mutually independent sections, issued concurrently.
+      const [settingRaw, npcsRaw, locationsRaw, hudWidgetsRaw] = await Promise.all([
+        this._generateStage(input, 'setting'),
+        this._generateStage(input, 'npcs'),
+        this._generateStage(input, 'locations'),
+        this._generateStage(input, 'hudWidgets'),
+      ]);
 
-      if (!rawOutput) {
-        throw new Error('LLM returned empty response');
-      }
+      // Stage B — party arcs reference NPC names as quest-givers, so they
+      // must wait for the NPC roster before resolving.
+      const npcNames = (Array.isArray(npcsRaw.npcs) ? npcsRaw.npcs : []).map(
+        (npc: unknown) => (npc as { name?: unknown }).name as string,
+      );
+      const arcsRaw = await this._generateStage(input, 'partyArcs', npcNames);
 
-      const parsed: WorldGenOutput = JSON.parse(rawOutput);
+      const parsed = this._mergeStages({
+        settingRaw,
+        npcsRaw,
+        locationsRaw,
+        hudWidgetsRaw,
+        arcsRaw,
+      });
 
       if (!parsed.worldName || !parsed.worldDescription || !Array.isArray(parsed.npcs)) {
         throw new Error('LLM response missing required fields');
@@ -543,16 +609,21 @@ export class WorldGenWizardViewModel
 
   /**
    * Calls the LLM to generate a world.
-   * Routes through textGenerationService.extractStructure() with the
-   * TypeBox WorldGenSchema for structured output validation.
-   * In the dev sandbox, this is overridden to return mock data.
+   * C-405 AC-5: generation is split into stages; `schema` selects the
+   * per-stage TypeBox schema for structured output validation. The dev
+   * sandbox overrides this method with a fixed signature and returns the
+   * full mock output — each stage parser extracts its own section from it.
    */
-  protected async _callLlm(_input: WorldGenInput, prompt: string): Promise<string | undefined> {
+  protected async _callLlm(
+    _input: WorldGenInput,
+    prompt: string,
+    schema: Record<string, unknown> = WorldGenSchema as unknown as Record<string, unknown>,
+  ): Promise<string | undefined> {
     this.debug('_callLlm:calling-textGenerationService');
 
     try {
       const result = await textGenerationService.extractStructure({
-        schema: WorldGenSchema as unknown as Record<string, unknown>,
+        schema,
         schemaName: 'WorldGenOutput',
         prompt,
         systemPrompt: WORLD_GEN_SYSTEM_PROMPT,
@@ -568,6 +639,78 @@ export class WorldGenWizardViewModel
       this.error('_callLlm:failed', { error });
       throw error;
     }
+  }
+
+  /**
+   * Runs one generation stage: assembles the stage prompt, calls the LLM with
+   * the stage schema, and parses the JSON response. Throws 'LLM returned
+   * empty response' when the LLM yields nothing — the same contract the
+   * retry logic in {@link _performGeneration} already handles.
+   */
+  private async _generateStage(
+    input: WorldGenInput,
+    stage: GenerationStage,
+    npcNames?: string[],
+  ): Promise<Record<string, unknown>> {
+    const prompt = this._assembleStagePrompt(input, stage, npcNames);
+    const rawOutput = await this._callLlm(input, prompt, STAGE_SCHEMAS[stage]);
+
+    if (!rawOutput) {
+      throw new Error('LLM returned empty response');
+    }
+
+    return JSON.parse(rawOutput) as Record<string, unknown>;
+  }
+
+  /**
+   * Assembles a stage-specific prompt. For partyArcs, the resolved NPC roster
+   * is embedded so questGivers reference real NPC names.
+   */
+  private _assembleStagePrompt(
+    input: WorldGenInput,
+    stage: GenerationStage,
+    npcNames?: string[],
+  ): string {
+    const lines = [WORLD_GEN_SYSTEM_PROMPT, '', '## User Input', JSON.stringify(input, null, 2)];
+
+    if (stage === 'partyArcs') {
+      lines.push('', '## NPC Roster (already generated)', JSON.stringify(npcNames ?? [], null, 2));
+      lines.push('The questGivers array MUST contain only names from this roster.');
+    }
+
+    lines.push(
+      '',
+      `## Task`,
+      `Generate ONLY ${STAGE_LABELS[stage]} for this world. Do NOT generate any other section.`,
+      '',
+      '## Response',
+      `Return ONLY valid JSON matching this shape: ${STAGE_SHAPE_HINTS[stage]}. No markdown fences, no explanations.`,
+    );
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Merges the per-stage results into a full WorldGenOutput.
+   * Runtime validation of the merged shape happens in _performGeneration.
+   */
+  private _mergeStages(options: {
+    settingRaw: Record<string, unknown>;
+    npcsRaw: Record<string, unknown>;
+    locationsRaw: Record<string, unknown>;
+    hudWidgetsRaw: Record<string, unknown>;
+    arcsRaw: Record<string, unknown>;
+  }): WorldGenOutput {
+    const { settingRaw, npcsRaw, locationsRaw, hudWidgetsRaw, arcsRaw } = options;
+
+    return {
+      worldName: String(settingRaw.worldName ?? ''),
+      worldDescription: String(settingRaw.worldDescription ?? ''),
+      npcs: Array.isArray(npcsRaw.npcs) ? npcsRaw.npcs : [],
+      locations: Array.isArray(locationsRaw.locations) ? locationsRaw.locations : [],
+      partyArcs: Array.isArray(arcsRaw.partyArcs) ? arcsRaw.partyArcs : [],
+      hudWidgets: Array.isArray(hudWidgetsRaw.hudWidgets) ? hudWidgetsRaw.hudWidgets : [],
+    } as WorldGenOutput;
   }
 }
 

--- a/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.test.ts
+++ b/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.test.ts
@@ -10,8 +10,10 @@
 // Contract: C-233
 
 import { describe, expect, test } from 'bun:test';
+import type { WorldGenInput } from '@aikami/types';
 import {
   getWorldGenWizardViewModel,
+  WorldGenWizardViewModel,
   type WorldGenWizardViewModelOptions,
 } from './world_gen_wizard_view_model.svelte.ts';
 
@@ -284,6 +286,117 @@ describe('WorldGenWizardViewModel — C-233', () => {
       expect(prompt).toContain('Heroic');
       expect(prompt).toContain('master world-builder');
       expect(prompt).toContain('## User Input');
+    });
+  });
+
+  // ── C-405 AC-5: parallel generation ──────────────────────────────────
+
+  describe('parallel generation (C-405 AC-5)', () => {
+    /** Compact valid full-world mock that every stage parser can extract from. */
+    const MockFullOutput = JSON.stringify({
+      worldName: 'Duskhollow',
+      worldDescription:
+        'Duskhollow is a lantern-lit frontier town in a perpetual twilight valley, where the ember-crowned mountains swallow the sun by midday.',
+      npcs: [
+        {
+          name: 'Maren',
+          race: 'Human',
+          class: 'Innkeeper',
+          role: 'Quest Giver',
+          description: 'A weathered innkeeper with a knowing smile and a ledger full of secrets.',
+          personality: 'Hospitable but sharp-tongued, she sizes up every traveler within seconds.',
+        },
+        {
+          name: 'Thorn',
+          race: 'Elf',
+          class: 'Ranger',
+          role: 'Ally',
+          description: 'A quiet elf ranger whose cloak is stitched with dried silverleaf.',
+          personality: 'Speaks in short sentences and trusts actions over words.',
+        },
+        {
+          name: 'Grimble',
+          race: 'Gnome',
+          class: 'Tinkerer',
+          role: 'Merchant',
+          description: 'A goggle-wearing gnome surrounded by humming brass contraptions.',
+          personality: 'Bubbly and distractible, he will trade anything for rare cogs.',
+        },
+      ],
+      locations: ['The Ember Market', 'Sunken Chapel', 'Ashfall Bridge', 'Cinder Mines'],
+      partyArcs: [
+        {
+          chapter: 'Chapter 1: The Fading Ward',
+          description:
+            'Maren tasks the party with rekindling the wardstone before the valley dims.',
+          objectives: ['Find the wardstone', 'Collect three ember shards', 'Return to Maren'],
+          questGivers: ['Maren'],
+        },
+      ],
+      hudWidgets: [
+        { slot: 'top-left', label: 'Ember Compass', icon: 'compass', defaultVisibility: true },
+      ],
+    });
+
+    test('independent stages are issued concurrently, arcs after npcs', async () => {
+      let activeCalls = 0;
+      let maxConcurrent = 0;
+
+      class RecordingViewModel extends WorldGenWizardViewModel {
+        protected override async _callLlm(
+          _input: WorldGenInput,
+          _prompt: string,
+          _schema?: Record<string, unknown>,
+        ): Promise<string | undefined> {
+          activeCalls++;
+          maxConcurrent = Math.max(maxConcurrent, activeCalls);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          activeCalls--;
+          return MockFullOutput;
+        }
+      }
+
+      const vm = RecordingViewModel.create({
+        className: 'WorldGenConcurrencyTest',
+        initialInputs: DEFAULT_INPUTS,
+      });
+
+      await vm.generateWorld();
+
+      // 4 independent stages overlap (concurrent); the 5th (partyArcs) runs
+      // only after the NPC roster resolves, so it never raises the max.
+      expect(maxConcurrent).toBe(4);
+      expect(vm.isGenerating).toBe(false);
+      expect(vm.currentStep).toBe('preview');
+      expect(vm.worldOutput?.worldName).toBe('Duskhollow');
+      expect(vm.worldOutput?.npcs).toHaveLength(3);
+      expect(vm.worldOutput?.partyArcs?.[0]?.questGivers).toContain('Maren');
+      expect(vm.worldOutput?.locations).toHaveLength(4);
+      expect(vm.worldOutput?.hudWidgets).toHaveLength(1);
+    });
+
+    test('a failed stage propagates the empty-response error into retry state', async () => {
+      class FailingViewModel extends WorldGenWizardViewModel {
+        protected override async _callLlm(
+          _input: WorldGenInput,
+          _prompt: string,
+          _schema?: Record<string, unknown>,
+        ): Promise<string | undefined> {
+          return undefined;
+        }
+      }
+
+      const vm = FailingViewModel.create({
+        className: 'WorldGenFailureTest',
+        initialInputs: DEFAULT_INPUTS,
+      });
+
+      await vm.generateWorld();
+
+      expect(vm.isGenerating).toBe(false);
+      expect(vm.generationError).toBe('LLM returned empty response');
+      expect(vm.retriesRemaining).toBe(0);
+      expect(vm.worldOutput).toBeUndefined();
     });
   });
 });

--- a/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.test.ts
+++ b/apps/frontend/client/src/lib/views/worldgen/world_gen_wizard_view_model.test.ts
@@ -12,6 +12,13 @@
 import { describe, expect, test } from 'bun:test';
 import type { WorldGenInput } from '@aikami/types';
 import {
+  WorldGenHudWidgetsStageSchema,
+  WorldGenLocationsStageSchema,
+  WorldGenNpcsStageSchema,
+  WorldGenPartyArcsStageSchema,
+  WorldGenSettingStageSchema,
+} from '$lib/data/ai_prompts/world_gen_schema';
+import {
   getWorldGenWizardViewModel,
   WorldGenWizardViewModel,
   type WorldGenWizardViewModelOptions,
@@ -292,67 +299,121 @@ describe('WorldGenWizardViewModel — C-233', () => {
   // ── C-405 AC-5: parallel generation ──────────────────────────────────
 
   describe('parallel generation (C-405 AC-5)', () => {
-    /** Compact valid full-world mock that every stage parser can extract from. */
-    const MockFullOutput = JSON.stringify({
-      worldName: 'Duskhollow',
-      worldDescription:
-        'Duskhollow is a lantern-lit frontier town in a perpetual twilight valley, where the ember-crowned mountains swallow the sun by midday.',
-      npcs: [
-        {
-          name: 'Maren',
-          race: 'Human',
-          class: 'Innkeeper',
-          role: 'Quest Giver',
-          description: 'A weathered innkeeper with a knowing smile and a ledger full of secrets.',
-          personality: 'Hospitable but sharp-tongued, she sizes up every traveler within seconds.',
-        },
-        {
-          name: 'Thorn',
-          race: 'Elf',
-          class: 'Ranger',
-          role: 'Ally',
-          description: 'A quiet elf ranger whose cloak is stitched with dried silverleaf.',
-          personality: 'Speaks in short sentences and trusts actions over words.',
-        },
-        {
-          name: 'Grimble',
-          race: 'Gnome',
-          class: 'Tinkerer',
-          role: 'Merchant',
-          description: 'A goggle-wearing gnome surrounded by humming brass contraptions.',
-          personality: 'Bubbly and distractible, he will trade anything for rare cogs.',
-        },
-      ],
-      locations: ['The Ember Market', 'Sunken Chapel', 'Ashfall Bridge', 'Cinder Mines'],
-      partyArcs: [
-        {
-          chapter: 'Chapter 1: The Fading Ward',
-          description:
-            'Maren tasks the party with rekindling the wardstone before the valley dims.',
-          objectives: ['Find the wardstone', 'Collect three ember shards', 'Return to Maren'],
-          questGivers: ['Maren'],
-        },
-      ],
-      hudWidgets: [
-        { slot: 'top-left', label: 'Ember Compass', icon: 'compass', defaultVisibility: true },
-      ],
-    });
+    // Stage-specific fixtures — each generation stage returns only its own
+    // section, exercising the real per-stage output contract (C-405 AC-5).
+    const StageResponses: Record<string, string> = {
+      setting: JSON.stringify({
+        worldName: 'Duskhollow',
+        worldDescription:
+          'Duskhollow is a lantern-lit frontier town in a perpetual twilight valley, where the ember-crowned mountains swallow the sun by midday.',
+      }),
+      npcs: JSON.stringify({
+        npcs: [
+          {
+            name: 'Maren',
+            race: 'Human',
+            class: 'Innkeeper',
+            role: 'Quest Giver',
+            description: 'A weathered innkeeper with a knowing smile and a ledger full of secrets.',
+            personality:
+              'Hospitable but sharp-tongued, she sizes up every traveler within seconds.',
+          },
+          {
+            name: 'Thorn',
+            race: 'Elf',
+            class: 'Ranger',
+            role: 'Ally',
+            description: 'A quiet elf ranger whose cloak is stitched with dried silverleaf.',
+            personality: 'Speaks in short sentences and trusts actions over words.',
+          },
+          {
+            name: 'Grimble',
+            race: 'Gnome',
+            class: 'Tinkerer',
+            role: 'Merchant',
+            description: 'A goggle-wearing gnome surrounded by humming brass contraptions.',
+            personality: 'Bubbly and distractible, he will trade anything for rare cogs.',
+          },
+        ],
+      }),
+      locations: JSON.stringify({
+        locations: ['The Ember Market', 'Sunken Chapel', 'Ashfall Bridge', 'Cinder Mines'],
+      }),
+      hudWidgets: JSON.stringify({
+        hudWidgets: [
+          { slot: 'top-left', label: 'Ember Compass', icon: 'compass', defaultVisibility: true },
+        ],
+      }),
+      partyArcs: JSON.stringify({
+        partyArcs: [
+          {
+            chapter: 'Chapter 1: The Fading Ward',
+            description:
+              'Maren tasks the party with rekindling the wardstone before the valley dims.',
+            objectives: ['Find the wardstone', 'Collect three ember shards', 'Return to Maren'],
+            questGivers: ['Maren'],
+          },
+        ],
+      }),
+    };
+
+    // The VM passes the per-stage TypeBox schema as the third arg — identity
+    // matching tells the mock which stage is being generated.
+    const SchemaToStage = new Map<unknown, string>([
+      [WorldGenSettingStageSchema, 'setting'],
+      [WorldGenNpcsStageSchema, 'npcs'],
+      [WorldGenLocationsStageSchema, 'locations'],
+      [WorldGenHudWidgetsStageSchema, 'hudWidgets'],
+      [WorldGenPartyArcsStageSchema, 'partyArcs'],
+    ]);
+
+    // The NPC stage is intentionally slower so the "arcs wait for npcs"
+    // ordering is observable: if partyArcs ever ran concurrently with npcs it
+    // would start while npcs is still in flight.
+    const StageDelays: Record<string, number> = {
+      setting: 30,
+      npcs: 90,
+      locations: 30,
+      hudWidgets: 30,
+      partyArcs: 30,
+    };
 
     test('independent stages are issued concurrently, arcs after npcs', async () => {
+      const stageLog: Array<{ stage: string; start: number; end: number }> = [];
       let activeCalls = 0;
       let maxConcurrent = 0;
 
       class RecordingViewModel extends WorldGenWizardViewModel {
         protected override async _callLlm(
           _input: WorldGenInput,
-          _prompt: string,
-          _schema?: Record<string, unknown>,
+          prompt: string,
+          schema?: Record<string, unknown>,
         ): Promise<string | undefined> {
+          const stage = SchemaToStage.get(schema ?? {});
+          if (!stage) {
+            throw new Error('Mock received an unexpected stage schema');
+          }
+
+          // Inspect the stage inputs instead of ignoring them: every stage
+          // prompt carries the shared task section, and partyArcs must embed
+          // the resolved NPC roster.
+          expect(prompt).toContain('## Task');
+          if (stage === 'partyArcs') {
+            expect(prompt).toContain('## NPC Roster (already generated)');
+          }
+
+          const start = Date.now();
           activeCalls++;
           maxConcurrent = Math.max(maxConcurrent, activeCalls);
-          await new Promise((resolve) => setTimeout(resolve, 30));
+          await new Promise((resolve) => setTimeout(resolve, StageDelays[stage] ?? 30));
           activeCalls--;
-          return MockFullOutput;
+          stageLog.push({ stage, start, end: Date.now() });
+
+          const response = StageResponses[stage];
+          if (!response) {
+            throw new Error(`Mock missing response for stage: ${stage}`);
+          }
+          return response;
         }
       }
 
@@ -363,9 +424,19 @@ describe('WorldGenWizardViewModel — C-233', () => {
 
       await vm.generateWorld();
 
+      const npcEntry = stageLog.find((entry) => entry.stage === 'npcs');
+      const arcsEntry = stageLog.find((entry) => entry.stage === 'partyArcs');
+      if (!npcEntry || !arcsEntry) {
+        throw new Error('npcs/partyArcs stage entries were not recorded');
+      }
+
       // 4 independent stages overlap (concurrent); the 5th (partyArcs) runs
       // only after the NPC roster resolves, so it never raises the max.
       expect(maxConcurrent).toBe(4);
+      // partyArcs may only begin after npcs has completed (questGivers must
+      // reference roster names) — the distinct NPC delay makes a concurrent
+      // start observable.
+      expect(arcsEntry.start).toBeGreaterThanOrEqual(npcEntry.end);
       expect(vm.isGenerating).toBe(false);
       expect(vm.currentStep).toBe('preview');
       expect(vm.worldOutput?.worldName).toBe('Duskhollow');

--- a/apps/frontend/client/src/routes/personas/create/+page.svelte
+++ b/apps/frontend/client/src/routes/personas/create/+page.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
 // apps/frontend/client/src/routes/personas/create/+page.svelte
+//
+// Persona creation route. With `?onboarding=1` (C-405 AC-1 default new-campaign
+// destination) it mounts the fast onboarding coordinator; otherwise it keeps
+// the legacy direct persona creation view.
+
 import PersonaCreateView from '$views/character/persona/create/persona_create_view.svelte';
 import { getPersonaCreateViewModel } from '$views/character/persona/create/persona_create_view_model.svelte';
+import OnboardingCoordinatorView from '$views/onboarding/onboarding_coordinator_view.svelte';
+import { getOnboardingCoordinatorViewModel } from '$views/onboarding/onboarding_coordinator_view_model.svelte';
 
-const viewModel = getPersonaCreateViewModel({ className: 'PersonaCreateViewModel' });
+const isOnboarding =
+  typeof window !== 'undefined' && window.location.search.includes('onboarding=1');
+
+const onboardingViewModel = getOnboardingCoordinatorViewModel({
+  className: 'OnboardingCoordinatorViewModel',
+});
+const personaViewModel = getPersonaCreateViewModel({ className: 'PersonaCreateViewModel' });
 </script>
 
-<PersonaCreateView {viewModel} />
+{#if isOnboarding}
+  <OnboardingCoordinatorView viewModel={onboardingViewModel} />
+{:else}
+  <PersonaCreateView viewModel={personaViewModel} />
+{/if}

--- a/apps/frontend/client/src/routes/personas/create/+page.svelte
+++ b/apps/frontend/client/src/routes/personas/create/+page.svelte
@@ -5,22 +5,23 @@
 // destination) it mounts the fast onboarding coordinator; otherwise it keeps
 // the legacy direct persona creation view.
 
+import { page } from '$app/state';
 import PersonaCreateView from '$views/character/persona/create/persona_create_view.svelte';
 import { getPersonaCreateViewModel } from '$views/character/persona/create/persona_create_view_model.svelte';
 import OnboardingCoordinatorView from '$views/onboarding/onboarding_coordinator_view.svelte';
 import { getOnboardingCoordinatorViewModel } from '$views/onboarding/onboarding_coordinator_view_model.svelte';
 
-const isOnboarding =
-  typeof window !== 'undefined' && window.location.search.includes('onboarding=1');
-
-const onboardingViewModel = getOnboardingCoordinatorViewModel({
-  className: 'OnboardingCoordinatorViewModel',
-});
-const personaViewModel = getPersonaCreateViewModel({ className: 'PersonaCreateViewModel' });
+// Reactive to the current URL — updates during same-route navigation and only
+// matches the exact parameter value.
+const isOnboarding = $derived(page.url.searchParams.get('onboarding') === '1');
 </script>
 
 {#if isOnboarding}
+  {@const onboardingViewModel = getOnboardingCoordinatorViewModel({
+    className: 'OnboardingCoordinatorViewModel',
+  })}
   <OnboardingCoordinatorView viewModel={onboardingViewModel} />
 {:else}
+  {@const personaViewModel = getPersonaCreateViewModel({ className: 'PersonaCreateViewModel' })}
   <PersonaCreateView viewModel={personaViewModel} />
 {/if}

--- a/apps/frontend/client/src/routes/worldgen/+page.svelte
+++ b/apps/frontend/client/src/routes/worldgen/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+// apps/frontend/client/src/routes/worldgen/+page.svelte
+//
+// C-405 AC-4: Advanced entry for the World Generation Wizard.
+//
+// This is a production route (not /dev) hosting the relocated wizard. The
+// generated world is a PREVIEW: it seeds NPCs/locations/arcs/HUD state and
+// GM prompt context, but it does not compile into the authored
+// ContentPackManifest the game loads maps from (issue #81). The banner below
+// states that plainly.
+
+import { routerService } from '$services';
+import WorldGenWizardView from '$views/worldgen/world_gen_wizard_view.svelte';
+import { getWorldGenWizardViewModel } from '$views/worldgen/world_gen_wizard_view_model.svelte';
+
+const viewModel = getWorldGenWizardViewModel({ className: 'WorldGenWizardViewModel' });
+</script>
+
+<div class="min-h-screen bg-base-100">
+  <!-- C-405: honest preview notice — the generated world is not playable yet -->
+  <div class="bg-warning/10 border-b border-warning/30 px-4 py-3">
+    <div class="max-w-3xl mx-auto flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+      <span class="badge badge-warning badge-sm shrink-0" data-testid="worldgen-preview-badge">
+        Preview
+      </span>
+      <p class="text-sm text-base-content/80">
+        This generated world is a preview and is not playable yet. It seeds story context and
+        prompts, but the playable map is authored content — see
+        <a
+          href="https://github.com/BearlySleeping/aikami/issues/81"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="link link-primary"
+        >
+          issue #81
+        </a>
+        for the content-pack compiler that will make generated worlds playable.
+      </p>
+    </div>
+  </div>
+
+  <button
+    type="button"
+    class="btn btn-ghost btn-sm m-4"
+    onclick={() => routerService.navigateToApp()}
+  >
+    ← Back to Start
+  </button>
+
+  <WorldGenWizardView {viewModel} />
+</div>

--- a/apps/frontend/docs/src/content/docs/start/installation.md
+++ b/apps/frontend/docs/src/content/docs/start/installation.md
@@ -118,3 +118,17 @@ However you install it, campaigns, saves, and chat history live in a local
 Turso (libSQL) database on your machine — that's the source of truth, not a
 server-side copy. Firebase (auth and optional cloud sync) layers on top and is
 never a boot dependency: the game plays and saves fine without ever signing in.
+
+## Starting a campaign
+
+Press **New Game** and you go straight to character creation — no AI
+world-generation wait. When more than one adventure is installed you first
+pick one from the adventure list (each pack ships its own map and quests);
+with a single adventure installed the picker is skipped. After you create
+or pick a hero you land directly in the world.
+
+A separate **Advanced → World Generation (Preview)** entry on the start screen
+lets you prototype AI-generated settings. It produces a world preview for
+story inspiration — it is **not playable yet** (the generated map compiler is
+still in progress); the playable world always comes from the authored
+adventure pack you selected.

--- a/apps/frontend/docs/src/content/docs/start/installation.md
+++ b/apps/frontend/docs/src/content/docs/start/installation.md
@@ -121,14 +121,19 @@ never a boot dependency: the game plays and saves fine without ever signing in.
 
 ## Starting a campaign
 
-Press **New Game** and you go straight to character creation — no AI
-world-generation wait. When more than one adventure is installed you first
-pick one from the adventure list (each pack ships its own map and quests);
-with a single adventure installed the picker is skipped. After you create
-or pick a hero you land directly in the world.
+Press **New Game** and you go straight to the world — no AI world-generation
+wait. When more than one adventure is installed you first pick one from the
+adventure list (each pack ships its own map and quests); with a single
+adventure installed the picker is skipped.
+
+Where you land after that depends on how many heroes you already have: with
+no heroes saved you're routed through onboarding to create your first hero;
+with exactly one hero you jump straight into the world as that hero; with
+two or more heroes you pick which one to play.
 
 A separate **Advanced → World Generation (Preview)** entry on the start screen
 lets you prototype AI-generated settings. It produces a world preview for
-story inspiration — it is **not playable yet** (the generated map compiler is
-still in progress); the playable world always comes from the authored
-adventure pack you selected.
+story inspiration — it is **not playable yet** (the generated map compiler,
+[issue #81](https://github.com/BearlySleeping/aikami/issues/81), is still in
+progress); the playable world always comes from the authored adventure pack
+you selected.


### PR DESCRIPTION
## Pipeline Status: review

**Contract**: C-405 — Cut World Generation from the Critical Path
**Contract Status**: implemented → verified
**Pipeline Stage**: review

### What was built
"Start campaign" now routes a fresh install through the C-345 pack picker (emberwatch + whispering-caves, full descriptions) to the onboarding coordinator (`/personas/create?onboarding=1`) — zero world-gen AI calls on the default path. The world-generation wizard was relocated unchanged to a new production route `/worldgen` behind an Advanced disclosure on the start screen, with an honest "preview, not playable yet" banner linking issue #81. `/setup` no longer fronts the wizard. Generation was parallelized (4 independent stages concurrent, party arcs after the NPC roster) with retry/schema behaviour preserved.

### Verification
✅ PASS — verifier attempt 1, 0 verify loops. All 5 ACs confirmed:
- **AC-1** — E2E `new_campaign_flow.spec.ts` 4/4: `/` → pack picker → onboarding, zero AI-provider requests via route-level request spy (not timing)
- **AC-2** — unit tests cover all three character-count branches (0→personaCreate?onboarding=1, 1→/game, 2+→/personas); live boot of selected pack spawns player at cave_entrance (224,416)
- **AC-3** — pack picker wired through `openPackBrowser()`; both packs listed; single-pack skip preserved; visual suite `start_picker` 100/100 (≥90 required)
- **AC-4** — `/worldgen` production route with preview-not-playable banner + issue #81 link; Advanced entry on start screen (validated 90-100/100 live)
- **AC-5** — parallel generation, unit test asserts max concurrency 4, arcs after npcs; retry/schema suites 27/27; 1830ms parallel vs 4000ms sequential-equivalent

### Verification evidence
- client unit: 1808 pass / 1 pre-existing fail (GameBootService cancellation, file not in diff)
- e2e focused: new_campaign_flow 4/4, world_gen 9/9, game_boot 4/5 (1 pre-existing strict-locator failure)
- visual: start_picker 100/100; ai_validate_image 90-100 on production screenshots
- validate() fix+typecheck+build green (client/docs/e2e); **0 new baseline failures**

### Files changed
16 files (13 modified, 3 added) — routes, start/setup/worldgen view models + tests, world_gen_schema per-stage TypeBox schemas, new_campaign_flow E2E spec, start_picker visual suite, docs getting-started page.

### Open questions resolved
- OQ-1: Advanced entry = start-screen disclosure; wizard on `/worldgen` production route (not `/dev`)
- OQ-2: whispering-caves confirmed complete enough to offer; live boot verified
- OQ-3: dependency graph — setting|npcs|locations|hudWidgets concurrent, partyArcs after npcs

### Test Results
Unit 1808 pass / 1 pre-existing fail · E2E focused 15 pass / 1 pre-existing fail · Visual 100/100 · 0 new failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Advanced World Generation preview accessible from the start menu.
  - Added staged world generation for settings, characters, locations, HUD widgets, and party arcs.
  - Added content-pack selection during new-game setup.
  - Improved campaign routing based on existing character progress.
  - Added onboarding and direct game-start flows.
- **Documentation**
  - Documented campaign startup, adventure selection, and the non-playable world-generation preview.
- **Tests**
  - Added visual and end-to-end coverage for pack selection, onboarding, campaign creation, and world generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->