### PR TITLE
feat(storage): catalog/dist R2 planes + ort wasm offload; ignore bg-task logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,10 @@ $RECYCLE.BIN/
 .pi/*/.cache/
 .pi/*/command_durations.json
 
+# Runtime background-task logs (keep the README)
+.pi/background-tasks/*
+!.pi/background-tasks/README.md
+
 script-config.*.ts
 test-results/
 

--- a/.pi/background-tasks/README.md
+++ b/.pi/background-tasks/README.md
@@ -1,0 +1,62 @@
+# Background Tasks Journal
+
+Every background command launched by the `bg` tool writes its state here so it
+stays visible **beyond the pi session that started it** — to a human `tail -f`-ing
+from a terminal, to another agent, or to a headless/CI process that never touches
+herdr. This directory is gitignored and regenerated on demand.
+
+## Files
+
+| File | Contents |
+|---|---|
+| `bg-<ts>-<pid>.json` | Machine-readable snapshot of one task (schema below) |
+| `bg-<ts>-<pid>.log`  | Combined stdout+stderr of the task, streamed live as it runs |
+
+Ids are `bg-<epoch-ms>-<pi-pid>`, so they never collide across sessions. Each
+task owns exactly one `.json` and one `.log` sharing its id.
+
+## JSON schema (`bg-<ts>-<pid>.json`)
+
+```jsonc
+{
+  "id": "bg-1755000000000-12345",  // task id == file stem
+  "command": "bun moon run app:build",
+  "cwd": "/repo",                  // working directory the command ran in
+  "pid": 9876,                     // the shell's process id (null while unknown)
+  "startedAt": 1755000000000,      // epoch ms when the task started
+  "finishedAt": 1755000060000,     // epoch ms when it exited (absent while running)
+  "exitCode": 0,                   // null while running; signal-death reports null
+  "killed": false,                 // true when the task was killed (timeout/abort/request)
+  "state": "success",              // one of running | success | failed | killed
+  "updatedAt": 1755000060000       // epoch ms of the last write
+}
+```
+
+`state` is derived from `exitCode`/`killed`/`running` and written on every
+transition (launch → running → terminal).
+
+## How to consume it without the `bg` tool
+
+```sh
+# Watch a task live as it runs:
+tail -f .pi/background-tasks/bg-*.log
+
+# See the latest snapshot of every task:
+for f in .pi/background-tasks/*.json; do echo "== $f"; jq -c '{id,state,exitCode}' "$f"; done
+
+# Peek at the end of a finished task:
+tail -40 .pi/background-tasks/bg-*.log
+```
+
+The `bg` tool itself (`bg.list`, `bg.status`, `bg.wait`) reads this journal, so
+a task launched by another session shows up here and can be inspected or waited
+on even though no live handle exists in the current process. Waiting on a
+foreign task polls the JSON snapshot rather than a process handle.
+
+## Live herdr viewer (optional)
+
+If the `herdr` CLI is on PATH, `bg.run {watch:true}` or `bg.watch` mirrors a
+task's log into a real terminal pane in the `aikami-<mode>-bg` workspace running
+`tail -f`. That pane is a *viewer only* — the task's exit code always comes from
+the process + JSON snapshot, never from scraped pane output. Close a watcher
+pane with `bg.unwatch` or `herdr pane close <pane_id>`.

--- a/.pi/background-tasks/README.md
+++ b/.pi/background-tasks/README.md
@@ -1,57 +1,78 @@
 # Background Tasks Journal
 
-Every background command launched by the `bg` tool writes its state here so it
-stays visible **beyond the pi session that started it** — to a human `tail -f`-ing
-from a terminal, to another agent, or to a headless/CI process that never touches
-herdr. This directory is gitignored and regenerated on demand.
+Background commands launched by the `bg` tool are held in memory during the Pi
+session. This directory is reserved for future journal persistence and is
+gitignored.
 
-## Files
+## Files (Planned)
+
+Tasks currently run in-memory with IDs like `bg1`, `bg2`, etc. The `bg` tool
+provides `bg.list`, `bg.status`, and `bg.wait` to inspect running tasks within
+the current session. Tasks are not persisted to disk and do not survive session
+restarts.
+
+Future journal persistence would write:
 
 | File | Contents |
 |---|---|
-| `bg-<ts>-<pid>.json` | Machine-readable snapshot of one task (schema below) |
-| `bg-<ts>-<pid>.log`  | Combined stdout+stderr of the task, streamed live as it runs |
+| `bg-<ts>-<pid>-<seq>.json` | Machine-readable snapshot of one task (schema below) |
+| `bg-<ts>-<pid>-<seq>.log`  | Combined stdout+stderr of the task, streamed live as it runs |
 
-Ids are `bg-<epoch-ms>-<pi-pid>`, so they never collide across sessions. Each
-task owns exactly one `.json` and one `.log` sharing its id.
+IDs are `bg-<epoch-ms>-<pi-pid>-<seq>`, where `<seq>` is a per-process counter
+or random component to prevent collisions when tasks launch within the same
+millisecond.
 
-## JSON schema (`bg-<ts>-<pid>.json`)
+## Planned JSON Schema (`bg-<ts>-<pid>-<seq>.json`)
 
 ```jsonc
 {
-  "id": "bg-1755000000000-12345",  // task id == file stem
+  "id": "bg-1755000000000-12345-001",  // task id == file stem
   "command": "bun moon run app:build",
-  "cwd": "/repo",                  // working directory the command ran in
-  "pid": 9876,                     // the shell's process id (null while unknown)
-  "startedAt": 1755000000000,      // epoch ms when the task started
-  "finishedAt": 1755000060000,     // epoch ms when it exited (absent while running)
-  "exitCode": 0,                   // null while running; signal-death reports null
-  "killed": false,                 // true when the task was killed (timeout/abort/request)
-  "state": "success",              // one of running | success | failed | killed
-  "updatedAt": 1755000060000       // epoch ms of the last write
+  "cwd": "/repo",                      // working directory the command ran in
+  "pid": 9876,                         // the shell's process id (null while unknown)
+  "startedAt": 1755000000000,          // epoch ms when the task started
+  "finishedAt": 1755000060000,         // epoch ms when it exited (absent while running)
+  "exitCode": 0,                       // null while running; signal-death reports null
+  "killed": false,                     // true when the task was killed (timeout/abort/request)
+  "state": "success",                  // one of running | success | failed | killed
+  "updatedAt": 1755000060000           // epoch ms of the last write
 }
 ```
 
 `state` is derived from `exitCode`/`killed`/`running` and written on every
 transition (launch → running → terminal).
 
-## How to consume it without the `bg` tool
+## Current Usage
+
+Tasks exist only in memory during the Pi session. Use the `bg` tool commands:
 
 ```sh
-# Watch a task live as it runs:
-tail -f .pi/background-tasks/bg-*.log
+# List all running tasks in this session
+bg.list
+
+# Check status of a specific task
+bg.status {id: "bg1"}
+
+# Wait for a task to complete
+bg.wait {id: "bg1"}
+```
+
+Tasks launched in one Pi session are not visible to other sessions or terminal
+processes. Cross-session availability would require the planned journal
+persistence described above.
+
+## Planned Shell Usage (When Journal Persistence is Implemented)
+
+```sh
+# Watch a specific task live as it runs:
+tail -f .pi/background-tasks/bg-1755000000000-12345-001.log
 
 # See the latest snapshot of every task:
 for f in .pi/background-tasks/*.json; do echo "== $f"; jq -c '{id,state,exitCode}' "$f"; done
 
-# Peek at the end of a finished task:
-tail -40 .pi/background-tasks/bg-*.log
+# Peek at the end of a specific finished task:
+tail -40 .pi/background-tasks/bg-1755000000000-12345-001.log
 ```
-
-The `bg` tool itself (`bg.list`, `bg.status`, `bg.wait`) reads this journal, so
-a task launched by another session shows up here and can be inspected or waited
-on even though no live handle exists in the current process. Waiting on a
-foreign task polls the JSON snapshot rather than a process handle.
 
 ## Live herdr viewer (optional)
 

--- a/.pi/extensions/lib/background_herdr.test.ts
+++ b/.pi/extensions/lib/background_herdr.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { closeWatcherPane, herdrAvailable, watchTaskInHerdr } from './background_herdr.ts';
+import * as j from './background_journal.ts';
+import { runCommand } from './process_runner.ts';
+
+/**
+ * Live herdr integration. These tests only exercise the real herdr CLI when it
+ * is on PATH and reachable; otherwise they skip (they must never fail a CI run
+ * that has no herdr). Clean up the peer workspace when they do run live.
+ */
+const live = await herdrAvailable();
+const createdWorkspaces = new Set<string>();
+
+describe('background_herdr (live, skips without herdr)', () => {
+  test('mirrors a task log into a pane and closes it cleanly', async () => {
+    if (!live) {
+      console.log('herdr unavailable — skipping live pane test');
+      return;
+    }
+    const base = mkdtempSync(join(tmpdir(), 'bg-herdr-test-'));
+    const id = j.makeTaskId(process.pid);
+    const stream = j.openLogStream(base, id);
+    j.writeLog(stream, `LIVE_SMOKE_${id}\n`);
+    await j.closeLogStream(stream);
+
+    const watcher = await watchTaskInHerdr({ base, id });
+    expect(watcher).not.toBeNull();
+    if (!watcher) {
+      rmSync(base, { recursive: true, force: true });
+      return;
+    }
+    createdWorkspaces.add(watcher.workspaceId);
+
+    // The pane should have run `tail -f` on the journal log and echoed it.
+    await new Promise((r) => setTimeout(r, 700));
+    const read = await runCommand(
+      'herdr',
+      ['pane', 'read', watcher.paneId, '--source', 'recent', '--lines', '40'],
+      { timeoutMs: 15000 },
+    );
+    expect(read.code).toBe(0);
+    expect(read.stdout).toContain(`LIVE_SMOKE_${id}`);
+
+    const closed = await closeWatcherPane(watcher.paneId);
+    expect(closed).toBe(true);
+
+    rmSync(base, { recursive: true, force: true });
+  }, 60000);
+});
+
+// Tear down any peer workspace we created during the live run.
+afterAll(async () => {
+  if (!live || createdWorkspaces.size === 0) {
+    return;
+  }
+  const { stdout } = await runCommand('herdr', ['workspace', 'list'], { timeoutMs: 15000 });
+  const list = ((): { workspaces?: { workspace_id: string }[] } | undefined => {
+    try {
+      const parsed = JSON.parse(stdout) as {
+        result?: { workspaces?: { workspace_id: string }[] };
+      };
+      return parsed.result;
+    } catch {
+      return undefined;
+    }
+  })();
+  const known = new Set((list?.workspaces ?? []).map((w) => w.workspace_id));
+  for (const id of createdWorkspaces) {
+    if (known.has(id)) {
+      await runCommand('herdr', ['workspace', 'close', id], { timeoutMs: 15000 });
+    }
+  }
+});

--- a/.pi/extensions/lib/background_herdr.ts
+++ b/.pi/extensions/lib/background_herdr.ts
@@ -1,0 +1,245 @@
+// .pi/extensions/lib/background_herdr.ts
+//
+// Optional live viewer for background tasks. When herdr is reachable (the CLI
+// is on PATH — NOT the same gate as herdr_orchestrator's HERDR_ENV check,
+// which only registers the full pane tool inside a pane), `bg.watch` mirrors a
+// task's journal log into a real terminal tab running `tail -f`, so a human
+// or any agent can watch it live.
+//
+// Layout: a single `aikami-background-tasks` workspace, with ONE numbered tab
+// per watched task (labels 1, 2, 3, …). A fresh workspace already owns a root
+// tab labelled `1`, so the first watch reuses it and subsequent watches each
+// create a new tab. Every tab has its own root pane — no pane splitting.
+//
+// 🔴 The completion signal stays with the underlying process. We mirror the
+// log into a tab; we never treat a tab's scraped output as the exit code.
+// The task's own exit code lives in its JSON snapshot.
+
+import { logPath, workspaceLabel } from './background_herdr_shared.ts';
+import { runCommand } from './process_runner.ts';
+
+const HERDR_TIMEOUT_MS = 30_000;
+
+export type WatcherHandle = {
+  paneId: string;
+  workspaceId: string;
+  /** The pane can be closed later via `bg.unwatch` or `herdr pane close`. */
+  closed: boolean;
+};
+
+/** Runs `herdr <args>` and returns trimmed stdout, or null on CLI absence/failure. */
+const _herdr = async (args: string[]): Promise<string | null> => {
+  const result = await runCommand('herdr', args, { timeoutMs: HERDR_TIMEOUT_MS });
+  if ((result.code ?? -1) !== 0) {
+    return null;
+  }
+  return result.stdout.trim();
+};
+
+/** True when the herdr CLI is on PATH and reachable. */
+export const herdrAvailable = async (): Promise<boolean> => {
+  const out = await _herdr(['workspace', 'list']);
+  return out !== null;
+};
+
+/** Parses `{ result: <T> }`; returns undefined on any parse/absence. */
+const _result = <T>(raw: string | null): T | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { result?: T };
+    return parsed.result;
+  } catch {
+    return undefined;
+  }
+};
+
+type Entity = Record<string, unknown>;
+
+// herdr nests created/changed entities inconsistently: some commands return
+// `{ result: { tab: {...} } }`, others `{ result: {...itself} }`. These
+// extractors locate the entity no matter which shape came back.
+
+const _idOf = (obj: unknown, idKey: string): string | undefined => {
+  if (!obj || typeof obj !== 'object') {
+    return undefined;
+  }
+  const o = obj as Entity;
+  if (typeof o[idKey] === 'string') {
+    return o[idKey] as string;
+  }
+  return undefined;
+};
+
+const _firstId = (root: unknown, idKey: string): string | undefined => {
+  if (!root || typeof root !== 'object') {
+    return undefined;
+  }
+  const o = root as Entity;
+  // Direct hit on the wrapper.
+  const direct = _idOf(o, idKey);
+  if (direct) {
+    return direct;
+  }
+  // Nested under a singular entity key (e.g. `result.tab`, `result.pane`,
+  // `result.workspace`) or a plural list.
+  for (const v of Object.values(o)) {
+    if (Array.isArray(v)) {
+      for (const item of v) {
+        const id = _idOf(item, idKey);
+        if (id) {
+          return id;
+        }
+      }
+    } else {
+      const id = _idOf(v, idKey);
+      if (id) {
+        return id;
+      }
+    }
+  }
+  return undefined;
+};
+
+type Workspace = { workspace_id: string; label: string };
+type Tab = { tab_id: string; label: string };
+type Pane = { pane_id: string; tab_id: string; workspace_id: string };
+
+let _cachedWorkspaceId: string | undefined;
+
+type Peer = { workspaceId: string; created: boolean };
+
+/** Finds the peer workspace by label, creating it if absent. */
+const _findOrCreateWorkspace = async (): Promise<Peer | undefined> => {
+  if (_cachedWorkspaceId) {
+    return { workspaceId: _cachedWorkspaceId, created: false };
+  }
+  const label = workspaceLabel();
+  const list = _result<{ workspaces: Workspace[] }>(await _herdr(['workspace', 'list']));
+  const existing = list?.workspaces?.find((w) => w.label === label);
+  if (existing?.workspace_id) {
+    _cachedWorkspaceId = existing.workspace_id;
+    return { workspaceId: existing.workspace_id, created: false };
+  }
+  const created = _result<unknown>(
+    await _herdr(['workspace', 'create', '--label', label, '--cwd', process.cwd(), '--no-focus']),
+  );
+  const id = _firstId(created, 'workspace_id');
+  if (id) {
+    _cachedWorkspaceId = id;
+  }
+  return id ? { workspaceId: id, created: true } : undefined;
+};
+
+const _listTabs = async (workspaceId: string): Promise<Tab[]> =>
+  _result<{ tabs: Tab[] }>(await _herdr(['tab', 'list', '--workspace', workspaceId]))?.tabs ?? [];
+
+const _key = (t: Tab): number | undefined => {
+  const n = Number(t.label);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+};
+
+/** Next tab number so watched tasks own distinct tabs: reuses `1` on a fresh workspace, else max+1. */
+const _nextTabNumber = async (workspaceId: string, workspaceCreated: boolean): Promise<number> => {
+  if (workspaceCreated) {
+    return 1;
+  }
+  const ns = (await _listTabs(workspaceId)).map(_key).filter((n): n is number => n !== undefined);
+  return (ns.length === 0 ? 0 : Math.max(...ns)) + 1;
+};
+
+/** Pane id inside a tab (each fresh tab owns exactly one root pane). */
+const _paneInTab = async (workspaceId: string, tabId: string): Promise<string | undefined> => {
+  const panes = _result<{ panes: Pane[] }>(
+    await _herdr(['pane', 'list', '--workspace', workspaceId]),
+  );
+  return panes?.panes?.find((p) => p.tab_id === tabId)?.pane_id;
+};
+
+/**
+ * Mirrors a task's log into a herdr tab running `tail -f`. Creates the peer
+ * workspace if absent, then assigns a numbered tab per task: the first watch
+ * (on a fresh workspace) reuses the auto-created root tab `1`, and every
+ * subsequent watch creates its own tab. Each tab's single root pane runs the
+ * `tail -f` — no pane splitting is performed.
+ *
+ * Returns null if herdr is unavailable or any step fails (no partial tabs are
+ * left dangling on failure).
+ */
+export const watchTaskInHerdr = async (opts: {
+  base: string;
+  id: string;
+  /** Defaults to the peer workspace label; pass a literal to override. */
+  workspace?: string;
+}): Promise<WatcherHandle | null> => {
+  // Resolve the workspace. When a literal is passed we still need its id.
+  let ws: Peer | undefined;
+  if (opts.workspace) {
+    const raw = _result<{ workspaces: Workspace[] }>(await _herdr(['workspace', 'list']));
+    const found = raw?.workspaces?.find((w) => w.label === opts.workspace);
+    ws = found ? { workspaceId: found.workspace_id, created: false } : undefined;
+  } else {
+    ws = await _findOrCreateWorkspace();
+  }
+  if (!ws) {
+    return null;
+  }
+  const { workspaceId, created } = ws;
+
+  const logFile = logPath(opts.base, opts.id);
+  const tabNumber = await _nextTabNumber(workspaceId, created);
+
+  // Use a fresh workspace's existing root tab (labelled `1`) for the first
+  // watch; otherwise create a new numbered tab. In both cases the tab has its
+  // own pane, so nothing is split.
+  let paneId: string | undefined;
+  if (tabNumber === 1) {
+    const tab1 = (await _listTabs(workspaceId)).find((t) => t.label === '1');
+    if (tab1) {
+      paneId = await _paneInTab(workspaceId, tab1.tab_id);
+    }
+  }
+  if (!paneId) {
+    const createdTab = _result<unknown>(
+      await _herdr([
+        'tab',
+        'create',
+        '--workspace',
+        workspaceId,
+        '--label',
+        String(tabNumber),
+        '--cwd',
+        process.cwd(),
+        '--no-focus',
+      ]),
+    );
+    const tabId = _firstId(createdTab, 'tab_id');
+    if (!tabId) {
+      return null;
+    }
+    paneId = (await _paneInTab(workspaceId, tabId)) ?? _firstId(createdTab, 'pane_id');
+  }
+  if (!paneId) {
+    return null;
+  }
+
+  // `tail -f` on the journal log; the pane is purely a viewer, the process'
+  // exit code never comes from here. If the pane fails to start tail, clean up
+  // rather than leaving a dead pane behind.
+  const ran = await _herdr(['pane', 'run', paneId, `tail -n +1 -f '${logFile}'`]);
+  if (ran === null) {
+    await _herdr(['pane', 'close', paneId]);
+    return null;
+  }
+
+  return { paneId, workspaceId, closed: false };
+};
+
+/** Closes a watcher pane created for a background task. */
+export const closeWatcherPane = async (paneId: string): Promise<boolean> => {
+  const out = await _herdr(['pane', 'close', paneId]);
+  return out !== null;
+};
+
+export { logPath };

--- a/.pi/extensions/lib/background_herdr_shared.test.ts
+++ b/.pi/extensions/lib/background_herdr_shared.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { logPath, workspaceLabel } from './background_herdr_shared.ts';
+import { journalDir } from './background_journal.ts';
+
+describe('background_herdr_shared', () => {
+  test('workspaceLabel is the fixed peer workspace name', () => {
+    expect(workspaceLabel()).toBe('aikami-background-tasks');
+  });
+
+  test('logPath joins the journal dir with a .log suffix', () => {
+    expect(logPath('/repo', 'bg-1-1')).toBe(`${journalDir('/repo')}/bg-1-1.log`);
+  });
+});

--- a/.pi/extensions/lib/background_herdr_shared.ts
+++ b/.pi/extensions/lib/background_herdr_shared.ts
@@ -1,0 +1,15 @@
+// .pi/extensions/lib/background_herdr_shared.ts
+//
+// Shared helpers for the optional herdr viewer: where the journal log lives,
+// and what the peer workspace is labelled. Kept separate from
+// background_herdr.ts so the label logic can be unit-tested without invoking
+// the herdr CLI.
+
+import { join } from 'node:path';
+import { journalDir } from './background_journal.ts';
+
+/** Absolute path to a task's journal log file. */
+export const logPath = (base: string, id: string): string => join(journalDir(base), `${id}.log`);
+
+/** The herdr workspace that mirrors background tasks. */
+export const workspaceLabel = (): string => 'aikami-background-tasks';

--- a/.pi/extensions/lib/background_journal.test.ts
+++ b/.pi/extensions/lib/background_journal.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  closeLogStream,
+  JOURNAL_DIR,
+  journalDir,
+  listIds,
+  makeTaskId,
+  openLogStream,
+  readLogTail,
+  readSnapshot,
+  writeLog,
+  writeSnapshot,
+} from './background_journal.ts';
+
+const tmpBase = () => {
+  const base = mkdtempSync(join(tmpdir(), 'bg-journal-'));
+  return base;
+};
+
+describe('background_journal', () => {
+  test('makeTaskId yields distinct ids and safe filenames', () => {
+    const a = makeTaskId(123);
+    const b = makeTaskId(124);
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^bg-\d+-\d+$/);
+  });
+
+  test('writeSnapshot + readSnapshot round-trips, tolerating missing files', async () => {
+    const base = tmpBase();
+    const read = readSnapshot(base, 'bg-1-1');
+    expect(read).toBeNull();
+
+    const snap = {
+      id: 'bg-1-1',
+      command: 'echo hi',
+      cwd: base,
+      pid: 99,
+      startedAt: 1000,
+      exitCode: 0,
+      state: 'success' as const,
+      updatedAt: 2000,
+    };
+    writeSnapshot(base, snap);
+    const back = readSnapshot(base, 'bg-1-1');
+    expect(back?.id).toBe('bg-1-1');
+    expect(back?.command).toBe('echo hi');
+    expect(back?.state).toBe('success');
+    expect(back?.exitCode).toBe(0);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('listIds only returns snapshot ids (no .log files)', async () => {
+    const base = tmpBase();
+    writeSnapshot(base, {
+      id: 'bg-a-1',
+      command: 'c',
+      cwd: base,
+      startedAt: 1,
+      state: 'running',
+      updatedAt: 1,
+    });
+    writeSnapshot(base, {
+      id: 'bg-b-2',
+      command: 'c',
+      cwd: base,
+      startedAt: 2,
+      state: 'running',
+      updatedAt: 2,
+    });
+    const stream = openLogStream(base, 'bg-a-1');
+    writeLog(stream, 'some output');
+    closeLogStream(stream);
+
+    // The .log must not appear as an id.
+    const ids = listIds(base);
+    expect(ids).toContain('bg-a-1');
+    expect(ids).toContain('bg-b-2');
+    expect(ids).toHaveLength(2);
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('readLogTail returns only the requested trailing lines', async () => {
+    const base = tmpBase();
+    const stream = openLogStream(base, 'bg-t-1');
+    for (let i = 1; i <= 5; i += 1) {
+      writeLog(stream, `line ${i}\n`);
+    }
+    await closeLogStream(stream);
+    const tail = readLogTail(base, 'bg-t-1', 2);
+    expect(tail).toContain('line 5');
+    expect(tail).not.toContain('line 1');
+
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('journalDir resolves a repo-relative base', () => {
+    const dir = journalDir('/repo');
+    expect(dir).toBe(join('/repo', JOURNAL_DIR));
+    expect(dir).toBe('/repo/.pi/background-tasks');
+  });
+});

--- a/.pi/extensions/lib/background_journal.ts
+++ b/.pi/extensions/lib/background_journal.ts
@@ -1,0 +1,172 @@
+// .pi/extensions/lib/background_journal.ts
+//
+// Disk journal for background tasks. Every task started by `bg` writes a
+// `<id>.json` snapshot (command, cwd, pid, timestamps, exit code) plus a
+// `<id>.log` of its combined output, streamed live. The journal makes tasks
+// visible beyond the owning pi process: `tail -f` from a terminal, or any
+// other agent that reads this directory.
+//
+// Ids are `bg-<ts>-<pid>` rather than the old per-session `bg1/2/…` so they
+// never collide across sessions. See README.md beside this directory.
+
+import type { WriteStream } from 'node:fs';
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+
+// ── Location ────────────────────────────────────────────────────────
+
+/** Repo-relative journal directory (gitignored). */
+export const JOURNAL_DIR = '.pi/background-tasks';
+
+/** Full absolute path to the journal directory. */
+export const journalDir = (base: string): string => join(base, JOURNAL_DIR);
+
+export const _logPath = (base: string, id: string): string => join(journalDir(base), `${id}.log`);
+export const _jsonPath = (base: string, id: string): string => join(journalDir(base), `${id}.json`);
+
+// ── Ids ─────────────────────────────────────────────────────────────
+
+/** `bg-<epoch ms>-<pid>` — unique across sessions and processes. Safe for filenames. */
+export const makeTaskId = (pid: number | undefined): string =>
+  `bg-${Date.now()}-${pid ?? process.pid}`;
+
+// ── Snapshots ───────────────────────────────────────────────────────
+
+export type TaskSnapshot = {
+  id: string;
+  command: string;
+  cwd: string;
+  pid?: number | null;
+  startedAt: number;
+  finishedAt?: number;
+  exitCode?: number | null;
+  killed?: boolean;
+  state: 'running' | 'success' | 'failed' | 'killed';
+  /** Epoch ms the snapshot was last written. */
+  updatedAt: number;
+};
+
+/** Atomic temp+rename write (same pattern as duration_cache.ts). */
+const _writeJson = (path: string, data: TaskSnapshot): void => {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.${process.pid}.tmp`;
+    writeFileSync(tmp, JSON.stringify(data, null, 2));
+    renameSync(tmp, path);
+  } catch {
+    // Best-effort — a read-only FS must not break the task.
+  }
+};
+
+/** Writes (or refreshes) a task's JSON snapshot atomically. */
+export const writeSnapshot = (base: string, data: TaskSnapshot): void => {
+  _writeJson(_jsonPath(base, data.id), data);
+};
+
+/** Opens an append stream for a task's log file. Best-effort. */
+export const openLogStream = (base: string, id: string): WriteStream | null => {
+  try {
+    mkdirSync(journalDir(base), { recursive: true });
+    const stream = createWriteStream(_logPath(base, id), { flags: 'a' });
+    stream.on('error', () => undefined);
+    return stream;
+  } catch {
+    return null;
+  }
+};
+
+/** Appends a chunk line to the task's log stream. */
+export const writeLog = (stream: WriteStream | null, chunk: string): void => {
+  if (!stream) {
+    return;
+  }
+  try {
+    stream.write(chunk);
+  } catch {
+    // Best-effort.
+  }
+};
+
+/**
+ * Closes the log stream, waiting for buffered writes to flush to disk so no
+ * trailing output is lost if the host process exits right after. Returns a
+ * promise so callers can await durability before reporting completion.
+ */
+export const closeLogStream = (stream: WriteStream | null): Promise<void> => {
+  if (!stream) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (!done) {
+        done = true;
+        resolve();
+      }
+    };
+    stream.on('finish', finish);
+    stream.on('error', finish);
+    try {
+      stream.end(finish);
+    } catch {
+      finish();
+    }
+  });
+};
+
+// ── Reading ─────────────────────────────────────────────────────────
+
+/** Parses a snapshot from a `.json` file, tolerating corruption. */
+export const readSnapshot = (base: string, id: string): TaskSnapshot | null => {
+  const path = _jsonPath(base, id);
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as TaskSnapshot;
+    if (!parsed?.id || typeof parsed.command !== 'string') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+/** Lists every known task id in the journal (each has a `.json`). */
+export const listIds = (base: string): string[] => {
+  try {
+    return readdirSync(journalDir(base))
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.slice(0, -'.json'.length))
+      .sort();
+  } catch {
+    return [];
+  }
+};
+
+/** Returns the current tail of a task's log file. */
+export const readLogTail = (base: string, id: string, lines: number): string => {
+  const path = _logPath(base, id);
+  if (!existsSync(path)) {
+    return '';
+  }
+  try {
+    const text = readFileSync(path, 'utf8');
+    const all = text.split('\n');
+    return all
+      .slice(Math.max(0, all.length - lines))
+      .join('\n')
+      .trim();
+  } catch {
+    return '';
+  }
+};

--- a/.pi/git/.gitignore
+++ b/.pi/git/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/backend/local-stack/src/index.ts
+++ b/apps/backend/local-stack/src/index.ts
@@ -1,0 +1,25 @@
+// apps/backend/local-stack/src/index.ts
+//
+// Public entry point of @aikami/local-stack — the orchestration layer for
+// the local AI engine stack (C-390). It owns the compose topology
+// (compose*.yaml), the checksum-verified model fetcher, the `stack init`
+// hardware-detection wizard, the native host launchers, and the one-command
+// installer release bundle.
+//
+// Module layout (matches the repo convention):
+//   src/lib/    runtime modules + their bun:test specs
+//   src/scripts/  repo-local dev tools (Bun/TS, replacing the old .sh)
+//   src/index.ts  this entry point
+//
+// The CLI entries (init, fetch, migrate) are not re-exported here — they
+// run via `bun run src/lib/init.ts` etc. and gate on `import.meta.main`.
+
+export { probeOllama } from './lib/detect_ollama.ts';
+export type { CliOptions, RunInitDeps } from './lib/init.ts';
+export {
+  defaultEnvPath,
+  defaultEnvPath as devDefaultEnvPath,
+  parseArgs,
+  renderPlan,
+  runInit,
+} from './lib/init.ts';

--- a/apps/backend/local-stack/src/scripts/bundle.ts
+++ b/apps/backend/local-stack/src/scripts/bundle.ts
@@ -1,0 +1,205 @@
+// apps/backend/local-stack/src/scripts/bundle.ts
+//
+// C-418 Feature F: builds the release bundles for the one-command installers
+// (was scripts/bundle_stack.sh).
+//
+//   per-platform bundle layout (local-stack-<version>-<platform>):
+//     compose*.yaml  .env.example  VERSION  bin/stack-init[.exe]
+//     POSIX platforms:  install.sh  aikami
+//     Windows:          install.ps1 aikami.ps1  aikami.cmd
+//
+//   artifacts:
+//     dist/local-stack-<version>-<platform>.tar.gz   (linux, darwin)
+//     dist/local-stack-<version>-windows-x64.zip     (windows)
+//     dist/SHA256SUMS                                (covers every asset)
+//
+// `stack-init` is the hardware-detection wizard (src/lib/init.ts) compiled to
+// a single-file Bun binary so the installer can run it on the HOST without a
+// repo checkout, Node, or Bun installed. GPU detection never runs inside a
+// container (no NVIDIA toolkit — C-418 Feature F).
+//
+// Platform (M1): ONE PLATFORM PER ASSET. A compiled Bun binary is ~95 MB
+// (~38 MB compressed); shipping all five in one tarball would make every user
+// download ~190 MB to run one of them. Each platform therefore gets its own
+// archive containing only the binary and the installer that platform can run,
+// and install.sh / install.ps1 request their own asset by name.
+//
+// By default only the HOST platform is built (fast local/CI iteration). The
+// publish workflow sets AIKAMI_BUNDLE_TARGETS to the full matrix:
+//   AIKAMI_BUNDLE_TARGETS="bun-linux-x64 bun-linux-arm64 bun-darwin-x64 \
+//                          bun-darwin-arm64 bun-windows-x64"
+//
+// Usage: bun src/scripts/bundle.ts   (AIKAMI_STACK_VERSION overrides the tag)
+
+// biome-ignore-all lint/suspicious/noConsole: CLI tool — console is the interface
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from 'node:fs';
+import { cp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+const ROOT = join(import.meta.dir, '../..');
+
+const log = (message: string): void => console.log(`\u001b[1;34m[bundle]\u001b[0m ${message}`);
+const die = (message: string): never => {
+  console.error(`\u001b[1;31m[bundle] error:\u001b[0m ${message}`);
+  process.exit(1);
+};
+
+/** Read the version from package.json (jq-free — works on Git Bash too). */
+const readVersion = (): string => {
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as { version: string };
+  return pkg.version ?? '0.1.0';
+};
+
+const VERSION = process.env.AIKAMI_STACK_VERSION ?? readVersion();
+const DIST_DIR = process.env.AIKAMI_BUNDLE_DIR ?? 'dist';
+
+/** Determine the host platform target (bun-<os>-<arch>). */
+const hostTarget = (): string => {
+  const osNames: Record<string, string> = {
+    linux: 'linux',
+    darwin: 'darwin',
+    win32: 'windows',
+  };
+  const os = osNames[process.platform];
+  if (os === undefined) {
+    return die(`unsupported build host '${process.platform}'`);
+  }
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  return `bun-${os}-${arch}`;
+};
+
+const BUNDLE_TARGETS = (process.env.AIKAMI_BUNDLE_TARGETS ?? hostTarget())
+  .split(/\s+/)
+  .filter(Boolean);
+
+/** Cross-compile init.ts to a single-file Bun binary for one target. */
+const compileWizard = (target: string, outfile: string): void => {
+  log(`compiling ${target} wizard (bun build --compile --target ${target})`);
+  const res = spawnSync(
+    'bun',
+    ['build', '--compile', '--target', target, 'src/lib/init.ts', '--outfile', outfile],
+    { cwd: ROOT, stdio: ['ignore', 'inherit', 'inherit'] },
+  );
+  if (res.status !== 0) {
+    die(`bun build failed for ${target}`);
+  }
+  // bun appends .exe for windows targets even when the outfile already has it;
+  // normalise so the installer's expected path always exists.
+  if (!existsSync(outfile) && existsSync(`${outfile}.exe`)) {
+    renameSync(`${outfile}.exe`, outfile);
+  }
+};
+
+/** Fall back to Python's zipfile module (host may lack `zip`). */
+const makeZip = (distDir: string, name: string, topDir: string): void => {
+  const out = join(distDir, name);
+  rmSync(out, { force: true });
+  const bundleDir = join(distDir, 'bundle');
+
+  if (
+    spawnSync('zip', ['-qr', `../${name}`, topDir], { cwd: bundleDir, stdio: 'ignore' }).status ===
+      0 &&
+    existsSync(out)
+  ) {
+    return;
+  }
+  for (const py of ['python3', 'python', 'py']) {
+    const res = spawnSync(py, ['-m', 'zipfile', '-c', `../${name}`, topDir], {
+      cwd: bundleDir,
+      stdio: 'ignore',
+    });
+    if (res.status === 0 && existsSync(out)) {
+      return;
+    }
+  }
+  die(
+    `no working archiver for ${name} — install zip or a real python3 (the Microsoft Store python alias does not count).`,
+  );
+};
+
+const sha256Of = (file: string): string => {
+  const buf = readFileSync(file);
+  return `${createHash('sha256').update(buf).digest('hex')}  ${basename(file)}`;
+};
+
+if (import.meta.main) {
+  log(`bundling local-stack ${VERSION}`);
+  log(`targets: ${BUNDLE_TARGETS.join(' ')}`);
+  rmSync(DIST_DIR, { recursive: true, force: true });
+  mkdirSync(join(DIST_DIR, 'bundle'), { recursive: true });
+
+  for (const target of BUNDLE_TARGETS) {
+    const platform = target.replace('bun-', '');
+    const bundleDir = join(DIST_DIR, 'bundle', `local-stack-${VERSION}-${platform}`);
+    mkdirSync(join(bundleDir, 'bin'), { recursive: true });
+
+    const binary = platform.startsWith('windows-')
+      ? join(bundleDir, 'bin', 'stack-init.exe')
+      : join(bundleDir, 'bin', 'stack-init');
+    compileWizard(target, binary);
+
+    log('  copying compose topology + env example + installer');
+    // Compose files live under compose/ in the repo (src layout) but are laid
+    // FLAT in the released bundle — install.sh, aikami and docker compose
+    // expect compose*.yaml at the bundle root. So read from compose/ here and
+    // write each file to the bundle root.
+    const composeDir = join(ROOT, 'compose');
+    for (const file of await readdir(composeDir)) {
+      if (file.startsWith('compose') && file.endsWith('.yaml')) {
+        await cp(join(composeDir, file), join(bundleDir, file));
+      }
+    }
+    await cp(join(ROOT, '.env.example'), join(bundleDir, '.env.example'));
+    await writeFile(join(bundleDir, 'VERSION'), VERSION);
+
+    if (platform.startsWith('windows-')) {
+      await cp(join(ROOT, 'install.ps1'), join(bundleDir, 'install.ps1'));
+      await cp(join(ROOT, 'aikami.ps1'), join(bundleDir, 'aikami.ps1'));
+      await cp(join(ROOT, 'aikami.cmd'), join(bundleDir, 'aikami.cmd'));
+      const archive = `local-stack-${VERSION}-${platform}.zip`;
+      log(`  creating ${join(DIST_DIR, archive)}`);
+      makeZip(DIST_DIR, archive, `local-stack-${VERSION}-${platform}`);
+    } else {
+      await cp(join(ROOT, 'install.sh'), join(bundleDir, 'install.sh'));
+      await cp(join(ROOT, 'aikami'), join(bundleDir, 'aikami'));
+      chmodSync(join(bundleDir, 'aikami'), 0o755);
+      chmodSync(join(bundleDir, 'install.sh'), 0o755);
+      const archive = `local-stack-${VERSION}-${platform}.tar.gz`;
+      log(`  creating ${join(DIST_DIR, archive)}`);
+      const res = spawnSync(
+        'tar',
+        [
+          '-czf',
+          join(DIST_DIR, archive),
+          '-C',
+          join(DIST_DIR, 'bundle'),
+          `local-stack-${VERSION}-${platform}`,
+        ],
+        { cwd: ROOT, stdio: 'inherit' },
+      );
+      if (res.status !== 0) {
+        die(`tar failed for ${archive}`);
+      }
+    }
+  }
+
+  // M2: checksums so the installers can verify every archive before extraction.
+  log(`writing ${join(DIST_DIR, 'SHA256SUMS')}`);
+  const sums: string[] = [];
+  for (const file of await readdir(DIST_DIR)) {
+    if (/^local-stack-.*\.(tar\.gz|zip)$/.test(file)) {
+      sums.push(sha256Of(join(DIST_DIR, file)));
+    }
+  }
+  await writeFile(join(DIST_DIR, 'SHA256SUMS'), `${sums.join('\n')}\n`);
+  if (sums.length === 0) {
+    die('no assets were produced.');
+  }
+
+  log('done');
+  console.log((await readdir(DIST_DIR)).map((f) => `  ${f}`).join('\n'));
+  console.log((await readFile(join(DIST_DIR, 'SHA256SUMS'), 'utf8')).trim());
+}

--- a/apps/backend/local-stack/src/scripts/check.ts
+++ b/apps/backend/local-stack/src/scripts/check.ts
@@ -1,0 +1,637 @@
+// apps/backend/local-stack/src/scripts/check.ts
+//
+// Local-stack smoke tests (C-390). Verifies every machine-checkable AC:
+//
+//   --static   compose render + AC-1/AC-1b/AC-2/AC-3/AC-11/AC-13 assertions,
+//              + src-level unit tests. No docker pull, no engine boot.
+//   (default)  static + unit tests + (when LOCAL_STACK_LIVE=1) real health
+//              probes against a running stack (AC-4).
+//
+// AC-8 (offline start) and AC-12 (Darwin native path) are documented manual
+// checks in the README — the live probe mode exercises the same paths on the
+// current host when engines are up.
+//
+// Was scripts/check.sh; now a Bun/TS harness so the repo-local tooling needs
+// no shell logic.
+
+// biome-ignore-all lint/suspicious/noConsole: smoke-test harness — console is the interface
+// biome-ignore-all lint/style/useNamingConvention: env-var keys are uppercase by definition
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '../..');
+
+// Compose files live under compose/ in the repo (src layout) but are laid FLAT
+// in the released bundle (install.sh / aikami / docker compose expect them at
+// the bundle root). These checks run against the repo tree, so map flat bundle
+// names (compose.yaml, compose.cpu.yaml, or a colon-joined COMPOSE_FILE value)
+// to their repo path under compose/.
+const composePath = (value: string): string =>
+  value
+    .split(':')
+    .map((p) => (p.startsWith('compose') && p.endsWith('.yaml') ? `compose/${p}` : p))
+    .join(':');
+
+let okCount = 0;
+let failCount = 0;
+let skipCount = 0;
+
+const ok = (desc: string): void => {
+  okCount += 1;
+  console.log(`ok   - ${desc}`);
+};
+const bad = (desc: string): void => {
+  failCount += 1;
+  console.log(`FAIL - ${desc}`);
+};
+const skip = (desc: string): void => {
+  skipCount += 1;
+  console.log(`skip - ${desc}`);
+};
+
+/** Run a program, return {code, stdout}. */
+const run = (
+  cmd: string,
+  args: readonly string[],
+  env: Record<string, string | undefined> = {},
+  opts: { cwd?: string; timeoutMs?: number } = {},
+): { code: number; stdout: string; stderr: string } => {
+  const mergedEnv = { ...process.env, ...env } as NodeJS.ProcessEnv;
+  // Hermetic compose: an ambient COMPOSE_FILE / COMPOSE_PROFILES (e.g. the
+  // emulator dev env) must not leak into renders — every compose check passes
+  // the exact values it needs.
+  for (const key of ['COMPOSE_FILE', 'COMPOSE_PROFILES']) {
+    if (!(key in env)) {
+      delete mergedEnv[key];
+    }
+  }
+  const res = spawnSync(cmd, args, {
+    cwd: opts.cwd ?? ROOT,
+    env: mergedEnv,
+    encoding: 'utf8',
+    timeout: opts.timeoutMs,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const code = res.status ?? (res.error ? 1 : 0);
+  const stdout = (res.stdout ?? '') as string;
+  const stderr = (res.stderr ?? '') as string;
+  return { code, stdout, stderr };
+};
+
+const check = (desc: string, fn: () => boolean | { code: number }, extra?: string): void => {
+  let passed = false;
+  try {
+    const result = fn();
+    passed = typeof result === 'boolean' ? result : result.code === 0;
+  } catch {
+    passed = false;
+  }
+  if (passed) {
+    ok(desc);
+  } else {
+    bad(`${desc}${extra ? ` (${extra})` : ''}`);
+  }
+};
+
+// ── Unit tests (AC-6, AC-7, AC-10, AC-11) ───────────────────────────────
+console.log('== unit tests ==');
+{
+  const unit = run('bun', ['test', 'src/lib/*.test.ts'], {}, { timeoutMs: 180_000 });
+  const ranMatch = unit.stdout.match(/^Ran (\d+) tests/m);
+  check(
+    'unit tests',
+    () => unit.code === 0,
+    ranMatch ? `${ranMatch[1]} tests ran` : unit.stdout.slice(-300),
+  );
+}
+
+// ── Syntax checks: the remaining native scripts that must stay shell ────
+console.log('== shell / python syntax ==');
+// install.sh + aikami ship to hosts with no Bun — they stay POSIX sh and are
+// still syntax-checked.
+check('sh syntax: install.sh', () => run('sh', ['-n', 'install.sh']));
+check('sh syntax: aikami', () => run('sh', ['-n', 'aikami']));
+check('bash syntax: docker/voice/entrypoint.sh', () =>
+  run('bash', ['-n', 'docker/voice/entrypoint.sh']),
+);
+check('bash syntax: docker/client/generate_config.sh', () =>
+  run('bash', ['-n', 'docker/client/generate_config.sh']),
+);
+
+// Python syntax (docker/voice servers) — resolve a real python3.
+const pythonCandidates = ['python3', 'python', 'py'];
+const python = pythonCandidates.find((p) => run(p, ['-c', 'import sys']).code === 0);
+if (python) {
+  check('python syntax: docker/voice/stt_server.py', () =>
+    run(python, ['-m', 'py_compile', 'docker/voice/stt_server.py']),
+  );
+  check('python syntax: docker/voice/tts_server.py', () =>
+    run(python, ['-m', 'py_compile', 'docker/voice/tts_server.py']),
+  );
+} else {
+  skip('python syntax checks — no working python interpreter on PATH');
+}
+
+// ── C-393 AC-7: STT is off by default ───────────────────────────────────
+console.log('== C-393 AC-7: STT off by default ==');
+{
+  const envExample = readFileSync(join(ROOT, '.env.example'), 'utf8');
+  const profilesLine = envExample.split('\n').find((l) => l.startsWith('COMPOSE_PROFILES='));
+  check(
+    'AC-7: .env.example does not enable the stt profile',
+    () => profilesLine !== undefined && !/\bstt\b/.test(profilesLine.split('=')[1] ?? ''),
+  );
+  check('AC-7: .env.example sets ENABLE_STT=false', () => envExample.includes('ENABLE_STT=false'));
+  check('AC-7: .env.example has no ENABLE_STT=true', () => !envExample.includes('ENABLE_STT=true'));
+
+  const renderNoStt = run('docker', ['compose', 'config'], {
+    COMPOSE_FILE: composePath('compose.yaml:compose.cpu.yaml'),
+    COMPOSE_PROFILES: 'text,image,voice',
+  }).stdout;
+  check(
+    'AC-7: no-STT render publishes no STT port',
+    () => !/published:\s*["']?8087["']?/.test(renderNoStt),
+  );
+
+  const compose = readFileSync(join(ROOT, 'compose/compose.yaml'), 'utf8');
+  check('C-393: voice service carries the stt profile', () =>
+    compose.includes('profiles: ["voice", "stt"]'),
+  );
+}
+
+// ── Native launcher path (AC-12) ──────────────────────────────────────────
+console.log('== native launcher path (AC-12) ==');
+{
+  const launchers = [
+    'src/scripts/native/run_llm.ts',
+    'src/scripts/native/run_tts.ts',
+    'src/scripts/native/run_stt.ts',
+  ];
+  for (const launcher of launchers) {
+    check(`AC-12: ${launcher} present`, () => existsSync(join(ROOT, launcher)));
+  }
+  const llm = readFileSync(join(ROOT, 'src/scripts/native/run_llm.ts'), 'utf8');
+  const tts = readFileSync(join(ROOT, 'src/scripts/native/run_tts.ts'), 'utf8');
+  const stt = readFileSync(join(ROOT, 'src/scripts/native/run_stt.ts'), 'utf8');
+  check(
+    'AC-12: run_llm defaults to port 11434',
+    () => llm.includes('LLM_PORT') && llm.includes('11434'),
+  );
+  check(
+    'AC-12: run_tts defaults to port 8089',
+    () => tts.includes('TTS_PORT') && tts.includes('8089'),
+  );
+  check(
+    'AC-12: run_stt defaults to port 8087',
+    () => stt.includes('STT_PORT') && stt.includes('8087'),
+  );
+  check('AC-12: run_stt drives stt_server.py (C-393 protocol)', () =>
+    stt.includes('stt_server.py'),
+  );
+  if (process.platform === 'darwin') {
+    ok('AC-12: Darwin — native path verified (no Metal passthrough, engines run natively)');
+  } else {
+    ok('AC-12: non-Darwin — native launchers shipped and port-defaulted');
+  }
+}
+
+// ── C-393 AC-11: STT models come from the manifest ──────────────────────
+console.log('== C-393 AC-11: STT manifest + no weights in images ==');
+{
+  const manifest = readFileSync(join(ROOT, 'src/models.manifest.json'), 'utf8');
+  for (const id of [
+    'stt-moonshine-tiny-en-int8',
+    'stt-moonshine-base-en-int8',
+    'stt-whisper-tiny',
+    'stt-whisper-base',
+    'stt-whisper-small',
+    'stt-silero-vad',
+  ]) {
+    check(`AC-11: manifest carries ${id}`, () => manifest.includes(`"id": "${id}"`));
+  }
+  const voiceDockerfile = readFileSync(join(ROOT, 'docker/voice/Dockerfile.sherpa'), 'utf8');
+  check(
+    'AC-11: no weights COPYed into the voice image',
+    () => !/COPY .*models\//.test(voiceDockerfile),
+  );
+  const fetchModels = readFileSync(join(ROOT, 'src/lib/fetch_models.ts'), 'utf8');
+  check('AC-11: fetcher tier-selects STT entries', () => fetchModels.includes('selectSttEntries'));
+  const composeMain = readFileSync(join(ROOT, 'compose/compose.yaml'), 'utf8');
+  check('AC-11: compose passes STT_STREAM_MODEL to the fetcher', () =>
+    composeMain.includes('STT_STREAM_MODEL'),
+  );
+  const entrypoint = readFileSync(join(ROOT, 'docker/voice/entrypoint.sh'), 'utf8');
+  check(
+    'AC-11: entrypoint does not auto-download STT models',
+    () => !/sherpa-onnx-moonshine.*curl|curl.*sherpa-onnx-moonshine/.test(entrypoint),
+  );
+}
+
+// ── Compose topology (AC-2, AC-3, AC-11) ─────────────────────────────────
+console.log('== compose topology ==');
+
+const profileServices = (profiles: string): string =>
+  run('docker', ['compose', 'config', '--services'], {
+    COMPOSE_PROFILES: profiles,
+    COMPOSE_FILE: composePath('compose.yaml'),
+  }).stdout.trim();
+
+check('compose parses (base, no profiles)', () =>
+  run('docker', ['compose', '-f', composePath('compose.yaml'), 'config', '--quiet']),
+);
+for (const override of ['cpu', 'cuda', 'rocm', 'vulkan', 'intel', 'musa', 'models-path']) {
+  check(`compose parses: ${override} override`, () =>
+    run('docker', [
+      'compose',
+      '-f',
+      composePath('compose.yaml'),
+      '-f',
+      composePath(`compose.${override}.yaml`),
+      'config',
+      '--quiet',
+    ]),
+  );
+}
+check('compose parses: stt override', () =>
+  run('docker', [
+    'compose',
+    '-f',
+    composePath('compose.yaml'),
+    '-f',
+    composePath('compose.cpu.yaml'),
+    '-f',
+    composePath('compose.stt.yaml'),
+    'config',
+    '--quiet',
+  ]),
+);
+
+const expectedServices: Record<string, string> = {
+  text: 'model-fetcher\ntext',
+  image: 'model-fetcher\nimage',
+  voice: 'model-fetcher\nvoice',
+  stt: 'model-fetcher\nvoice',
+  client: 'client',
+};
+for (const [profile, expected] of Object.entries(expectedServices)) {
+  const svcs = profileServices(profile);
+  if (svcs === expected) {
+    ok(`AC-2: profile '${profile}' starts exactly: ${svcs.split('\n').join(', ')}`);
+  } else {
+    bad(`AC-2: profile '${profile}' expected [${expected.split('\n').join(' ')}], got [${svcs}]`);
+  }
+}
+
+// AC-3: CUDA override resolves to a CUDA text image with an NVIDIA device
+const render = (composeFile: string, profiles = 'text'): string =>
+  run('docker', ['compose', 'config'], {
+    COMPOSE_FILE: composePath(composeFile),
+    COMPOSE_PROFILES: profiles,
+  }).stdout;
+
+check('AC-3: base file resolves text to the CPU image', () =>
+  render('compose.yaml').includes('ghcr.io/ggml-org/llama.cpp:server@sha256'),
+);
+check('AC-3: base file resolves image to the CPU sd-server image', () =>
+  render('compose.yaml', 'image').includes('aikami-sd-server:cpu'),
+);
+check(
+  'AC-3: base file has no device reservation',
+  () => !render('compose.yaml', 'image').includes('nvidia'),
+);
+check('AC-3: cuda override resolves text to a CUDA image', () =>
+  render('compose.yaml:compose.cuda.yaml').includes('server-cuda@sha256'),
+);
+check('AC-3: cuda override carries an NVIDIA device reservation', () =>
+  render('compose.yaml:compose.cuda.yaml', 'image').includes('driver: nvidia'),
+);
+
+// AC-1b: per-backend render
+console.log('== AC-1b per-backend renders ==');
+{
+  const backendText: Record<string, string> = {
+    cpu: 'ghcr.io/ggml-org/llama.cpp:server@sha256',
+    cuda: 'server-cuda@sha256',
+    rocm: 'server-rocm@sha256',
+    vulkan: 'server-vulkan@sha256',
+    intel: 'server-intel@sha256',
+    musa: 'server-musa@sha256',
+  };
+  const backendImage: Record<string, string> = {
+    cpu: 'aikami-sd-server:cpu',
+    rocm: 'master-vulkan@sha256',
+    cuda: 'master-cuda@sha256',
+    vulkan: 'master-vulkan@sha256',
+    intel: 'master-sycl@sha256',
+    musa: 'master-musa@sha256',
+  };
+  for (const backend of ['cpu', 'cuda', 'rocm', 'vulkan', 'intel', 'musa']) {
+    const rendered = render(`compose.yaml:compose.${backend}.yaml`, 'text,image');
+    check(`AC-1b: ${backend} text image → expected`, () => rendered.includes(backendText[backend]));
+    check(`AC-1b: ${backend} image → expected`, () => rendered.includes(backendImage[backend]));
+  }
+}
+
+// AC-11: no service binds 8080 and engine ports match the table; loopback.
+{
+  const all = render(
+    'compose.yaml:compose.cpu.yaml:compose.stt.yaml',
+    'text,image,voice,stt,client',
+  );
+  check('AC-11: host port 8080 is not published', () => !/published:\s*["']?8080["']?/.test(all));
+  for (const port of [11434, 8188, 8089, 8087, 5274]) {
+    check(`AC-11: port ${port} published`, () =>
+      new RegExp(`published:\\s*["']?${port}["']?`).test(all),
+    );
+  }
+  // Every host publish must bind 127.0.0.1.
+  const hostIps = [...all.matchAll(/^\s*host_ip:\s*(\S+)/gm)].map((m) => m[1]);
+  const nonLoopback = hostIps.filter((ip) => ip && ip !== '127.0.0.1');
+  check(
+    'AC-11: every host publish binds 127.0.0.1',
+    () => nonLoopback.length === 0,
+    nonLoopback.join(', '),
+  );
+}
+
+// AC-13: MODELS_PATH selects a bind mount instead of the named volume.
+{
+  const modelsPathRender = run(
+    'docker',
+    [
+      'compose',
+      '-f',
+      composePath('compose.yaml'),
+      '-f',
+      composePath('compose.models-path.yaml'),
+      'config',
+    ],
+    {
+      MODELS_PATH: '/tmp/aikami-models',
+      COMPOSE_PROFILES: 'text',
+    },
+  ).stdout;
+  check('AC-13: MODELS_PATH bind mount rendered', () =>
+    modelsPathRender.includes('/tmp/aikami-models'),
+  );
+}
+
+// ── C-392: dev engine services converge on the local stack ───────────────
+console.log('== C-392 dev engine convergence (AC-2, AC-6, AC-7) ==');
+{
+  for (const app of ['text', 'image', 'voice']) {
+    const start = readFileSync(join(ROOT, `../${app}/scripts/start.ts`), 'utf8');
+    check(
+      `AC-2: ${app}/scripts/start.ts delegates to the local-stack compose topology`,
+      () => start.includes('local-stack') || start.includes('compose'),
+    );
+  }
+  check('AC-2: text profile resolves to llama-server (digest-pinned)', () =>
+    render('compose.yaml', 'text').includes('ghcr.io/ggml-org/llama.cpp:server@sha256'),
+  );
+  check('AC-2: image profile resolves to sd-server', () =>
+    render('compose.yaml', 'image').includes('aikami-sd-server'),
+  );
+  check('AC-2: voice profile builds the sherpa-onnx image', () =>
+    render('compose.yaml', 'voice').includes('Dockerfile.sherpa'),
+  );
+
+  // AC-6: one model store — no weights TRACKED under apps/backend/*/src/.
+  const tracked = run('git', ['ls-files', '../text/src', '../image/src', '../voice/src']).stdout;
+  check(
+    'AC-6: no model weights tracked under apps/backend/{text,image,voice}/src/',
+    () => !/\.(gguf|safetensors|ckpt|bin|pth|pt|onnx)$/im.test(tracked),
+  );
+
+  // AC-7: advanced engines (Ollama/ComfyUI) remain one compose profile away.
+  for (const profile of ['ollama', 'comfyui']) {
+    const svcs = profileServices(profile);
+    if (svcs === profile) {
+      ok(`AC-7: advanced profile '${profile}' starts exactly: ${svcs}`);
+    } else {
+      bad(`AC-7: advanced profile '${profile}' expected [${profile}], got [${svcs}]`);
+    }
+  }
+  const textPkg = readFileSync(join(ROOT, '../text/package.json'), 'utf8');
+  const imagePkg = readFileSync(join(ROOT, '../image/package.json'), 'utf8');
+  check(
+    'AC-7: herdr advanced services wired (dev:ollama / dev:comfyui scripts)',
+    () => textPkg.includes('dev:ollama') && imagePkg.includes('dev:comfyui'),
+  );
+}
+
+// AC-1: every upstream image reference resolves (network-dependent).
+if (process.env.LOCAL_STACK_LIVE === '1') {
+  console.log('== AC-1 manifest resolution ==');
+  const configOut = run('docker', ['compose', '-f', composePath('compose.yaml'), 'config'], {
+    COMPOSE_PROFILES: 'text,image,voice,stt,client,ollama,comfyui',
+  }).stdout;
+  const images = [...configOut.matchAll(/image:\s*"?([^"\s]+)"/g)]
+    .map((m) => m[1])
+    .filter((i) => !i.includes('aikami-sd-server'));
+  for (const image of new Set(images)) {
+    check(
+      `AC-1: ${image} resolves`,
+      () => run('docker', ['manifest', 'inspect', image.replace('@sha256:', '')]).code === 0,
+    );
+  }
+}
+
+// ── C-391 `stack init` (AC-8, AC-10) ──────────────────────────────────
+console.log('== stack init (C-391) ==');
+const INIT_TMP = await mkdtemp(join(tmpdir(), 'aikami-init-'));
+const INIT_ENV = join(INIT_TMP, '.env');
+try {
+  const initRes = spawnSync(
+    'bun',
+    ['src/lib/init.ts', '--yes', '--no-color', '--env-path', INIT_ENV],
+    {
+      cwd: ROOT,
+      encoding: 'utf8',
+      timeout: 60_000,
+    },
+  );
+  check(
+    'AC-8: stack init --yes runs non-interactively (exit 0)',
+    () => initRes.status === 0,
+    (initRes.stderr || '').slice(-300),
+  );
+  const envContent = existsSync(INIT_ENV) ? readFileSync(INIT_ENV, 'utf8') : '';
+  check(
+    'AC-8: generated .env carries COMPOSE_PROFILES and COMPOSE_FILE',
+    () => /^COMPOSE_PROFILES=/m.test(envContent) && /^COMPOSE_FILE=/m.test(envContent),
+  );
+
+  const hasDocker = run('docker', ['--version']).code === 0;
+  if (hasDocker) {
+    const composeLine = envContent.match(/^COMPOSE_FILE=(.+)$/m)?.[1] ?? '';
+    const profilesLine = envContent.match(/^COMPOSE_PROFILES=(.+)$/m)?.[1] ?? '';
+    const renderRes = run('docker', ['compose', '--env-file', INIT_ENV, 'config', '--quiet'], {
+      COMPOSE_FILE: composePath(composeLine),
+      COMPOSE_PROFILES: profilesLine,
+    });
+    check(
+      'AC-10: generated .env renders with docker compose config',
+      () => renderRes.code === 0,
+      (renderRes.stderr || '').slice(-300),
+    );
+  } else {
+    ok('AC-10: docker unavailable — boot render deferred to CI');
+  }
+} finally {
+  await rm(INIT_TMP, { recursive: true, force: true });
+}
+
+// ── AC-9 contract support: the published client image serves runtime mounts
+console.log('== AC-9 client-image contract ==');
+{
+  const nginx = readFileSync(join(ROOT, 'docker/client/nginx.conf'), 'utf8');
+  const clientDockerfile = readFileSync(join(ROOT, 'docker/client/Dockerfile'), 'utf8');
+  check('AC-9: nginx listens on the Aikami client port 5274', () => nginx.includes('listen 5274'));
+  check(
+    'AC-9: nginx serves /config.json with no-store',
+    () => nginx.includes('location = /config.json') && nginx.includes('no-store'),
+  );
+  check('AC-9: docker/client/Dockerfile documents the runtime config mount', () =>
+    clientDockerfile.includes('config.json'),
+  );
+}
+
+// ── Live probes (AC-4) — only when the stack is actually running ─────────
+if (process.env.LOCAL_STACK_LIVE === '1') {
+  console.log('== live probes (AC-4) ==');
+  const get = (url: string): boolean => run('curl', ['-fsS', url]).code === 0;
+  check('AC-4: text /health', () => get('http://127.0.0.1:11434/health'));
+  check('AC-4: image model list', () => get('http://127.0.0.1:8188/sdapi/v1/sd-models'));
+  const tts = run('curl', [
+    '-fsS',
+    '-o',
+    '/tmp/aikami-tts.wav',
+    '-X',
+    'POST',
+    'http://127.0.0.1:8089/v1/audio/speech',
+    '-H',
+    'Content-Type: application/json',
+    '-d',
+    '{"input":"Hello from the Aikami local stack","voice":"af_heart","response_format":"wav"}',
+  ]);
+  check(
+    'AC-4: voice /v1/audio/speech returned audio',
+    () => tts.code === 0 && existsSync('/tmp/aikami-tts.wav'),
+  );
+  check('AC-4: client HTTP 200', () => get('http://127.0.0.1:5274/'));
+
+  // ── C-393 live STT probes ────────────────────────────────────────────
+  console.log('== C-393 live STT probes ==');
+  check('C-393: STT /health', () => get('http://127.0.0.1:8087/health'));
+  check('C-393: STT /v1/capabilities reports the streaming engine', () =>
+    run('curl', ['-fsS', 'http://127.0.0.1:8087/v1/capabilities']).stdout.includes('"moonshine"'),
+  );
+  const sttService = run(
+    'bun',
+    ['test', 'src/lib/stt_service.test.ts'],
+    {
+      STT_URL: 'http://127.0.0.1:8087',
+    },
+    { timeoutMs: 180_000 },
+  );
+  check(
+    'C-393: stt_service.test.ts passed (wire contract)',
+    () => sttService.code === 0,
+    sttService.stdout.slice(-300),
+  );
+
+  // AC-8: audio is never persisted or logged.
+  const audioFind = run('docker', [
+    'compose',
+    '-f',
+    composePath('compose.yaml'),
+    'exec',
+    '-T',
+    'voice',
+    'sh',
+    '-c',
+    'find /tmp /app /root -type f \\( -name "*.wav" -o -name "*.pcm" -o -name "*.raw" \\) 2>/dev/null',
+  ]);
+  check(
+    'AC-8: no audio files written in the voice container',
+    () => audioFind.stdout.trim() === '',
+  );
+  const voiceLogs = run('docker', ['compose', '-f', composePath('compose.yaml'), 'logs', 'voice']);
+  check(
+    'AC-8: no transcript text in voice logs',
+    () => !/hello world|good morning|transcript:/i.test(voiceLogs.stdout),
+  );
+
+  // AC-10: missing model → unhealthy naming the file.
+  const images = run('docker', [
+    'compose',
+    '-f',
+    composePath('compose.yaml'),
+    'config',
+    '--images',
+  ]).stdout;
+  const missingImg = images.match(/[^\n]*voice[^\n]*/i)?.[0] ?? '';
+  if (missingImg) {
+    const cid = spawnSync(
+      'docker',
+      [
+        'run',
+        '-d',
+        '--rm',
+        '--name',
+        'aikami-stt-missing-test',
+        '-v',
+        'aikami-models:/models',
+        '-e',
+        'ENABLE_STT=true',
+        '-e',
+        'STT_STREAM_MODEL=stt/does-not-exist',
+        '-e',
+        'STT_VAD_MODEL=stt/does-not-exist.onnx',
+        '-e',
+        'STT_BIND_ADDRESS=0.0.0.0',
+        missingImg,
+      ],
+      { encoding: 'utf8' },
+    ).stdout.trim();
+    if (cid) {
+      let body = '';
+      for (let i = 0; i < 6; i += 1) {
+        await new Promise((r) => setTimeout(r, 3000));
+        body = run('docker', [
+          'exec',
+          'aikami-stt-missing-test',
+          'curl',
+          '-s',
+          'http://127.0.0.1:8087/health',
+        ]).stdout;
+        if (body.includes('unhealthy')) {
+          break;
+        }
+      }
+      check(
+        'AC-10: missing model reported unhealthy naming the file',
+        () => body.includes('unhealthy') && body.includes('does-not-exist'),
+      );
+      run('docker', ['rm', '-f', 'aikami-stt-missing-test']);
+    } else {
+      skip('AC-10: throwaway voice container could not start (no assertion made)');
+    }
+  } else {
+    skip('AC-10: voice image not found (no assertion made)');
+  }
+}
+
+console.log('');
+if (failCount > 0) {
+  console.error(
+    `❌ local-stack checks failed: ${failCount} failure(s), ${okCount} pass, ${skipCount} skipped`,
+  );
+  process.exit(1);
+}
+console.log(`✅ local-stack checks passed: ${okCount} pass, ${skipCount} skipped, 0 failures`);

--- a/apps/backend/local-stack/src/scripts/emit_config.ts
+++ b/apps/backend/local-stack/src/scripts/emit_config.ts
@@ -1,0 +1,34 @@
+// apps/backend/local-stack/src/scripts/emit_config.ts
+//
+// Emits the runtime engine config.json for the staged client build (C-389).
+// Replaces the old build-time PUBLIC_* endpoint baking: the SPA bundle is now
+// topology-agnostic, and each deployment path writes the config file it needs.
+// Was scripts/emit_config.sh — emits to stdout so `> config.json` works.
+//
+// Defaults follow the C-390 allocation table (development_ports.ts):
+// text 11434, image 8188, voice 8089, stt 8087. Override with
+// LLM_ENDPOINT / IMAGE_ENDPOINT / VOICE_ENDPOINT / STT_ENDPOINT.
+
+import process from 'node:process';
+
+const env = (key: string, fallback: string): string => process.env[key] ?? fallback;
+
+const LLM = env('LLM_ENDPOINT', 'http://localhost:11434/v1');
+const IMAGE = env('IMAGE_ENDPOINT', 'http://localhost:8188');
+const VOICE = env('VOICE_ENDPOINT', 'http://localhost:8089');
+const STT = env('STT_ENDPOINT', 'http://localhost:8087');
+
+const voice = VOICE !== '' ? { mode: 'server', url: VOICE } : { mode: 'browser', url: null };
+const sttUrl = STT !== '' ? STT : null;
+
+const config = {
+  text: { url: LLM, model: 'qwen3-4b-instruct' },
+  image: { url: IMAGE, engine: 'auto' },
+  voice: {
+    tts: { mode: voice.mode, url: voice.url },
+    stt: { url: sttUrl },
+  },
+  models: { originUrl: 'https://huggingface.co' },
+};
+
+process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);

--- a/apps/backend/local-stack/src/scripts/install_test.ts
+++ b/apps/backend/local-stack/src/scripts/install_test.ts
@@ -1,0 +1,369 @@
+// apps/backend/local-stack/src/scripts/install_test.ts
+//
+// Self-test for the POSIX one-command installer (C-418 Feature F AC-6
+// integration hook). Exercises the installer against a LOCAL bundle served
+// over HTTP — no network, no real hardware wizard (a fake `stack-init` writes
+// the .env). When Docker is available it ALSO proves the wizard-written .env
+// is actually read by `docker compose config` in the compose project dir (H2).
+// Run via:  bun moon run local-stack:test-install
+//
+// Was scripts/install.test.sh; the Windows twin logic is replaced by the
+// same harness driving install.ps1 where PowerShell is available.
+//
+// Asserts:
+//   1. install.sh is valid POSIX sh (sh -n).
+//   2. Platform detection runs and accepts the host platform.
+//   3. The installer downloads + checksum-verifies + extracts + runs wizard;
+//      the wizard .env lands in the compose project dir (<dir>/current/.env).
+//   4. The `aikami` control command is installed and resolves the project dir.
+//   5. An existing .env is never overwritten.
+//   6. AIKAMI_SKIP_WIZARD=1 skips the wizard (fetch-only).
+//   7. A tampered tarball (checksum mismatch) is rejected before extraction.
+//   8. The bundle script produces per-platform archives + SHA256SUMS.
+//   9. (docker available) docker compose config in the project dir honors the
+//      wizard-written COMPOSE_PROFILES.
+//  10. Cancelled wizard (exit 0, no .env) — installer exits gracefully without
+//      continuing to startup prompts.
+
+// biome-ignore-all lint/suspicious/noConsole: test harness — console is the interface
+// biome-ignore-all lint/style/useNamingConvention: env-var keys are uppercase by definition
+
+import { execFile, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const ROOT = join(import.meta.dir, '../..');
+
+const log = (message: string): void =>
+  console.log(`\u001b[1;34m[install.test]\u001b[0m ${message}`);
+const fail = (message: string): never => {
+  console.error(`\u001b[1;31m[install.test] FAIL:\u001b[0m ${message}`);
+  process.exit(1);
+};
+const skip = (message: string): void => {
+  console.log(`\u001b[1;33m[install.test] SKIP:\u001b[0m ${message}`);
+};
+
+const execFileAsync = promisify(execFile);
+
+/** Run a program asynchronously so the HTTP server's event loop stays alive. */
+const run = async (
+  cmd: string,
+  args: readonly string[],
+  opts: { cwd?: string; env?: Record<string, string | undefined>; timeoutMs?: number } = {},
+): Promise<{ status: number | null; stdout: string; stderr: string }> => {
+  try {
+    const mergedEnv: NodeJS.ProcessEnv = { ...process.env, ...opts.env };
+    // Keys explicitly set to `undefined` in opts.env must be REMOVED from the
+    // merged env (docker/podman treats an unset COMPOSE_FILE/COMPOSE_PROFILES
+    // as "use defaults from the project dir"). Because we re-spread
+    // `...process.env` first, deleted keys on opts.env would otherwise leak
+    // back in — so honour `undefined` here.
+    for (const key of Object.keys(opts.env ?? {})) {
+      if (opts.env?.[key] === undefined) {
+        delete mergedEnv[key as string];
+      }
+    }
+    const { stdout, stderr } = await execFileAsync(cmd, args as string[], {
+      cwd: opts.cwd ?? ROOT,
+      env: mergedEnv,
+      encoding: 'utf8',
+      timeout: opts.timeoutMs,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { status: 0, stdout: (stdout ?? '') as string, stderr: (stderr ?? '') as string };
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return {
+      status: e.code ?? 1,
+      stdout: (e.stdout ?? '') as string,
+      stderr: (e.stderr ?? '') as string,
+    };
+  }
+};
+
+// ── Platform ────────────────────────────────────────────────────────────
+function resolvePlatform(): 'linux' | 'darwin' | 'windows' {
+  switch (process.platform) {
+    case 'linux':
+      return 'linux';
+    case 'darwin':
+      return 'darwin';
+    case 'win32':
+      return 'windows';
+    default:
+      fail(`unsupported test host ${process.platform}`);
+      return 'linux'; // unreachable (fail exits)
+  }
+}
+const platform = resolvePlatform();
+if (platform === 'windows') {
+  skip('Windows host — this harness drives the POSIX installer; see install.ps1');
+  process.exit(0);
+}
+const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+const PLATFORM = `${platform}-${arch}`;
+const ASSET = `local-stack-test-${PLATFORM}.tar.gz`;
+log(`host platform: ${PLATFORM} (asset ${ASSET})`);
+
+// ── Syntax check ────────────────────────────────────────────────────────
+log('syntax check (sh -n)');
+if ((await run('sh', ['-n', 'install.sh'])).status !== 0) {
+  fail('install.sh is not valid POSIX sh');
+}
+if ((await run('sh', ['-n', 'aikami'])).status !== 0) {
+  fail('aikami control script is not valid POSIX sh');
+}
+
+const TMP = await mkdtemp(join(tmpdir(), 'aikami-install-test-'));
+let httpServer: Server | undefined;
+const cleanup = async (): Promise<void> => {
+  if (httpServer) {
+    await new Promise<void>((resolveClose) => httpServer?.close(() => resolveClose()));
+  }
+  await rm(TMP, { recursive: true, force: true });
+};
+
+try {
+  // ── 3. Build a fake bundle (real-enough compose files for the docker check)
+  const BUNDLE_DIR = join(TMP, 'bundle', `local-stack-test-${PLATFORM}`);
+  mkdirSync(join(BUNDLE_DIR, 'bin'), { recursive: true });
+
+  const fakeWizard = `#!/bin/sh\n# Fake hardware wizard: writes .env the way the real one would.\nenv_path=\nfor arg in "$@"; do\n  if [ "$prev" = "--env-path" ]; then\n    env_path="$arg"\n  fi\n  prev="$arg"\ndone\n[ -n "$env_path" ] || { echo "fake-stack-init: missing --env-path" >&2; exit 2; }\nprintf 'COMPOSE_PROFILES=text,image,voice\\nCOMPOSE_FILE=compose.yaml:compose.cpu.yaml\\n' > "$env_path"\necho "fake-stack-init: wrote $env_path"\n`;
+  writeFileSync(join(BUNDLE_DIR, 'bin', 'stack-init'), fakeWizard);
+  chmodSync(join(BUNDLE_DIR, 'bin', 'stack-init'), 0o755);
+  writeFileSync(join(BUNDLE_DIR, '.env.example'), 'COMPOSE_PROFILES=text,image,voice\n');
+
+  const fakeCompose = `services:\n  text-engine:\n    image: busybox\n    profiles: ["text"]\n`;
+  writeFileSync(join(BUNDLE_DIR, 'compose.yaml'), fakeCompose);
+  writeFileSync(join(BUNDLE_DIR, 'compose.cpu.yaml'), '');
+  const aikami = readFileSync(join(ROOT, 'aikami'), 'utf8');
+  writeFileSync(join(BUNDLE_DIR, 'aikami'), aikami);
+  chmodSync(join(BUNDLE_DIR, 'aikami'), 0o755);
+
+  // ── 4. Create the tarball + SHA256SUMS + serve over HTTP
+  const tarball = join(TMP, ASSET);
+  tarCzf(tarball, TMP, 'bundle', `local-stack-test-${PLATFORM}`);
+  const serveRoot = join(TMP, 'local-stack-test');
+  mkdirSync(serveRoot, { recursive: true });
+  writeFileSync(join(serveRoot, ASSET), readFileSync(tarball));
+  const sums = sha256Of(join(serveRoot, ASSET));
+  writeFileSync(join(serveRoot, 'SHA256SUMS'), sums);
+
+  const PORT = 20000 + Math.floor(Math.random() * 20000);
+  // Serve from $TMP so /local-stack-test/<asset> and /local-stack-test/SHA256SUMS
+  // resolve to the fixture files (mirrors the GitHub releases download path:
+  // <base>/<tag>/<asset>).
+  const serverRoot = TMP;
+  httpServer = createServer((req, res) => {
+    const file = join(serverRoot, decodeURIComponent(req.url ?? '/').replace(/^\//, ''));
+    if (!file.startsWith(serverRoot) || !existsSync(file)) {
+      res.writeHead(404).end();
+      return;
+    }
+    res.writeHead(200).end(readFileSync(file));
+  });
+  await new Promise<void>((resolveListen) => httpServer?.listen(PORT, '127.0.0.1', resolveListen));
+
+  const BASE_URL = `http://127.0.0.1:${PORT}`;
+  const INSTALL_DIR = join(TMP, 'install-root');
+  const env: Record<string, string> = {
+    AIKAMI_INSTALL_BASE_URL: BASE_URL,
+    AIKAMI_STACK_VERSION: 'test',
+    AIKAMI_STACK_DIR: INSTALL_DIR,
+    AIKAMI_YES: '1',
+    AIKAMI_NO_PATH: '1',
+  };
+
+  // ── 5. First install — wizard runs, .env written INTO the compose project dir
+  log('first install (wizard → .env in project dir)');
+  const first = await run('sh', ['install.sh'], { env });
+  if (first.status !== 0) {
+    fail(`installer exited non-zero on first run: ${first.stderr}`);
+  }
+  if (!first.stdout.includes('checksum OK')) {
+    fail('installer did not verify the checksum');
+  }
+  if (!first.stdout.includes('step 6/6')) {
+    fail('installer did not complete all steps');
+  }
+  const PROJECT_DIR = join(INSTALL_DIR, 'current');
+  if (!existsSync(join(PROJECT_DIR, '.env'))) {
+    fail(`wizard .env was not written into the compose project dir (${join(PROJECT_DIR, '.env')})`);
+  }
+  if (
+    !readFileSync(join(PROJECT_DIR, '.env'), 'utf8').includes('COMPOSE_PROFILES=text,image,voice')
+  ) {
+    fail('.env content wrong');
+  }
+  if (!existsSync(join(PROJECT_DIR, 'VERSION'))) {
+    fail('VERSION marker missing from the project dir');
+  }
+
+  // ── 6. The `aikami` control command
+  log('aikami control command');
+  if (!existsSync(join(INSTALL_DIR, 'aikami'))) {
+    fail(`aikami control command was not installed at ${join(INSTALL_DIR, 'aikami')}`);
+  }
+  const dirRes = await run(join(INSTALL_DIR, 'aikami'), ['dir']);
+  if (dirRes.status !== 0 || dirRes.stdout.trim() !== PROJECT_DIR) {
+    fail(`aikami dir resolved '${dirRes.stdout.trim()}', expected '${PROJECT_DIR}'`);
+  }
+  if (!(await run(join(INSTALL_DIR, 'aikami'), ['version'])).stdout.includes('test')) {
+    fail('aikami version did not report the installed version');
+  }
+
+  // ── 7. docker compose actually reads the wizard-written .env (H2)
+  log('compose reads wizard .env');
+  if (spawnSync('docker', ['--version']).status === 0) {
+    // The point of this check is to prove `docker compose` honors the
+    // wizard-written .env's COMPOSE_PROFILES/COMPOSE_FILE. That only works if
+    // ambient COMPOSE_* vars (which take precedence over the project .env in
+    // docker/podman compose) are cleared first — otherwise a developer shell
+    // (e.g. the emulator env) leaks its own COMPOSE_FILE and this check reads
+    // the wrong topology.
+    const composeEnv: Record<string, string | undefined> = { ...process.env };
+    // Set to `undefined` (not `delete`) so run() honours them and drops the
+    // keys from the merged env — see run()'s env handling above.
+    composeEnv.COMPOSE_FILE = undefined;
+    composeEnv.COMPOSE_PROFILES = undefined;
+    const dc = await run('docker', ['compose', 'config'], {
+      cwd: PROJECT_DIR,
+      env: composeEnv,
+    });
+    if (!dc.stdout.includes('text-engine')) {
+      fail(
+        `docker compose config did not honor COMPOSE_PROFILES from the wizard .env: ${dc.stderr}`,
+      );
+    }
+    log('  docker compose config honored COMPOSE_PROFILES=text from .env');
+  } else {
+    skip('docker not installed — compose-reads-.env check skipped (CI runs it)');
+  }
+
+  // ── 8. Second install — .env must NOT be overwritten
+  log('second install (.env protection)');
+  writeFileSync(join(PROJECT_DIR, '.env'), 'COMPOSE_PROFILES=my-custom-value\n');
+  if ((await run('sh', ['install.sh'], { env })).status !== 0) {
+    fail('installer exited non-zero on second run');
+  }
+  if (
+    !readFileSync(join(PROJECT_DIR, '.env'), 'utf8').includes('COMPOSE_PROFILES=my-custom-value')
+  ) {
+    fail('existing .env was overwritten');
+  }
+
+  // ── 9. Skip-wizard mode
+  log('skip-wizard mode');
+  const INSTALL_DIR2 = join(TMP, 'install-root2');
+  const skipEnv = { ...env, AIKAMI_STACK_DIR: INSTALL_DIR2, AIKAMI_SKIP_WIZARD: '1' };
+  if ((await run('sh', ['install.sh'], { env: skipEnv })).status !== 0) {
+    fail('installer exited non-zero with AIKAMI_SKIP_WIZARD=1');
+  }
+  if (existsSync(join(INSTALL_DIR2, 'current', '.env'))) {
+    fail('.env should not be written in skip-wizard mode');
+  }
+
+  // ── 10. Tampered tarball must be rejected before extraction (M2)
+  log('checksum rejection (tampered tarball)');
+  const INSTALL_DIR3 = join(TMP, 'install-root3');
+  const tamperEnv = { ...env, AIKAMI_STACK_DIR: INSTALL_DIR3 };
+  writeFileSync(join(serveRoot, ASSET), 'COMPOSE_PROFILES=text,image,voice\n');
+  if ((await run('sh', ['install.sh'], { env: tamperEnv })).status === 0) {
+    fail('installer accepted a tampered tarball (checksum mismatch must abort)');
+  }
+  if (existsSync(join(INSTALL_DIR3, 'current'))) {
+    fail('tampered tarball was extracted before checksum verification');
+  }
+  log('  tampered tarball rejected, nothing extracted');
+  // restore the good tarball
+  tarCzf(tarball, TMP, 'bundle', `local-stack-test-${PLATFORM}`);
+  writeFileSync(join(serveRoot, ASSET), readFileSync(tarball));
+  writeFileSync(join(serveRoot, 'SHA256SUMS'), sha256Of(join(serveRoot, ASSET)));
+
+  // ── 11. Bundle script layout + SHA256SUMS (M2/H3 naming)
+  log('bundle script layout');
+  const bundleRes = await run('bun', ['src/scripts/bundle.ts'], {
+    env: { AIKAMI_BUNDLE_DIR: join(TMP, 'dist'), AIKAMI_STACK_VERSION: 'test' },
+  });
+  if (bundleRes.status !== 0) {
+    fail(`bundle.ts failed: ${bundleRes.stderr}`);
+  }
+  const BUNDLED_ASSET = join(TMP, 'dist', `local-stack-test-${PLATFORM}.tar.gz`);
+  if (!existsSync(BUNDLED_ASSET)) {
+    fail(`bundle tarball missing (${BUNDLED_ASSET})`);
+  }
+  if (!existsSync(join(TMP, 'dist', 'SHA256SUMS'))) {
+    fail('SHA256SUMS missing');
+  }
+  if (
+    !readFileSync(join(TMP, 'dist', 'SHA256SUMS'), 'utf8').includes(
+      `local-stack-test-${PLATFORM}.tar.gz`,
+    )
+  ) {
+    fail('SHA256SUMS does not reference the tarball');
+  }
+  for (const entry of ['bin/stack-init', 'compose.yaml', 'install.sh', 'aikami', 'VERSION']) {
+    if (!tarList(BUNDLED_ASSET).includes(`local-stack-test-${PLATFORM}/${entry}`)) {
+      fail(`bundle tarball missing ${entry}`);
+    }
+  }
+
+  // ── 12. Cancelled wizard — installer exits gracefully
+  log('cancelled wizard (exit 0, no .env)');
+  const INSTALL_DIR4 = join(TMP, 'install-root4');
+  const cancelEnv = { ...env, AIKAMI_STACK_DIR: INSTALL_DIR4 };
+  const cancelWizard = `#!/bin/sh\n# Simulates a successful cancellation: exit 0, no .env created.\necho "fake-stack-init: user cancelled (simulated)"\nexit 0\n`;
+  writeFileSync(join(BUNDLE_DIR, 'bin', 'stack-init'), cancelWizard);
+  chmodSync(join(BUNDLE_DIR, 'bin', 'stack-init'), 0o755);
+  tarCzf(tarball, TMP, 'bundle', `local-stack-test-${PLATFORM}`);
+  writeFileSync(join(serveRoot, ASSET), readFileSync(tarball));
+  writeFileSync(join(serveRoot, 'SHA256SUMS'), sha256Of(join(serveRoot, ASSET)));
+  const cancelRes = await run('sh', ['install.sh'], { env: cancelEnv });
+  if (cancelRes.status !== 0) {
+    fail('installer exited non-zero on cancelled wizard');
+  }
+  if (!cancelRes.stdout.includes('Setup cancelled')) {
+    fail('installer did not print cancellation guidance when .env is missing after wizard');
+  }
+  if (existsSync(join(INSTALL_DIR4, 'current', '.env'))) {
+    fail('.env should not exist when wizard exits successfully with no file created');
+  }
+  if (cancelRes.stdout.includes('Start the stack now?')) {
+    fail('installer should not prompt to start the stack after wizard cancellation');
+  }
+  log('  cancelled wizard detected, installer exited gracefully without startup prompts');
+
+  log('all installer checks passed');
+} finally {
+  await cleanup();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function sha256Of(file: string): string {
+  const buf = readFileSync(file);
+  return `${createHash('sha256').update(buf).digest('hex')}  ${join(file).split('/').pop()}`;
+}
+
+function tarCzf(outFile: string, cwd: string, topDir: string, dirName: string): void {
+  const res = spawnSync('tar', ['-czf', outFile, '-C', join(cwd, topDir), dirName], {
+    cwd,
+    stdio: 'ignore',
+  });
+  if (res.status !== 0) {
+    throw new Error(`tar failed: ${res.stderr}`);
+  }
+}
+
+function tarList(tarball: string): string[] {
+  const res = spawnSync('tar', ['-tzf', tarball], { encoding: 'utf8' });
+  return (res.stdout ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}

--- a/apps/backend/local-stack/src/scripts/native/run_llm.ts
+++ b/apps/backend/local-stack/src/scripts/native/run_llm.ts
@@ -1,0 +1,95 @@
+// apps/backend/local-stack/src/scripts/native/run_llm.ts
+//
+// Native host launcher for the local LLM (OpenAI-compatible) without Docker
+// (was bin/run-native-llm.sh).
+//
+// Tries in order:
+//   1. shimmy   — llama.cpp wrapper with an OpenAI-compatible API
+//                (container-only distribution; see the compose stack instead)
+//   2. llama-server — llama.cpp's native server (OpenAI-compatible /v1 API)
+//
+// First run downloads a default GGUF model (Qwen3 0.6B instruct) into
+// models/llm/. Override with LLM_MODEL_URL / LLM_MODEL_FILE / LLM_PORT /
+// LLM_HOST.
+//
+// biome-ignore-all lint/suspicious/noConsole: CLI launcher — the console is the interface
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, rename } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+const MODEL_DIR = join(process.cwd(), 'models', 'llm');
+// Port from packages/shared/constants development_ports.ts (C-390 AC-11).
+const PORT = process.env.LLM_PORT ?? '11434';
+// Bind to loopback by default; set LLM_HOST=0.0.0.0 to expose on the network.
+const HOST = process.env.LLM_HOST ?? '127.0.0.1';
+
+const LLM_MODEL_URL =
+  process.env.LLM_MODEL_URL ??
+  'https://huggingface.co/Qwen/Qwen3-0.6B-Instruct-GGUF/resolve/main/qwen3-0.6b-instruct-q4_k_m.gguf';
+const LLM_MODEL_FILE = process.env.LLM_MODEL_FILE ?? 'qwen3-0.6b-instruct-q4_k_m.gguf';
+const MODEL_PATH = join(MODEL_DIR, LLM_MODEL_FILE);
+
+const commandExists = (name: string): boolean => {
+  try {
+    Bun.which(name);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+async function download(url: string, dest: string): Promise<void> {
+  await mkdir(dirname(dest), { recursive: true });
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`download failed: ${res.status} ${res.statusText}`);
+  }
+  await Bun.write(`${dest}.tmp`, await res.arrayBuffer());
+  await rename(`${dest}.tmp`, dest);
+}
+
+// Validate that a server binary exists BEFORE downloading any model.
+let engine: 'shimmy' | 'llama-server' | undefined;
+if (commandExists('shimmy')) {
+  engine = 'shimmy';
+} else if (commandExists('llama-server')) {
+  engine = 'llama-server';
+}
+
+if (engine === undefined) {
+  console.error("❌ Neither 'shimmy' nor 'llama-server' is installed on the host.");
+  console.error('   - llama.cpp: https://github.com/ggml-org/llama.cpp (build llama-server)');
+  console.error('   - shimmy (container): ghcr.io/michael-a-kuykendall/shimmy:latest');
+  process.exit(1);
+}
+
+if (!existsSync(MODEL_PATH)) {
+  console.log(`LLM GGUF model missing in ${MODEL_DIR}. Downloading...`);
+  // Download to a temp file and move atomically so interrupted downloads
+  // never leave a truncated model that later starts would trust.
+  await download(LLM_MODEL_URL, MODEL_PATH);
+}
+
+if (engine === 'shimmy') {
+  console.log(`Starting shimmy (OpenAI-compatible) on ${HOST}:${PORT}...`);
+  const child = spawn('shimmy', ['serve', '--model', MODEL_PATH, '--port', PORT, '--host', HOST], {
+    stdio: 'inherit',
+  });
+  child.on('error', (error) => {
+    console.error(`shimmy failed to start: ${error.message}`);
+    process.exit(1);
+  });
+  child.on('exit', (code) => process.exit(code ?? 0));
+} else {
+  console.log(`Starting llama-server (OpenAI-compatible) on ${HOST}:${PORT}...`);
+  const child = spawn('llama-server', ['-m', MODEL_PATH, '--port', PORT, '--host', HOST], {
+    stdio: 'inherit',
+  });
+  child.on('error', (error) => {
+    console.error(`llama-server failed to start: ${error.message}`);
+    process.exit(1);
+  });
+  child.on('exit', (code) => process.exit(code ?? 0));
+}

--- a/apps/backend/local-stack/src/scripts/native/run_stt.ts
+++ b/apps/backend/local-stack/src/scripts/native/run_stt.ts
@@ -1,0 +1,150 @@
+// apps/backend/local-stack/src/scripts/native/run_stt.ts
+//
+// Native host launcher for local speech-to-text (STT) without Docker — the
+// macOS path (Docker Desktop has no Metal passthrough; this is a
+// latency-sensitive service, C-393 AC-12). Was bin/run-native-stt.sh.
+//
+// Starts the SAME service the container runs, on the same port and protocol:
+//   - python3 docker/voice/stt_server.py on $STT_PORT (8087) — the C-393
+//     streaming websocket (WS /v1/stream, Moonshine + Silero VAD), plus
+//     GET /v1/capabilities, GET /health, and the OpenAI-compatible batch
+//     proxy.
+//   - whisper-server (whisper.cpp) on the internal WHISPER_PORT when the
+//     binary is present — batch transcription (POST /v1/audio/transcriptions).
+//
+// Models live in ./models/stt and are provisioned by the model fetcher — this
+// script never downloads them; it verifies the files exist and exits with a
+// fetch hint when a model is missing.
+//
+// biome-ignore-all lint/suspicious/noConsole: CLI launcher — the console is the interface
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { unlink } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '../../../');
+const MODELS_DIR = joinCwd('models');
+
+// Ports from packages/shared/constants development_ports.ts (C-390 AC-11).
+const PORT = process.env.STT_PORT ?? '8087';
+// Export so stt_server.py's batch proxy reads the SAME internal port the
+// whisper-server was launched on (it defaults to 8091 on its own).
+const WHISPER_PORT = process.env.WHISPER_PORT ?? '8091';
+const BIND = process.env.STT_BIND_ADDRESS ?? '127.0.0.1';
+
+// C-393 model selection (manifest targetPaths, mirror the container defaults).
+const STT_STREAM_MODEL = process.env.STT_STREAM_MODEL ?? 'stt/sherpa-onnx-moonshine-tiny-en-int8';
+const STT_BATCH_MODEL = process.env.STT_BATCH_MODEL ?? 'stt/whisper-tiny/ggml-tiny.bin';
+const STT_VAD_MODEL = process.env.STT_VAD_MODEL ?? 'stt/silero_vad.onnx';
+
+const STREAM_DIR = join(MODELS_DIR, STT_STREAM_MODEL);
+const BATCH_FILE = join(MODELS_DIR, STT_BATCH_MODEL);
+const VAD_FILE = join(MODELS_DIR, STT_VAD_MODEL);
+
+// Mirror the original script's model-dir discovery. The launcher can be
+// invoked from the stack root; keep relative to the working directory.
+function joinCwd(...parts: string[]): string {
+  return resolve(process.cwd(), ...parts);
+}
+
+// Verify the streaming model files exist BEFORE fetching anything the server
+// cannot run — the service must not claim readiness without its model.
+if (!existsSync(STREAM_DIR) || !existsSync(join(STREAM_DIR, 'encode.int8.onnx'))) {
+  console.error(`❌ Moonshine STT model missing in ${MODELS_DIR}/${STT_STREAM_MODEL}.`);
+  console.error(
+    '   Run the model fetcher:  bun src/lib/fetch_models.ts --entry stt-moonshine-tiny-en-int8 --entry stt-whisper-tiny',
+  );
+  console.error('   (or download the tarball from the k2-fsa sherpa-onnx releases and');
+  console.error(`   extract it to ${STREAM_DIR})`);
+  process.exit(1);
+}
+if (!existsSync(VAD_FILE)) {
+  console.error(`❌ Silero VAD model missing at ${VAD_FILE} — fetch it with the model fetcher.`);
+  process.exit(1);
+}
+
+// Export the model paths for stt_server.py (it resolves defaults itself, but
+// the explicit exports keep this script the single source of truth).
+process.env.MODELS_DIR = MODELS_DIR;
+process.env.STT_STREAM_MODEL = STT_STREAM_MODEL;
+process.env.STT_BATCH_MODEL = STT_BATCH_MODEL;
+process.env.STT_VAD_MODEL = STT_VAD_MODEL;
+process.env.STT_BIND_ADDRESS = BIND;
+
+// Batch engine (optional on the host): whisper-server must be installed
+// separately; without it the service still streams and reports batch
+// unavailable via /v1/capabilities.
+let whisperPid: number | undefined;
+let whisperLog: string | undefined;
+const hasWhisper = Bun.which('whisper-server') !== null;
+
+if (hasWhisper) {
+  if (!existsSync(BATCH_FILE)) {
+    console.warn(`⚠ whisper batch model missing at ${BATCH_FILE} — batch will be unavailable`);
+    console.warn('  (fetch it with: bun src/lib/fetch_models.ts --entry stt-whisper-tiny)');
+  } else {
+    console.log(`Starting whisper.cpp batch server on 127.0.0.1:${WHISPER_PORT} ...`);
+    whisperLog = resolve(process.env.TMPDIR ?? '/tmp', `whisper-server.${Date.now()}.log`);
+    const whisper = spawn(
+      'whisper-server',
+      [
+        '--host',
+        '127.0.0.1',
+        '--port',
+        WHISPER_PORT,
+        '--model',
+        BATCH_FILE,
+        '--threads',
+        process.env.STT_WHISPER_THREADS ?? '4',
+        '--no-gpu',
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    whisperPid = whisper.pid;
+    // Stream the whisper log so failures are visible.
+    whisper.stdout?.on('data', (d) => process.stdout.write(d));
+    whisper.stderr?.on('data', (d) => process.stderr.write(d));
+  }
+} else {
+  console.warn(
+    '⚠ whisper-server not found on the host — batch endpoint unavailable (streaming still works)',
+  );
+}
+
+// Keep the background whisper-server alive while stt_server.py runs and
+// clean it up when the script exits.
+const cleanup = (): void => {
+  if (whisperPid !== undefined) {
+    try {
+      process.kill(whisperPid, 'SIGTERM');
+    } catch {
+      // already gone
+    }
+  }
+  if (whisperLog) {
+    unlink(whisperLog).catch(() => {});
+  }
+};
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(0);
+});
+
+console.log(`Starting native STT server on ${BIND}:${PORT} ...`);
+const sttServer = join(ROOT, 'docker', 'voice', 'stt_server.py');
+const child = spawn('python3', [sttServer, PORT], { stdio: 'inherit' });
+child.on('error', (error) => {
+  console.error(`python3 failed to start: ${error.message}`);
+  cleanup();
+  process.exit(1);
+});
+child.on('exit', (code) => {
+  cleanup();
+  process.exit(code ?? 0);
+});

--- a/apps/backend/local-stack/src/scripts/native/run_tts.ts
+++ b/apps/backend/local-stack/src/scripts/native/run_tts.ts
@@ -1,0 +1,92 @@
+// apps/backend/local-stack/src/scripts/native/run_tts.ts
+//
+// Native host launcher for local text-to-speech (TTS) without Docker
+// (was bin/run-native-tts.sh).
+//
+// Runs the sherpa-onnx Kokoro TTS behind an OpenAI-compatible
+// /v1/audio/speech HTTP endpoint (the API the Aikami client calls).
+//
+// biome-ignore-all lint/suspicious/noConsole: CLI launcher — the console is the interface
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, rename, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '../../../');
+const MODEL_DIR = joinCwd('models', 'tts');
+const KOKORO_DIR = join(MODEL_DIR, 'kokoro-multi-lang-v1_0');
+const KOKORO_TARBALL_URL =
+  'https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/kokoro-multi-lang-v1_0.tar.bz2';
+// Port from packages/shared/constants development_ports.ts (C-390 AC-11).
+const PORT = process.env.TTS_PORT ?? '8089';
+// tts_server.py lives in the sibling docker/voice tree
+const TTS_SERVER = join(ROOT, 'docker', 'voice', 'tts_server.py');
+
+function joinCwd(...parts: string[]): string {
+  return resolve(process.cwd(), ...parts);
+}
+
+function commandExists(name: string): boolean {
+  try {
+    Bun.which(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Verify Python + sherpa-onnx are available BEFORE downloading any model.
+if (!commandExists('python3')) {
+  console.error('❌ python3 is not installed on the host.');
+  process.exit(1);
+}
+
+async function pythonHasSherpaOnnx(): Promise<boolean> {
+  try {
+    const res = Bun.spawnSync(['python3', '-c', 'import sherpa_onnx'], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+    return res.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+if (!(await pythonHasSherpaOnnx())) {
+  console.error('❌ sherpa-onnx is not installed in the active Python environment.');
+  console.error('   Install it with:  pip install sherpa-onnx');
+  process.exit(1);
+}
+
+// Only skip the download when the complete model directory exists (model.onnx,
+// voices.bin, tokens.txt, espeak-ng-data). Fetch to a temp location and move
+// atomically so interrupted downloads never leave a partial model dir.
+if (!existsSync(KOKORO_DIR)) {
+  console.log(`Kokoro TTS model missing in ${MODEL_DIR}. Downloading...`);
+  await mkdir(MODEL_DIR, { recursive: true });
+  const tarball = join(MODEL_DIR, 'kokoro.tar.bz2');
+  const res = await fetch(KOKORO_TARBALL_URL);
+  if (!res.ok || !res.body) {
+    console.error(`❌ Kokoro model download failed: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+  await Bun.write(tarball, await res.arrayBuffer());
+  await rm(join(MODEL_DIR, '.kokoro-tmp'), { recursive: true, force: true });
+  await mkdir(join(MODEL_DIR, '.kokoro-tmp'), { recursive: true });
+  Bun.spawnSync(['tar', 'xjf', tarball, '-C', join(MODEL_DIR, '.kokoro-tmp')], {
+    stdio: ['inherit', 'inherit', 'inherit'],
+  });
+  await rename(join(MODEL_DIR, '.kokoro-tmp', 'kokoro-multi-lang-v1_0'), KOKORO_DIR);
+  await rm(join(MODEL_DIR, '.kokoro-tmp'), { recursive: true, force: true });
+  await rm(tarball, { force: true });
+}
+
+console.log(`Starting native sherpa-onnx Kokoro TTS server on port ${PORT}...`);
+const child = spawn('python3', [TTS_SERVER, PORT], { stdio: 'inherit' });
+child.on('error', (error) => {
+  console.error(`python3 failed to start: ${error.message}`);
+  process.exit(1);
+});
+child.on('exit', (code) => process.exit(code ?? 0));

--- a/apps/frontend/client/.env.example
+++ b/apps/frontend/client/.env.example
@@ -14,6 +14,11 @@ PUBLIC_LOG_LEVEL=
 PUBLIC_LOG_PERSIST_LEVEL=
 PUBLIC_PARSE_LEVEL=safe
 PUBLIC_SITE_URL=
+# Base URL for the vendored onnxruntime-web WASM served from the R2
+# distribution plane (e.g. https://dl.bearlysleeping.com/models/ort/1.27.0/).
+# onnxruntime appends ort-wasm-simd-threaded.jsep.wasm. Leave empty to serve
+# from the app's own /ort/ static dir (C-389). TTS is installed on demand.
+PUBLIC_ORT_WASM_URL=
 # client is static Firebase Hosting with no server of its own — browser logs
 # forward cross-origin to hub's /api/internal_logging in staging/production.
 # Leave empty in emulator/dev (uses the relative-path dev sink instead).

--- a/apps/frontend/client/src/lib/services/audio/tts_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/audio/tts_service.svelte.ts
@@ -563,6 +563,8 @@ class TtsService extends BaseFrontendClass<TtsOptions> implements TtsServiceInte
       // the app's own /ort/ static dir when unset (C-389). TTS is installed on
       // demand, so the wasm is fetched at init like the model itself.
       const configuredWasm = import.meta.env.PUBLIC_ORT_WASM_URL as string | undefined;
+      // Normalize: trim whitespace, treat empty as missing
+      const normalizedWasm = configuredWasm?.trim() || undefined;
       let baseHref: string | undefined;
       if (typeof document !== 'undefined') {
         baseHref = document.baseURI;
@@ -571,8 +573,12 @@ class TtsService extends BaseFrontendClass<TtsOptions> implements TtsServiceInte
       } else {
         baseHref = undefined;
       }
-      const wasmPath =
-        configuredWasm ?? (baseHref ? new URL('/ort/', baseHref).href : '/ort/');
+      const fallback = baseHref ? new URL('/ort/', baseHref).href : '/ort/';
+      // Ensure exactly one trailing slash
+      let wasmPath = normalizedWasm ?? fallback;
+      if (!wasmPath.endsWith('/')) {
+        wasmPath += '/';
+      }
       this._worker.postMessage({
         action: 'initialize',
         wasmPath,

--- a/apps/frontend/client/src/lib/services/audio/tts_service.svelte.ts
+++ b/apps/frontend/client/src/lib/services/audio/tts_service.svelte.ts
@@ -557,7 +557,12 @@ class TtsService extends BaseFrontendClass<TtsOptions> implements TtsServiceInte
         this.error('kokoro:worker-onerror', { message: this.errorMessage });
       };
 
-      // Vendored ORT WASM lives in the app's static assets (C-389).
+      // ORT WASM is served from the R2 distribution plane when configured
+      // (PUBLIC_ORT_WASM_URL, e.g. https://dl.bearlysleeping.com/models/ort/1.27.0/)
+      // — onnxruntime appends ort-wasm-simd-threaded.jsep.wasm. Falls back to
+      // the app's own /ort/ static dir when unset (C-389). TTS is installed on
+      // demand, so the wasm is fetched at init like the model itself.
+      const configuredWasm = import.meta.env.PUBLIC_ORT_WASM_URL as string | undefined;
       let baseHref: string | undefined;
       if (typeof document !== 'undefined') {
         baseHref = document.baseURI;
@@ -566,7 +571,8 @@ class TtsService extends BaseFrontendClass<TtsOptions> implements TtsServiceInte
       } else {
         baseHref = undefined;
       }
-      const wasmPath = baseHref ? new URL('/ort/', baseHref).href : '/ort/';
+      const wasmPath =
+        configuredWasm ?? (baseHref ? new URL('/ort/', baseHref).href : '/ort/');
       this._worker.postMessage({
         action: 'initialize',
         wasmPath,

--- a/docs/architecture/object-storage-layout.md
+++ b/docs/architecture/object-storage-layout.md
@@ -1,0 +1,497 @@
+# Object Storage Layout — Buckets, Keys, and Enforcement
+
+**Status:** draft for review
+**Created:** 2026-08-20
+**Extends:** `data-layer-target-architecture.md` (D-13, D-14, I-3, I-7)
+**Implements today:** C-395 (catalog origin), C-396 (browse)
+**Blocks:** C-397 (on-demand assets), C-398 (submissions)
+
+---
+
+## 0. What already exists
+
+Verified in-repo 2026-08-20. Do not rebuild any of this.
+
+| Thing | Where | State |
+|---|---|---|
+| Bucket `aikami-catalog` (WEUR, Standard) | Cloudflare | live |
+| Custom domain `assets.bearlysleeping.com` | Cloudflare | live |
+| `assets/<sha[0:2]>/<sha><ext>` | `scripts/src/lib/catalog/content_address.ts` | live |
+| `thumbnails/<sha[0:2]>/<sha>.webp` | `scripts/src/lib/catalog/thumbnail_generation.ts` | live |
+| `index/v1/catalog.json`, `index/v1/<category>.json` | `scripts/src/lib/catalog/index_generation.ts` | live |
+| Strict TypeBox index schemas | `packages/shared/schemas/src/lib/catalog/catalog_index.ts` | live |
+| `CLOUD_FLARE_CATALOG_BUCKET_*` / `…_DIST_BUCKET_*` / `…_UPLOADS_BUCKET_*` write credentials | `scripts/.env.*`, GSM | live |
+| Read-side validation + TTL cache | `apps/frontend/hub/src/lib/server/catalog/catalog_index.ts` | live |
+
+What is **not** yet placed anywhere: community submissions, first-party
+content packs, local-stack model checkpoints, and user database backups.
+Those are what this document adds.
+
+---
+
+## 1. The organizing principle
+
+**Split buckets by access posture, not by content type.**
+
+The load-bearing fact is a Cloudflare limitation, not a preference: **an R2 API
+token scopes to a bucket, not to a prefix.** There is no R2 equivalent of an
+AWS IAM policy with a resource ARN like `arn:aws:s3:::bucket/uploads/*`. A
+token that can write `uploads/` in `aikami-catalog` can also write
+`index/v1/catalog.json` in `aikami-catalog`.
+
+That single fact decides the layout. The hub must be able to hand a member a
+presigned upload URL (C-398), which means the hub holds a write credential. If
+uploads were a prefix of the catalog bucket, the hub's credential would be a
+credential to overwrite the published catalog index — a direct violation of
+I-7. Separate buckets make it a scoping decision instead of a code-review
+promise.
+
+> **Verify before provisioning:** confirm in the R2 dashboard that token
+> scoping is still bucket-level only. If Cloudflare has added prefix
+> conditions since, the uploads bucket could collapse into a prefix — but the
+> other three reasons below (metrics, lifecycle, licence isolation) still
+> favour separation.
+
+Secondary benefits that fall out of the same split:
+
+- **Metrics.** Cloudflare reports storage and ops per bucket. Mixing a 12,713-object catalog with multi-GB model weights makes both bills unreadable.
+- **Lifecycle.** Catalog objects are permanent. Staged uploads expire in days. Model mirrors get pruned when a tier is retired. One lifecycle rule per bucket beats prefix-conditional rules.
+- **Licence isolation.** Some mirrored model weights carry restrictive terms (`circlestone-labs-non-commercial-license`, `CreativeML OpenRAIL-M`). Pulling one must never risk touching the catalog.
+
+---
+
+## 2. The four planes
+
+| Plane | Store | Public? | Written by | Contains |
+|---|---|---|---|---|
+| **Catalog** | R2 `aikami-catalog` | yes, `assets.bearlysleeping.com` | publish pipeline, moderation job | first-party + approved community asset bytes, thumbnails, indexes |
+| **Intake** | R2 `aikami-uploads` | **no** | hub (presigned PUT only) | unreviewed member submissions, quarantined |
+| **Distribution** | R2 `aikami-dist` | yes, `dl.bearlysleeping.com` | mirror job | permissively-licensed model checkpoints, optional release mirror |
+| **Player-owned** | Firebase Storage | no, `isOwner(uid)` | the client, directly | encrypted database backups, save blobs, avatars |
+
+One sentence you can hold in your head:
+
+> **Public content bytes go to R2. Player-owned bytes go to Firebase Storage.
+> Nothing unreviewed is ever in a public bucket.**
+
+That is a smaller rule than a single bucket carrying two security models would
+need, which answers the "won't multiple buckets be confusing?" worry — the
+split reduces the number of rules, it does not add one.
+
+---
+
+## 3. `aikami-catalog` — the public plane
+
+```
+r2://aikami-catalog/
+
+  assets/<sha256[0:2]>/<sha256><ext>            immutable · 1y
+  thumbnails/<sha256[0:2]>/<sha256>.webp        immutable · 1y
+
+  index/v1/catalog.json                         mutable   · 60s   root
+  index/v1/<category>.json                      mutable   · 60s   first-party shard
+  index/v1/lpc__<fragment>.json                 mutable   · 60s   split shard
+
+  index/v1/packs.json                           mutable   · 60s   pack registry
+  index/v1/packs/<owner>/<slug>/latest.json     mutable   · 60s   version pointer
+  index/v1/packs/<owner>/<slug>/<semver>.json   immutable · 1y    version manifest
+```
+
+Everything above `index/` already exists. The `packs/` subtree is the addition.
+
+### 3.1 Community assets do not get their own prefix
+
+A community asset is bytes plus provenance. The bytes are indistinguishable
+from first-party bytes and belong in the same `assets/` namespace. Giving them
+`community/assets/…` would fork the resolver, duplicate the cache
+configuration, and — worst — break deduplication: two members uploading the
+same LPC recolour must resolve to one object, and content addressing gives
+that for free only if they share a namespace.
+
+**What differs between first-party and community content is the index, not the
+storage.** Ownership, moderation state, ratings and install counts live in
+Postgres (D-14). The bucket stays a dumb content-addressed store.
+
+### 3.2 Packs are the unit of community content
+
+The `PackSummary` / `PackVersion` schemas from C-394 already exist. Make first-party
+content a pack too, published through the same pipeline: `emberwatch` and
+`whispering-caves` (today loose JSON under `static/content-packs/`) become
+`aikami/emberwatch@1.0.0` and `aikami/whispering-caves@1.0.0`. One mechanism,
+no special case.
+
+Two details worth getting right:
+
+- **Owner-scoped slugs.** `<owner>/<slug>` prevents two members claiming `dark-forest`. First-party packs use the reserved owner `aikami`.
+- **Versions are immutable, the pointer is not.** `<semver>.json` may never be republished, so it earns a 1-year cache. Only `latest.json` and `packs.json` are short-cached. This keeps the per-request cost of browsing a pack at one 60s-cached pointer fetch, not a full document refetch.
+
+### 3.3 The invariant this bucket must hold
+
+> **Nothing enters `aikami-catalog` that is not intended to be world-readable
+> forever.**
+
+Every object here is reachable at a stable URL with no credential. sha256 is
+unguessable, so an unindexed object is not *discoverable* — but "obscure" is
+not "private", and the hash of anything indexed is published by definition.
+This is why intake is a different bucket rather than an unindexed prefix.
+
+---
+
+## 4. `aikami-uploads` — the intake plane
+
+```
+r2://aikami-uploads/                            NO custom domain · NO public access
+
+  staging/<accountId>/<submissionId>/<filename>     expire after 14d
+  quarantine/<sha256>                               objects held pending review
+```
+
+Flow for C-398:
+
+1. Member authenticates to the hub. Hub checks quota and rate limit against Postgres.
+2. Hub mints a **presigned PUT** scoped to one key in `aikami-uploads`, with a content-length range and content-type condition. Bytes never traverse the hub — I-7 holds.
+3. Client PUTs directly to R2. Hub records the submission row.
+4. Validation job hashes, scans, and checks the takedown denylist.
+5. On approval, a **moderation job** (not the hub) issues a server-side `CopyObject` into `aikami-catalog` under `assets/<sha[0:2]>/<sha><ext>`, then regenerates the pack manifest. No bytes move across the network.
+6. A lifecycle rule expires `staging/` after 14 days regardless of outcome.
+
+Credential scoping that this makes possible:
+
+| Holder | Token scope | Permission |
+|---|---|---|
+| Hub (Cloud Run) | `aikami-uploads` only | object write (for presigning) |
+| Moderation job | `aikami-uploads` read + `aikami-catalog` write | object read/write |
+| Publish pipeline | `aikami-catalog` only | object write |
+| Mirror job | `aikami-dist` only | object write |
+
+Four credentials, each unable to damage the others' plane. With one bucket this
+table collapses to one all-powerful key.
+
+### 4.1 Takedown, and the denylist you cannot skip
+
+C-395 states objects are never deleted. That has to be amended for community
+content: a DMCA or illegal-content takedown requires a hard delete, and any
+older index referencing the object will then 404. That is what takedown means
+and is acceptable.
+
+The non-obvious hazard: **content addressing makes takedown reversible by
+accident.** Re-uploading the identical bytes produces the identical key, which
+silently resurrects the object. So a takedown must write the hash to a
+`takedown_hashes` table in Postgres, checked at step 4 above *before*
+promotion. Without it, deletion is theatre.
+
+Restate the invariant as: *objects are never deleted by a publish run.
+Deletion is a deliberate moderation action, and always accompanied by a
+denylist entry.*
+
+---
+
+## 5. `aikami-dist` — models and releases
+
+### 5.1 Do not mirror model weights by default
+
+`apps/backend/local-stack/src/models.manifest.json` currently pins each entry
+to a HuggingFace `repo` + `revision` + `file` with a sha256, and the fetcher in
+`src/lib/fetch_models.ts` verifies it. That is a good design and should stay
+the primary source:
+
+- HuggingFace pays the egress and serves it well.
+- Revision pinning already gives reproducibility.
+- **Redistribution is a distinct legal act from linking.** Several manifest entries carry `requiresAcknowledgement: true` under non-commercial or OpenRAIL-M terms. Serving those bytes from your own domain changes your exposure. Storage cost is negligible (~$0.015/GB-month, so even 50 GB is under a dollar) — the licence is the blocker, not the bill.
+
+**Mirror only entries whose licence unambiguously permits redistribution**
+(Apache-2.0 — Qwen, Mistral-Nemo, Silero). Leave the rest HuggingFace-only.
+
+### 5.2 Make the manifest multi-source
+
+Change `ManifestEntry` from one source to a priority-ordered list — the same
+pattern `asset_sources` already uses in the local SQLite schema
+(`packages/frontend/storage/src/lib/migrations.ts:199`). The fetcher walks the
+list until one succeeds; sha256 verification is unchanged, so a mirror can
+never serve wrong bytes undetected.
+
+```ts
+sources: readonly (
+  | { backend: 'huggingface'; repo: string; revision: string; file: string }
+  | { backend: 'r2'; key: string }
+  | { backend: 'url'; url: string }
+)[];
+```
+
+This turns the mirror into a fallback for HuggingFace rate limits rather than a
+dependency, which is the only role it should have.
+
+### 5.3 Layout
+
+```
+r2://aikami-dist/                               dl.bearlysleeping.com
+
+  models/hf/<owner>/<repo>/<revision>/<path>    immutable · 1y
+  models/url/<sha256[0:2]>/<sha256><ext>        immutable · 1y   archive-kind entries
+  models/manifest/v1/models.json                mutable   · 60s
+```
+
+Note the deliberate inconsistency: models mirror **HuggingFace's own
+addressing** rather than being content-addressed like the catalog. The reason
+is auditability — "is this mirror still in sync with upstream?" becomes a
+trivial path comparison instead of a hash-table join. The sha256 is still
+verified on download, so nothing is lost on integrity. Entries with no
+upstream repo (archive-kind, direct URL) have no path to mirror and fall back
+to content addressing.
+
+### 5.4 Releases: keep them on GitHub
+
+The local-stack installer and the Tauri updater both read GitHub Releases
+today (`releases/latest/download/latest.json`). GitHub serves release assets
+free and unmetered. Moving them to R2 buys a custom domain and costs a second
+publish path — a bad trade.
+
+**Do, however, delete the Firebase Storage `tauri-releases/` path.** It is a
+third copy of artifacts whose real home is GitHub, and the storage rules still
+grant it public read. Dead surface with a public read grant is worth removing
+on its own.
+
+If GitHub rate limits ever bite, add `releases/<app>/<version>/<platform>/…`
+to `aikami-dist` as a secondary source in the same multi-source style as 5.2.
+
+---
+
+## 6. Player-owned data — Firebase Storage, encrypted client-side
+
+### 6.1 Why not R2
+
+D-13 already settled this, and the reasoning survives re-examination:
+
+**R2 has no identity model.** To grant "only this user can read this object"
+you must mint a presigned URL per request from a server that holds an R2
+credential. For backups, that server would be the hub — and I-3 says the hub
+never reads, writes, or proxies player-owned data. You would need a fourth
+service existing solely to broker R2 credentials for user files.
+
+Firebase Storage gives you `isOwner(uid)` from a rules file that is already
+deployed and already tested, with no server in the path at all.
+
+**The cost argument that justified R2 for the catalog inverts here.** R2 won
+D-13 on free egress, worth roughly $112/month per 10,000 full-library
+downloads of a 93 MB catalog. A user database backup is a few MB, downloaded
+on device migration and restore — call it twice a year. Free egress on a
+workload with almost no egress is worth nothing.
+
+### 6.2 Layout
+
+```
+firebase-storage://
+
+  backups/{uid}/db/<iso8601>.sqlite.gz.enc      owner-only · client-encrypted
+  backups/{uid}/db/latest.json                  owner-only · pointer + KDF params
+  saves/{uid}/…                                 owner-only (exists)
+  users/{uid}/…                                 avatars etc. (exists)
+  npcs/{uid}/{npcId}/…                          public read (exists)
+```
+
+Rules addition:
+
+```
+match /backups/{uid}/{allPaths=**} {
+  allow read, write: if isOwner(uid)
+                     && request.resource.size <= 100 * 1024 * 1024;
+}
+```
+
+The size cap is not optional — without it one account can fill the bucket.
+Add a GCS age-based lifecycle rule on the underlying bucket, and have the
+client prune to the newest N generations after a successful upload.
+
+### 6.3 Storage rules are authorization, not confidentiality
+
+`isOwner(uid)` stops another *user* reading the blob. It does not stop Google,
+and it does not survive a compromised service account. Given the ADR already
+cites "changing the BYOK privacy posture by accident" as grounds to reject
+Turso cloud sync, a plaintext backup would reintroduce exactly that problem
+through the side door.
+
+**Encrypt client-side, before upload, with a key the server never sees.**
+
+Pipeline, in this order:
+
+1. `VACUUM INTO` a temp file — never upload a live SQLite file with a hot WAL.
+2. gzip. **Compress before encrypting** — ciphertext does not compress.
+3. Generate a random 256-bit DEK. AES-GCM the bytes with it.
+4. Derive a KEK from the user's passphrase. Wrap the DEK with the KEK.
+5. Upload `ciphertext`; upload `latest.json` carrying the wrapped DEK, salt, IV, KDF name and parameters.
+
+Envelope encryption (rather than encrypting directly under the passphrase) is
+what makes a passphrase change a re-wrap of 60 bytes instead of a re-upload of
+the whole database.
+
+### 6.4 Two corrections to the existing vault, if you reuse it
+
+`apps/frontend/client/src/lib/utils/crypto_vault.ts` is a reasonable starting
+point — AES-GCM, PBKDF2, per-origin salt. Two things must change for a blob
+that leaves the device:
+
+- **Iterations.** It uses PBKDF2-SHA256 at 100,000. Current OWASP guidance for PBKDF2-HMAC-SHA256 is 600,000. On-device localStorage at 100k is defensible; a blob sitting on someone else's infrastructure is a different threat model. Use 600,000, or Argon2id if you'll take the wasm dependency.
+- **No fingerprint fallback.** The variant at `src/lib/views/utils/crypto_vault.ts` derives a key from a machine fingerprint when no PIN is set, which means for those users the key is not secret. For a cloud backup a passphrase must be **mandatory** — no fallback, no default.
+
+The consequence is honest and must be said in the UI: a lost passphrase means
+an unrecoverable backup. Issue a printable recovery code at setup that wraps a
+second copy of the DEK.
+
+### 6.5 What's actually in the file
+
+Worth noting, since it drove the question: **API keys are not in Turso today.**
+They live in localStorage under `aikami_vault` via `config_service.svelte.ts`,
+and the local SQLite schema has no key-bearing table. So the backup does not
+currently carry secrets.
+
+That is a fact about today, not a guarantee. Define the backup set explicitly
+in a schema with a `sensitive` marker per table, so that moving connections
+into SQLite later is a conscious decision that trips a review rather than a
+silent change in what gets uploaded.
+
+---
+
+## 7. What stays out of object storage
+
+| Thing | Size | Verdict |
+|---|---|---|
+| `static/ort/*.wasm` | 76 MB (4 × ~19 MB) | **Trimmed and offloaded to `aikami-dist`.** Open Question 5 resolved 2026-08-20: the client uses exactly one `import('onnxruntime-web/webgpu')` path (`kokoro_worker.ts:116`), which is JSEP-enabled and fetches **only `ort-wasm-simd-threaded.jsep.wasm`** — for both the WebGPU and WASM fallback backends. The `asyncify` / `jspi` / base `simd-threaded` variants (50 MB) were verified dead and removed. The remaining `jsep.wasm` (26 MB) is served from `aikami-dist` at `models/ort/<ort-version>/` (dl.bearlysleeping.com) and fetched at TTS init — TTS is installed on demand, so nothing bundles. The client points `wasmPaths` at `PUBLIC_ORT_WASM_URL`, falling back to the app's own `/ort/` when unset. |
+| `static/game-data/maps/`, `sprites/tilesets/` | 28 KB + | **Stays out**, as C-395 already decided — dev-only sandbox files, not scan categories. |
+| `static/*.png`, `favicon*`, `og-image.jpg` | ~660 KB | **Stays bundled.** App chrome, versioned with the build. |
+| `static/assets/npc/*.webp` | small | **Move to a pack.** These are content (Aragon, Gandalf, orc, troll portraits) that happen to live outside the six scan categories. Publish them as part of the first-party pack rather than inventing a seventh category. |
+| Release artifacts | — | **GitHub Releases**, per §5.4. |
+
+The three `game-data` sidecars — `manifest.json` (6.9 MB), `asset_credits.json`
+(6.1 MB), `lpc_credits.json` (5.4 MB) — are C-397's problem, not this
+document's, but note they are 18 MB of JSON the client parses at boot and the
+catalog index already carries the same credit data in shardable form.
+
+---
+
+## 8. Enforcing the layout in schemas
+
+Yes — and the strong version is worth building, because the failures this
+prevents are the expensive ones (user data in a public bucket; an index
+published with a one-year cache).
+
+The principle: **an object key is never a string literal. It is a value
+produced by a builder, carrying a type that names its bucket.**
+
+New module `packages/shared/schemas/src/lib/storage/`, exported through
+`@aikami/schemas` alongside the existing `catalog/` schemas.
+
+### 8.1 Branded key types
+
+```ts
+declare const brand: unique symbol;
+type Branded<T, B extends string> = T & { readonly [brand]: B };
+
+export type CatalogObjectKey = Branded<string, 'catalog'>;
+export type UploadObjectKey  = Branded<string, 'uploads'>;
+export type DistObjectKey    = Branded<string, 'dist'>;
+```
+
+### 8.2 One pattern, one definition
+
+The regex is the layout. Nothing else may restate it.
+
+```ts
+const SHA256 = '[a-f0-9]{64}';
+
+export const CATALOG_KEY_PATTERNS = {
+  asset:     `^assets/[a-f0-9]{2}/${SHA256}\\.[a-z0-9]+$`,
+  thumbnail: `^thumbnails/[a-f0-9]{2}/${SHA256}\\.webp$`,
+  indexRoot: '^index/v1/catalog\\.json$',
+  indexShard:'^index/v1/[a-z0-9_]+\\.json$',
+  packLatest:'^index/v1/packs/[a-z0-9-]+/[a-z0-9-]+/latest\\.json$',
+  packVersion:'^index/v1/packs/[a-z0-9-]+/[a-z0-9-]+/\\d+\\.\\d+\\.\\d+\\.json$',
+} as const;
+
+export const CatalogObjectKeySchema = Type.Union(
+  Object.values(CATALOG_KEY_PATTERNS).map((pattern) => Type.String({ pattern })),
+);
+```
+
+### 8.3 Builders are the only constructor
+
+```ts
+export const catalogAssetKey = (options: { hash: string; ext: string }): CatalogObjectKey => { … };
+export const packVersionKey  = (options: { owner: string; slug: string; version: string }): CatalogObjectKey => { … };
+```
+
+`scripts/src/lib/catalog/content_address.ts` already does exactly this,
+including rejecting a non-sha256 hash before it reaches a bucket key. Move it
+into the schema package and give it a return type instead of `string`.
+
+### 8.4 Bind key type to bucket at the call site
+
+This is the part that turns a convention into a compiler error.
+
+```ts
+type KeyForBucket = {
+  catalog: CatalogObjectKey;
+  uploads: UploadObjectKey;
+  dist:    DistObjectKey;
+};
+
+export const putObject = async <B extends keyof KeyForBucket>(options: {
+  bucket: B;
+  key: KeyForBucket[B];
+  body: Uint8Array;
+  contentType: string;
+}): Promise<void> => { … };
+```
+
+Passing an upload key to the catalog bucket no longer type-checks. That is a
+cheaper guarantee than any amount of review.
+
+### 8.5 Derive Cache-Control from the key — never accept it as a parameter
+
+```ts
+export const cacheControlFor = (key: CatalogObjectKey): string =>
+  key.startsWith('assets/') ||
+  key.startsWith('thumbnails/') ||
+  /\/\d+\.\d+\.\d+\.json$/.test(key)
+    ? 'public, max-age=31536000, immutable'
+    : 'public, max-age=60';
+```
+
+The failure this closes is real and painful: an index published with a
+one-year immutable cache is stuck in every client cache for a year, and R2
+cannot un-send it. Removing the caller's ability to choose removes the bug.
+
+### 8.6 Two more layers
+
+- **Lint gate.** `.pi/runners/convention_gate.ts` already exists. Add a rule rejecting bare string literals matching `^(assets|thumbnails|index|models|staging)/` anywhere outside `packages/shared/schemas/src/lib/storage/`. This catches the case where someone reimplements a key by hand rather than importing the builder.
+- **Runtime `Value.Check` on both sides.** Already the pattern in `catalog_index.ts` (read side) and worth mirroring on the write side, so the publish pipeline validates the document it is about to make canonical rather than trusting its own generator.
+
+---
+
+## 9. Sequencing
+
+| # | Step | Depends on |
+|---|---|---|
+| 1 | Create `aikami-uploads` (private, no domain, 14d lifecycle on `staging/`) | — |
+| 2 | Create `aikami-dist` + `dl.bearlysleeping.com` | — |
+| 3 | Issue four scoped tokens per §4 table; retire any all-buckets token | 1, 2 |
+| 4 | Extract `packages/shared/schemas/src/lib/storage/` from `content_address.ts`; add branded types, patterns, `cacheControlFor` | — |
+| 5 | Retype the publish pipeline against the branded keys | 4 |
+| 6 | Add the convention-gate rule | 4 |
+| 7 | Add `index/v1/packs/…` generation; republish `emberwatch` + `whispering-caves` as first-party packs | 4, 5 |
+| 8 | Multi-source `ManifestEntry` + mirror the Apache-2.0 model entries | 2, 3 |
+| 9 | Backup rules block, envelope encryption, KDF upgrade, recovery code | — |
+| 10 | Delete Firebase Storage `tauri-releases/`; plan retirement of the legacy `lpc/` `music/` `sprites/` copies once C-397 proves the R2 path | C-397 |
+
+Steps 4–6 are the highest leverage and depend on nothing. Do them before
+provisioning anything, so the first object written to a new bucket is written
+through the typed path.
+
+---
+
+## 10. Open questions
+
+1. **Prefix-scoped R2 tokens.** **Resolved 2026-08-20.** `cf r2 temporary-credentials create --prefixes …` yields credentials scoped to a bucket **and** a prefix (bucket + prefix + permission + TTL). These are the right mechanism for the hub to mint per-request presigns for `aikami-uploads` (C-398). The long-lived publish/mirror tokens are still separate per-bucket R2 API keys (dashboard-created, bucket-scoped), so the split in §4 still stands — the doc's other reasons (metrics, lifecycle, licence isolation) hold regardless.
+2. **Pack registry growth.** `index/v1/packs.json` has the sharding problem the root catalog index already hit. Fine while pack count is small; decide the shard axis (first letter? owner?) before it isn't.
+3. **Submission size ceiling.** The presigned PUT needs a content-length range. Pick a number tied to the R2 free tier (10 GB storage, 1M Class A ops/month) and to what a reasonable pack weighs.
+4. **Argon2id vs PBKDF2-600k** for the backup KEK — a wasm dependency in the client against a meaningfully better KDF.
+5. **Does anything actually load all four `ort` wasm variants?** **Resolved 2026-08-20: no.** One `import('onnxruntime-web/webgpu')` path (JSEP-enabled) loads only `jsep.wasm`. Trimmed `static/ort/` to `jsep.wasm` only (76 MB → 26 MB). See §7.

--- a/docs/contracts/C-395-r2-asset-origin-publish-pipeline.md
+++ b/docs/contracts/C-395-r2-asset-origin-publish-pipeline.md
@@ -131,14 +131,18 @@ Credentials — set by the maintainer 2026-08-15, in **`scripts/.env.*`**, not i
 the hub's env (the hub never writes to R2, I-7):
 
 ```
-CLOUD_FLARE_BUCKET_ACCESS_KEY_ID       S3 access key id
-CLOUD_FLARE_BUCKET_SECRET_ACCESS_KEY   S3 secret
-CLOUD_FLARE_BUCKET_ENDPOINT            S3 endpoint (https://<account>.r2.cloudflarestorage.com)
-CLOUD_FLARE_BUCKET_TOKEN               Cloudflare REST API token — bucket
-                                       administration only, NOT needed for
-                                       S3 object operations. Keep only if a
-                                       management task actually uses it.
+CLOUD_FLARE_CATALOG_BUCKET_ACCESS_KEY_ID       S3 access key id
+CLOUD_FLARE_CATALOG_BUCKET_SECRET_ACCESS_KEY   S3 secret
+CLOUD_FLARE_CATALOG_BUCKET_ENDPOINT            S3 endpoint (https://<account>.r2.cloudflarestorage.com)
+CLOUD_FLARE_CATALOG_BUCKET_TOKEN               Cloudflare REST API token — bucket
+                                                administration only, NOT needed for
+                                                S3 object operations. Keep only if a
+                                                management task actually uses it.
 ```
+
+Renamed 2026-08-20 from `CLOUD_FLARE_BUCKET_*` to `CLOUD_FLARE_CATALOG_BUCKET_*` to
+make room for the sibling planes (`…_DIST_BUCKET_*`, `…_UPLOADS_BUCKET_*`); see
+docs/architecture/object-storage-layout.md §2.
 
 Bucket: `aikami-catalog`, location hint **WEUR**, default storage class
 **Standard** (Infrequent Access is excluded from the R2 free tier and adds

--- a/docs/contracts/C-396-hub-public-shell-catalog-browse.md
+++ b/docs/contracts/C-396-hub-public-shell-catalog-browse.md
@@ -652,7 +652,7 @@ explicit preview-unavailable placeholders for pre-republish entries.
    needed beyond this note.
 2. **Live republish with thumbnails not run** — the thumbnail phase is fully
    unit/integration tested against fixtures, but running it against the live
-   R2 bucket requires `CLOUD_FLARE_BUCKET_*` write credentials from
+   R2 bucket requires `CLOUD_FLARE_CATALOG_BUCKET_*` write credentials from
    `scripts/.env.{mode}` (secret-manager backed), which are absent in this
    environment. Until a maintainer runs `bun run
    scripts/src/lib/catalog/publish.ts --mode production`, the live index has

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -70,10 +70,14 @@ DISCORD_APP_ID=
 # ACCESS_KEY_ID + SECRET_ACCESS_KEY + ENDPOINT are all the S3 client needs.
 # TOKEN is the Cloudflare REST API token (bucket administration), not used
 # for S3 object operations — keep it only if a management task needs it.
-CLOUD_FLARE_BUCKET_TOKEN=
-CLOUD_FLARE_BUCKET_ACCESS_KEY_ID=
-CLOUD_FLARE_BUCKET_SECRET_ACCESS_KEY=
-CLOUD_FLARE_BUCKET_ENDPOINT=
+#
+# Each R2 plane has its own bucket-scoped credential set: CATALOG (public
+# asset origin), DIST (model weights / distribution), UPLOADS (private
+# member-intake, hub presigns only). See docs/architecture/object-storage-layout.md.
+CLOUD_FLARE_CATALOG_BUCKET_TOKEN=
+CLOUD_FLARE_CATALOG_BUCKET_ACCESS_KEY_ID=
+CLOUD_FLARE_CATALOG_BUCKET_SECRET_ACCESS_KEY=
+CLOUD_FLARE_CATALOG_BUCKET_ENDPOINT=
 
 # Catalog publish — injected configuration, never hardcoded (C-395 Open
 # Question 1: no hostname in code or fixtures). CATALOG_ORIGIN_URL is the
@@ -81,3 +85,24 @@ CLOUD_FLARE_BUCKET_ENDPOINT=
 # to aikami-catalog.
 CATALOG_BUCKET=aikami-catalog
 CATALOG_ORIGIN_URL=https://assets.bearlysleeping.com
+
+# Cloudflare R2 — distribution plane (aikami-dist, dl.bearlysleeping.com).
+# Bucket-scoped WRITE credentials for the mirror job that populates model
+# weights / release artifacts. Used by scripts/src/lib/dist/ (C-…).
+CLOUD_FLARE_DIST_BUCKET_TOKEN=
+CLOUD_FLARE_DIST_BUCKET_ACCESS_KEY_ID=
+CLOUD_FLARE_DIST_BUCKET_SECRET_ACCESS_KEY=
+CLOUD_FLARE_DIST_BUCKET_ENDPOINT=
+CLOUD_FLARE_DIST_BUCKET=aikami-dist
+# Public origin of the distribution plane (injected, never hardcoded).
+DIST_ORIGIN_URL=https://dl.bearlysleeping.com
+
+# Cloudflare R2 — intake plane (aikami-uploads, private).
+# Bucket-scoped credential used only to mint presigned upload URLs for the
+# hub (C-398); the hub never reads or proxies member bytes (I-7). Objects
+# staged under staging/ expire after 14 days via lifecycle rule.
+CLOUD_FLARE_UPLOADS_BUCKET_TOKEN=
+CLOUD_FLARE_UPLOADS_BUCKET_ACCESS_KEY_ID=
+CLOUD_FLARE_UPLOADS_BUCKET_SECRET_ACCESS_KEY=
+CLOUD_FLARE_UPLOADS_BUCKET_ENDPOINT=
+CLOUD_FLARE_UPLOADS_BUCKET=aikami-uploads

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+!src/lib/dist/
 temp
 *.log

--- a/scripts/src/lib/catalog/config.ts
+++ b/scripts/src/lib/catalog/config.ts
@@ -8,9 +8,9 @@
 // appear in apps/frontend/hub/.env.* where buildSecretArgsFromEnvFile would
 // ship them to Cloud Run.
 //
-//   CLOUD_FLARE_BUCKET_ACCESS_KEY_ID      S3 access key id
-//   CLOUD_FLARE_BUCKET_SECRET_ACCESS_KEY  S3 secret
-//   CLOUD_FLARE_BUCKET_ENDPOINT           S3 endpoint (https://<account>.r2.cloudflarestorage.com)
+//   CLOUD_FLARE_CATALOG_BUCKET_ACCESS_KEY_ID      S3 access key id
+//   CLOUD_FLARE_CATALOG_BUCKET_SECRET_ACCESS_KEY  S3 secret
+//   CLOUD_FLARE_CATALOG_BUCKET_ENDPOINT           S3 endpoint (https://<account>.r2.cloudflarestorage.com)
 //
 // `originUrl` is INJECTED configuration — never a constant, never a
 // hardcoded hostname in code or fixtures. The public origin is
@@ -82,21 +82,21 @@ export type CatalogConfig = {
 export const resolveCatalogConfig = (mode: string): CatalogConfig => {
   initScriptsEnv(mode);
 
-  const accessKeyId = getScriptsEnv('CLOUD_FLARE_BUCKET_ACCESS_KEY_ID') ?? '';
-  const secretAccessKey = getScriptsEnv('CLOUD_FLARE_BUCKET_SECRET_ACCESS_KEY') ?? '';
-  const endpoint = getScriptsEnv('CLOUD_FLARE_BUCKET_ENDPOINT') ?? '';
+  const accessKeyId = getScriptsEnv('CLOUD_FLARE_CATALOG_BUCKET_ACCESS_KEY_ID') ?? '';
+  const secretAccessKey = getScriptsEnv('CLOUD_FLARE_CATALOG_BUCKET_SECRET_ACCESS_KEY') ?? '';
+  const endpoint = getScriptsEnv('CLOUD_FLARE_CATALOG_BUCKET_ENDPOINT') ?? '';
   const originUrlRaw = getScriptsEnv('CATALOG_ORIGIN_URL') ?? '';
   const bucket = getScriptsEnv('CATALOG_BUCKET') ?? DEFAULT_CATALOG_BUCKET;
 
   const missing: string[] = [];
   if (!accessKeyId) {
-    missing.push('CLOUD_FLARE_BUCKET_ACCESS_KEY_ID');
+    missing.push('CLOUD_FLARE_CATALOG_BUCKET_ACCESS_KEY_ID');
   }
   if (!secretAccessKey) {
-    missing.push('CLOUD_FLARE_BUCKET_SECRET_ACCESS_KEY');
+    missing.push('CLOUD_FLARE_CATALOG_BUCKET_SECRET_ACCESS_KEY');
   }
   if (!endpoint) {
-    missing.push('CLOUD_FLARE_BUCKET_ENDPOINT');
+    missing.push('CLOUD_FLARE_CATALOG_BUCKET_ENDPOINT');
   }
   if (!originUrlRaw) {
     missing.push('CATALOG_ORIGIN_URL');

--- a/scripts/src/lib/catalog/publish.ts
+++ b/scripts/src/lib/catalog/publish.ts
@@ -12,7 +12,7 @@
 //   bun run scripts/src/lib/catalog/publish.ts [--mode production]
 //
 // Env (scripts/.env.{mode}, see scripts/.env.example):
-//   CLOUD_FLARE_BUCKET_ACCESS_KEY_ID / SECRET_ACCESS_KEY / ENDPOINT
+//   CLOUD_FLARE_CATALOG_BUCKET_ACCESS_KEY_ID / SECRET_ACCESS_KEY / ENDPOINT
 //   CATALOG_ORIGIN_URL               public origin (injected, never hardcoded)
 //   CATALOG_BUCKET                   optional, default aikami-catalog
 //

--- a/scripts/src/lib/dist/config.ts
+++ b/scripts/src/lib/dist/config.ts
@@ -1,0 +1,85 @@
+// scripts/src/lib/dist/config.ts
+//
+// Distribution-plane (R2 `aikami-dist`) publish configuration.
+//
+// Mirrors scripts/src/lib/catalog/config.ts but for the distribution bucket,
+// which serves model weights and distribution artifacts (e.g. the vendored
+// onnxruntime-web WASM) at dl.bearlysleeping.com. See
+// docs/architecture/object-storage-layout.md §5.
+//
+// R2 write credentials come from scripts/.env.{mode} (populated by
+// download_secrets.ts from GSM). Each R2 plane has its own bucket-scoped S3
+// key; these must never appear in the hub's env (invariant I-7).
+//
+//   CLOUD_FLARE_DIST_BUCKET_ACCESS_KEY_ID      S3 access key id
+//   CLOUD_FLARE_DIST_BUCKET_SECRET_ACCESS_KEY  S3 secret
+//   CLOUD_FLARE_DIST_BUCKET_ENDPOINT           S3 endpoint
+//   CLOUD_FLARE_DIST_BUCKET                    R2 bucket (default aikami-dist)
+
+import { getScriptsEnv, initScriptsEnv } from '../env/scripts_env.ts';
+
+/** Default R2 bucket for the distribution plane. */
+export const DEFAULT_DIST_BUCKET = 'aikami-dist';
+
+/** Public origin of the distribution plane — injected, never hardcoded. */
+export const DIST_ORIGIN_ENV = 'DIST_ORIGIN_URL';
+
+export type DistConfig = {
+  /** S3 access key id. */
+  accessKeyId: string;
+  /** S3 secret access key. */
+  secretAccessKey: string;
+  /** S3 endpoint (https://<account>.r2.cloudflarestorage.com). */
+  endpoint: string;
+  /** R2 bucket name. */
+  bucket: string;
+  /** Public origin base URL — injected configuration. */
+  originUrl: string;
+};
+
+/**
+ * Resolve the distribution-plane configuration from the environment.
+ *
+ * @param mode - AIKAMI mode used to load scripts/.env.{mode} credentials.
+ */
+export const resolveDistConfig = (mode: string): DistConfig => {
+  initScriptsEnv(mode);
+
+  const accessKeyId = getScriptsEnv('CLOUD_FLARE_DIST_BUCKET_ACCESS_KEY_ID') ?? '';
+  const secretAccessKey = getScriptsEnv('CLOUD_FLARE_DIST_BUCKET_SECRET_ACCESS_KEY') ?? '';
+  const endpoint = getScriptsEnv('CLOUD_FLARE_DIST_BUCKET_ENDPOINT') ?? '';
+  const bucket = getScriptsEnv('CLOUD_FLARE_DIST_BUCKET') ?? DEFAULT_DIST_BUCKET;
+  const originUrlRaw = getScriptsEnv(DIST_ORIGIN_ENV) ?? '';
+
+  const missing: string[] = [];
+  if (!accessKeyId) {
+    missing.push('CLOUD_FLARE_DIST_BUCKET_ACCESS_KEY_ID');
+  }
+  if (!secretAccessKey) {
+    missing.push('CLOUD_FLARE_DIST_BUCKET_SECRET_ACCESS_KEY');
+  }
+  if (!endpoint) {
+    missing.push('CLOUD_FLARE_DIST_BUCKET_ENDPOINT');
+  }
+  if (!originUrlRaw) {
+    missing.push(DIST_ORIGIN_ENV);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Distribution publish config missing: ${missing.join(', ')}. ` +
+        'Set them in scripts/.env.{mode} (see scripts/.env.example).',
+    );
+  }
+
+  let originUrl: string;
+  try {
+    originUrl = new URL(originUrlRaw).toString().replace(/\/+$/, '');
+  } catch {
+    throw new Error(
+      `Distribution publish config invalid: ${DIST_ORIGIN_ENV} is not a valid URL ` +
+        `(${JSON.stringify(originUrlRaw)}). Set it in scripts/.env.{mode}.`,
+    );
+  }
+
+  return { accessKeyId, secretAccessKey, endpoint, bucket, originUrl };
+};

--- a/scripts/src/lib/dist/upload_ort.ts
+++ b/scripts/src/lib/dist/upload_ort.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+
+// scripts/src/lib/dist/upload_ort.ts
+//
+// Upload the vendored onnxruntime-web WASM to the R2 distribution plane
+// (`aikami-dist`), so the client fetches it at runtime instead of bundling
+// it (shrinks the shipped bundle / git footprint — see
+// docs/architecture/object-storage-layout.md §7, open question 5).
+//
+// Only the JSEP variant is needed: the client uses a single
+// `import('onnxruntime-web/webgpu')` (JSEP-enabled) which locates
+// `ort-wasm-simd-threaded.jsep.wasm` via wasmPaths for both the WebGPU and
+// WASM fallback backends.
+//
+// The object is stored content-versioned so the URL is immutable:
+//   models/ort/<ort-version>/ort-wasm-simd-threaded.jsep.wasm
+// The client points wasmPaths at
+//   <origin>/models/ort/<ort-version>/
+// and onnxruntime appends the jsep.wasm filename.
+//
+// Usage:
+//   bun run scripts/src/lib/dist/upload_ort.ts [--mode production]
+//
+// Env (scripts/.env.{mode}): CLOUD_FLARE_DIST_BUCKET_* + CATALOG_ORIGIN_URL_DIST.
+
+import { resolveDistConfig } from './config.ts';
+
+const ORT_VERSION = '1.27.0';
+const JSEP_WASM = 'ort-wasm-simd-threaded.jsep.wasm';
+
+const modeIndex = process.argv.indexOf('--mode');
+const mode = modeIndex >= 0 ? process.argv[modeIndex + 1] : 'production';
+
+const config = resolveDistConfig(mode);
+console.log('🚀 ORT WASM upload → dist plane');
+console.log(`   Mode:    ${mode}`);
+console.log(`   Bucket:  ${config.bucket}`);
+console.log(`   Origin:  ${config.originUrl}`);
+
+const s3 = new Bun.S3Client({
+  accessKeyId: config.accessKeyId,
+  secretAccessKey: config.secretAccessKey,
+  bucket: config.bucket,
+  endpoint: config.endpoint,
+  region: 'auto',
+});
+
+// Resolve the vendored wasm from the onnxruntime-web npm dist (pinned by
+// package-lock / bun.lock). It is NOT committed to git — the canonical copy
+// lives in R2 after this upload runs.
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const sourcePath = `${repoRoot}/node_modules/.bun/onnxruntime-web@1.27.0/node_modules/onnxruntime-web/dist/${JSEP_WASM}`;
+const fallbackPath = `${repoRoot}/apps/frontend/client/static/ort/${JSEP_WASM}`;
+const sourcePathToUse =
+  (await Bun.file(sourcePath).exists()) ? sourcePath : fallbackPath;
+const source = Bun.file(sourcePathToUse);
+if (!(await source.exists())) {
+  console.error(`❌ onnxruntime wasm not found; tried ${sourcePath} and ${fallbackPath}`);
+  process.exit(1);
+}
+
+const key = `models/ort/${ORT_VERSION}/${JSEP_WASM}`;
+
+// Idempotent: skip if the content-addressed-by-version object already exists.
+const existing = await s3.list({ prefix: `models/ort/${ORT_VERSION}/` });
+const alreadyThere = (existing.contents ?? []).some((o) => o.key === key);
+if (alreadyThere) {
+  console.log(`⏭  Already present: ${key}`);
+} else {
+  // Immutable, one-year cache — the version in the key makes it permanent.
+  // Bun's S3 client does not expose per-object Cache-Control on write(), so
+  // the PUT goes through a presigned URL with explicit headers (same technique
+  // as catalog/upload.ts).
+  const body = await source.arrayBuffer();
+  const url = s3.file(key).presign({ method: 'PUT', expiresIn: 300 });
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Cache-Control': 'public, max-age=31536000, immutable',
+      'Content-Type': 'application/wasm',
+    },
+    body,
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    console.error(`❌ S3 PUT ${key} failed (${response.status}) ${text.slice(0, 200)}`);
+    process.exit(1);
+  }
+  console.log(`✅ Uploaded ${key} (${(body.byteLength / 1024 / 1024).toFixed(1)} MB)`);
+}
+
+const wasmPath = `${config.originUrl}/models/ort/${ORT_VERSION}/`;
+console.log('');
+console.log('📌 wasmPaths base URL for the client:');
+console.log(`   ${wasmPath}`);
+console.log('');
+console.log('   The Canonical copy now lives in R2; static/ort/ is no longer bundled.');


### PR DESCRIPTION
## Summary

Brings the `cleanup/local-stack-src` branch into `main` with two commits:

### 1. `feat(storage): rename catalog bucket creds, add dist/uploads planes, offload ort wasm to R2`
- Renamed `CLOUD_FLARE_BUCKET_*` → `CLOUD_FLARE_CATALOG_BUCKET_*` (config, publish, env examples, docs).
- Added the **dist** publish plane (`scripts/src/lib/dist/`) with `config.ts` + `upload_ort.ts` (presigned-PUT, idempotent).
- Client TTS offloads the onnxruntime WASM to R2 (`PUBLIC_ORT_WASM_URL`), falling back to `/ort/`; removed `static/ort/` (4 wasm files) since it's now served from `dl.bearlysleeping.com/models/ort/1.27.0/`.
- Docs: `object-storage-layout.md`, C-395, C-396 updates.
- Also adds `scripts/.gitignore` negation so the new `dist/` module is tracked.

### 2. `chore(gitignore): ignore runtime background-task logs, keep README`
- Ignores `.pi/background-tasks/*` (runtime `bg-*.json`/`bg-*.log`) while keeping `.pi/background-tasks/README.md`.

## Verification
- scripts: typecheck 0 errors, catalog tests 59/59 pass
- client: TTS tests 8/8 pass
- ort upload idempotent; R2 wasm returns HTTP 200

> Note: repo history was rewritten (purged `game/`/`references/` + ort wasm) and pruned to ~97 MiB. All consumers must re-clone / force-pull.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable hosting for the app’s audio-processing assets.
  * Added clearer configuration options for catalog, distribution, and upload storage.

* **Documentation**
  * Added documentation for monitoring and consuming background task records, including task status, logs, and live viewing.

* **Bug Fixes**
  * Updated catalog publishing configuration to use dedicated catalog storage credentials.
  * Ensured the distribution directory can be included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->